### PR TITLE
fix(cron): daily Vercel cron; trigger real cadence from Actions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,49 @@
+name: Trigger Indexer Sync
+
+# Vercel Cron on the Hobby plan is limited to one run per day, which is too
+# coarse for a payments dashboard. This workflow just *calls* the deployed
+# /api/sync endpoint on a tighter schedule — all indexing logic lives in the
+# app, not here. vercel.json keeps a daily cron as a backstop.
+#
+# Required repository secrets:
+#   SYNC_URL      https://accensa-dashboard.vercel.app/api/sync
+#   CRON_SECRET   must match the CRON_SECRET set on the Vercel project
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/5 * * * *'
+
+# Never let two syncs overlap; the later one wins.
+concurrency:
+  group: indexer-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call sync endpoint
+        env:
+          SYNC_URL: ${{ secrets.SYNC_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$SYNC_URL" ]; then
+            echo "SYNC_URL secret is not set"; exit 1
+          fi
+          # -sS keeps output quiet but still reports transport errors.
+          response=$(curl -sS --max-time 120 -w '\n%{http_code}' \
+            -H "Authorization: Bearer $CRON_SECRET" "$SYNC_URL")
+          body=$(printf '%s' "$response" | sed '$d')
+          code=$(printf '%s' "$response" | tail -n1)
+
+          echo "HTTP $code"
+          echo "$body"
+
+          if [ "$code" != "200" ]; then
+            echo "Sync failed with HTTP $code"; exit 1
+          fi
+          # The route returns {"success":false,...} on a handled error.
+          if printf '%s' "$body" | grep -q '"success":false'; then
+            echo "Sync reported failure"; exit 1
+          fi

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/sync",
-      "schedule": "*/5 * * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #47, which merged before this fix was pushed. **`main` currently cannot deploy to Vercel.**

## The problem

Vercel rejects the deploy outright on the Hobby plan when a cron runs more than once per day — a hard failure, not a silent clamp:

```
Hobby accounts are limited to daily cron jobs. This cron expression
(*/5 * * * *) would run more than once per day.
```

The `*/5` schedule that landed in #47 makes every deploy of `main` fail at build time.

## The fix

- `vercel.json` drops to a daily schedule (`0 0 * * *`) so deploys succeed on Hobby.
- A small workflow calls the deployed `/api/sync` every 5 minutes to keep the dashboard current.

Daily-only syncing would leave a payments dashboard up to 24 hours stale, which defeats the point.

## This is not a return to the old arrangement

The workflow removed in #47 did the indexing itself and invented the amounts and payers. This one makes a single authenticated HTTP call — **all indexing logic stays in the app**. It fails loudly on a non-200 or on a `{"success":false}` body, rather than reporting a green run for a failed sync.

## Required repository secrets

| Secret | Value |
|---|---|
| `SYNC_URL` | `https://accensa-dashboard.vercel.app/api/sync` |
| `CRON_SECRET` | must match the `CRON_SECRET` set on the Vercel project |

Without them the workflow fails fast with a clear message rather than silently no-oping.

## Verified

Preview deploy of this exact code against the live database and live Soroban RPC:

- Sent a real 8.25 XLM payment on testnet ([`d4fcc3a2…`](https://stellar.expert/explorer/testnet/tx/d4fcc3a257cd96fccc1a698555ec894dcf5b9b5b813b5bb3e5df5cb0851133d0))
- Deployed `/api/sync` returned `{"scanned":1,"decoded":1,"inserted":1}`
- Deployed `/api/payments` returned both real payments with exact amounts (`8.2500000`, `3.7500000`) and the real payer address

The deploy that failed before this change now succeeds.
