### PR TITLE
fix(sync): resolve IPv6 unreachable issue and use DATABASE_URL env var

### DIFF
--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -17,3 +17,5 @@ jobs:
         run: npm install pg node-fetch@2
       - name: Run sync script
         run: node sync_github.js
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/sync_github.js
+++ b/sync_github.js
@@ -4,7 +4,8 @@ const SOROBAN_RPC = "https://soroban-testnet.stellar.org";
 const MERCHANT_CONTRACT = "CDP76EZKUOMRZMETU4CR276SHBMNBTIZDIM7GJEESTX3CJEXXBTTSWBV";
 
 async function main() {
-  const dbUrl = "postgresql://postgres:@Basirat031@db.ialomdzbhjzizojvbady.supabase.co:5432/postgres";
+  // Use process.env.DATABASE_URL which should be set to the Supabase IPv4 connection pooler string
+  const dbUrl = process.env.DATABASE_URL || "postgresql://postgres:%40Basirat031@db.ialomdzbhjzizojvbady.supabase.co:5432/postgres";
   const client = new Client({ connectionString: dbUrl });
 
   try {


### PR DESCRIPTION
   ## What does this PR do?
   This PR resolves the `ENETUNREACH` connection error that was causing the `Blockchain Indexer Sync` GitHub Action to fail periodically. 
  
   ## Why was the fix needed?
   The database sync script (`sync_github.js`) was hardcoded to connect to the Supabase direct connection URL (`db.[ref].supabase.co`). Supabase recently migrated direct connections to be IPv6-only, but GitHub Actions (`ubuntu-latest` runners) do not natively support outbound IPv6 traffic, causing the connection to fail. 
  
   Additionally, the password in the connection string contained a special character (`@`) that was breaking standard Postgres URL parsing.
  
   ## How was it fixed?
   1. **Added Environment Variable Support**: Updated `sync_github.js` to prioritize the `DATABASE_URL` environment variable over the hardcoded string. 
   2. **Updated GitHub Workflow**: Modified `.github/workflows/indexer.yml` to securely pass the `DATABASE_URL` secret into the script during execution.
   3. **URL Encoding**: Percent-encoded the `@` symbol to `%40` in the fallback connection string to ensure reliable parsing.
  
   ## To-Do Before Merging/Running:
   - [x] Add `DATABASE_URL` as an Actions Repository Secret. This URL **must** be the Supabase Session/Transaction Pooler connection string (e.g., `aws-0-[region].pooler.supabase.com:5432`) which properly resolves to IPv4.
