### PR TITLE
fix(ci): strictly enforce code quality checks and add Go linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: pnpm install
       - name: Lint Next.js
         working-directory: ./apps/web
-        run: pnpm lint || echo "No lint errors"
+        run: pnpm lint
 
   typecheck:
     name: typecheck
@@ -39,7 +39,22 @@ jobs:
         run: pnpm install
       - name: Typecheck Next.js
         working-directory: ./apps/web
-        run: pnpm tsc --noEmit || echo "No type errors"
+        run: pnpm tsc --noEmit
+
+  lint-go:
+    name: lint go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
+          working-directory: ./indexer
 
   test:
     name: test

--- a/indexer/api/api.go
+++ b/indexer/api/api.go
@@ -41,7 +41,7 @@ func (s *Server) Start(port string) error {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"ok"}`))
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
 func (s *Server) handleGetPayments(w http.ResponseWriter, r *http.Request) {
@@ -105,5 +105,5 @@ func (s *Server) handleDemoInject(w http.ResponseWriter, r *http.Request) {
 	
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"demo injected"}`))
+	_, _ = w.Write([]byte(`{"status":"demo injected"}`))
 }


### PR DESCRIPTION
# Closes #42  
This pull request introduces improvements to CI workflows and minor refinements to Go server response handling. The main highlights are stricter CI error reporting, the addition of Go linting, and improved error handling in HTTP responses.

**CI/CD Workflow Improvements:**

* The Next.js lint and typecheck steps in `.github/workflows/ci.yml` will now fail the workflow on errors, instead of always passing with a message. This enforces code quality by preventing silent failures.
* A new `lint-go` job is added to the CI workflow, running `golangci-lint` on the `indexer` directory to ensure Go code quality.

**Go Server Response Handling:**

* In `indexer/api/api.go`, HTTP handlers now ignore the return value from `Write` using the blank identifier (`_, _ = ...`), making error handling explicit and eliminating linter warnings about unchecked errors. [[1]](diffhunk://#diff-017fb2fb251686d7b664b94fe91d24a1efc14124b7711c8a6df151e1e919c007L44-R44) [[2]](diffhunk://#diff-017fb2fb251686d7b664b94fe91d24a1efc14124b7711c8a6df151e1e919c007L108-R108)