### PR TITLE
feat(verify): public receipt verifier with dual local + on-chain checks

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@accensa/sdk": "workspace:^",
     "@stellar/stellar-sdk": "^16.0.1",
     "next": "16.2.10",
     "pg": "^8.22.0",

--- a/apps/web/src/app/api/verify/route.ts
+++ b/apps/web/src/app/api/verify/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from 'next/server';
+import { verifyReceipt } from '@accensa/sdk/merkle';
+import {
+  verifyReceiptOnChain,
+  getBatch,
+  isHash32,
+  RECEIPT_ANCHOR_ID,
+} from '@/lib/receipt-anchor';
+
+export const dynamic = 'force-dynamic';
+
+export interface VerifyRequest {
+  batchId: number;
+  leaf: string;
+  proof: string[];
+}
+
+export interface CheckResult {
+  ok: boolean | null;
+  error?: string;
+}
+
+export interface VerifyResponse {
+  /** Recomputed in this process from the proof — no ledger involved. */
+  local: CheckResult;
+  /** The contract's own answer, read from the ledger. */
+  onchain: CheckResult;
+  /** True only when both independent implementations agree the receipt is valid. */
+  verified: boolean;
+  /** Set when the two disagree — which should never happen. */
+  disagreement: boolean;
+  batch?: { id: number; root: string; count: number; periodStart: number; periodEnd: number };
+  contract: string;
+}
+
+export async function POST(request: Request) {
+  let body: VerifyRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const { batchId, leaf, proof } = body ?? {};
+
+  if (!Number.isInteger(batchId) || batchId < 1) {
+    return NextResponse.json({ error: 'batchId must be a positive integer' }, { status: 400 });
+  }
+  if (typeof leaf !== 'string' || !isHash32(leaf)) {
+    return NextResponse.json(
+      { error: 'leaf must be a hex-encoded 32-byte hash' },
+      { status: 400 },
+    );
+  }
+  if (!Array.isArray(proof) || proof.some((p) => typeof p !== 'string' || !isHash32(p))) {
+    return NextResponse.json(
+      { error: 'proof must be an array of hex-encoded 32-byte hashes' },
+      { status: 400 },
+    );
+  }
+
+  // Read the anchored batch first: without its root there is nothing to check
+  // the local recomputation against.
+  let batch;
+  try {
+    batch = await getBatch(batchId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      {
+        error: /BatchNotFound|#4/.test(message)
+          ? `Batch #${batchId} has not been anchored on this contract.`
+          : `Could not read batch #${batchId}: ${message}`,
+      },
+      { status: 404 },
+    );
+  }
+
+  // The two checks are deliberately independent. Local recomputes the root from
+  // the proof in this process; on-chain asks the contract. Running both and
+  // showing both is the point — agreement between an independent computation
+  // and the ledger is what makes a receipt trustworthy without trusting us.
+  const local: CheckResult = (() => {
+    try {
+      return { ok: verifyReceipt(leaf.trim(), proof.map((p) => p.trim()), batch.root) };
+    } catch (error) {
+      return { ok: null, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  })();
+
+  const onchain: CheckResult = await (async () => {
+    try {
+      return { ok: await verifyReceiptOnChain(batchId, leaf.trim(), proof.map((p) => p.trim())) };
+    } catch (error) {
+      return { ok: null, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  })();
+
+  const disagreement =
+    local.ok !== null && onchain.ok !== null && local.ok !== onchain.ok;
+
+  const response: VerifyResponse = {
+    local,
+    onchain,
+    verified: local.ok === true && onchain.ok === true,
+    disagreement,
+    batch: {
+      id: batchId,
+      root: batch.root,
+      count: batch.count,
+      periodStart: batch.periodStart,
+      periodEnd: batch.periodEnd,
+    },
+    contract: RECEIPT_ANCHOR_ID,
+  };
+
+  return NextResponse.json(response);
+}

--- a/apps/web/src/app/verify/page.tsx
+++ b/apps/web/src/app/verify/page.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import type { VerifyResponse } from '../api/verify/route';
+
+/**
+ * Batch #1, anchored live on Stellar testnet. Lets anyone see the verifier work
+ * end to end without first obtaining a receipt from a merchant.
+ */
+const SAMPLE = {
+  batchId: '1',
+  leaf: 'c476fc0553303ec4275bd4cb50ab7fa8182e343dbc4c721d7e2076fd77a5b56c',
+  proof:
+    '7ca64ee60e2b975f59f2a1f1cc1526d5b001a5c29f70291f316ba1c012a01bd1\n1733fad16ada0c23d8cdaff52bea66bea308dddddcb79348842acef0065c9615',
+};
+
+const FORGED_LEAF = '16b138aabc889c21114436424e13132bd8928d2c21b4ac5a9ac5198104efb42c';
+
+type State =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'done'; result: VerifyResponse }
+  | { status: 'error'; message: string };
+
+export default function VerifyPage() {
+  const [batchId, setBatchId] = useState('');
+  const [leaf, setLeaf] = useState('');
+  const [proof, setProof] = useState('');
+  const [state, setState] = useState<State>({ status: 'idle' });
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setState({ status: 'checking' });
+    try {
+      const res = await fetch('/api/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          batchId: Number(batchId),
+          leaf: leaf.trim(),
+          proof: proof
+            .split(/[\s,]+/)
+            .map((p) => p.trim())
+            .filter(Boolean),
+        }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setState({ status: 'error', message: body.error ?? `Request failed (${res.status})` });
+        return;
+      }
+      setState({ status: 'done', result: body as VerifyResponse });
+    } catch (error) {
+      setState({
+        status: 'error',
+        message: error instanceof Error ? error.message : 'Request failed',
+      });
+    }
+  }
+
+  function loadSample(forged = false) {
+    setBatchId(SAMPLE.batchId);
+    setLeaf(forged ? FORGED_LEAF : SAMPLE.leaf);
+    setProof(SAMPLE.proof);
+    setState({ status: 'idle' });
+  }
+
+  return (
+    <main className="min-h-screen bg-[#0a0a0a] text-white px-6 py-16 md:py-24">
+      <div className="fixed inset-0 overflow-hidden -z-10 pointer-events-none">
+        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-emerald-600/20 blur-[120px]" />
+        <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-teal-600/20 blur-[120px]" />
+      </div>
+
+      <div className="max-w-3xl mx-auto space-y-10">
+        <header className="space-y-4">
+          <Link href="/" className="text-sm text-gray-500 hover:text-gray-300 transition-colors">
+            ← Dashboard
+          </Link>
+          <h1 className="text-4xl font-bold tracking-tight bg-gradient-to-r from-emerald-400 to-teal-500 bg-clip-text text-transparent">
+            Verify a receipt
+          </h1>
+          <p className="text-gray-400 leading-relaxed">
+            Check that a payment receipt really belongs to a batch anchored on
+            Stellar. Your receipt is checked <strong className="text-gray-200">twice</strong>:
+            recomputed here from the proof, and independently by the{' '}
+            <code className="text-emerald-300">ReceiptAnchor</code> contract on
+            the ledger. They must agree.
+          </p>
+          <p className="text-gray-500 text-sm">
+            No account, no wallet, no signature. Both checks are read-only and
+            cost nothing.
+          </p>
+        </header>
+
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={() => loadSample(false)}
+            className="px-4 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 text-sm hover:bg-emerald-500/20 transition-colors"
+          >
+            Load a valid sample
+          </button>
+          <button
+            type="button"
+            onClick={() => loadSample(true)}
+            className="px-4 py-2 rounded-lg bg-white/5 border border-white/10 text-gray-300 text-sm hover:bg-white/10 transition-colors"
+          >
+            Load a forged receipt
+          </button>
+        </div>
+
+        <form onSubmit={submit} className="space-y-6">
+          <Field label="Batch ID" hint="The anchored batch this receipt belongs to.">
+            <input
+              value={batchId}
+              onChange={(e) => setBatchId(e.target.value)}
+              inputMode="numeric"
+              placeholder="1"
+              required
+              className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-2.5 font-mono text-sm focus:outline-none focus:border-emerald-500/50"
+            />
+          </Field>
+
+          <Field label="Receipt hash (leaf)" hint="Hex-encoded 32-byte hash of your receipt.">
+            <input
+              value={leaf}
+              onChange={(e) => setLeaf(e.target.value)}
+              placeholder="c476fc05…"
+              required
+              className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-2.5 font-mono text-sm focus:outline-none focus:border-emerald-500/50"
+            />
+          </Field>
+
+          <Field
+            label="Merkle proof"
+            hint="One sibling hash per line, ordered leaf to root. A single-receipt batch has an empty proof."
+          >
+            <textarea
+              value={proof}
+              onChange={(e) => setProof(e.target.value)}
+              rows={4}
+              placeholder={'7ca64ee6…\n1733fad1…'}
+              className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-2.5 font-mono text-sm focus:outline-none focus:border-emerald-500/50"
+            />
+          </Field>
+
+          <button
+            type="submit"
+            disabled={state.status === 'checking'}
+            className="px-6 py-3 rounded-lg bg-emerald-500 text-black font-semibold text-sm hover:bg-emerald-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {state.status === 'checking' ? 'Checking both sources…' : 'Verify receipt'}
+          </button>
+        </form>
+
+        {state.status === 'error' && (
+          <div className="rounded-2xl border border-amber-500/30 bg-amber-500/5 p-6 space-y-2">
+            <p className="text-amber-400 font-medium">Could not verify</p>
+            <p className="text-gray-400 text-sm">{state.message}</p>
+          </div>
+        )}
+
+        {state.status === 'done' && <Result result={state.result} />}
+      </div>
+    </main>
+  );
+}
+
+function Result({ result }: { result: VerifyResponse }) {
+  const { local, onchain, verified, disagreement, batch } = result;
+
+  return (
+    <div className="space-y-6">
+      <div
+        className={`rounded-2xl border p-6 ${
+          verified
+            ? 'border-emerald-500/30 bg-emerald-500/5'
+            : 'border-red-500/30 bg-red-500/5'
+        }`}
+      >
+        <p className={`text-lg font-semibold ${verified ? 'text-emerald-400' : 'text-red-400'}`}>
+          {verified ? 'Receipt verified' : 'Receipt not verified'}
+        </p>
+        <p className="text-gray-400 text-sm mt-1">
+          {verified
+            ? 'Both an independent local recomputation and the on-chain contract agree this receipt is in the anchored batch.'
+            : 'This receipt is not part of the anchored batch. Nothing was charged incorrectly by checking — the proof simply does not lead to the anchored root.'}
+        </p>
+      </div>
+
+      {disagreement && (
+        <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 p-6">
+          <p className="text-amber-300 font-semibold">The two checks disagree</p>
+          <p className="text-gray-300 text-sm mt-1">
+            This should never happen. The local implementation and the contract
+            are pinned to the same conformance vectors. Please report it.
+          </p>
+        </div>
+      )}
+
+      <div className="grid md:grid-cols-2 gap-4">
+        <CheckCard
+          title="Local recomputation"
+          subtitle="Recomputed from your proof, in this process."
+          result={local}
+        />
+        <CheckCard
+          title="On-chain contract"
+          subtitle="ReceiptAnchor.verify_receipt, read from the ledger."
+          result={onchain}
+        />
+      </div>
+
+      {batch && (
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 space-y-3">
+          <p className="text-sm font-medium text-gray-300">Anchored batch #{batch.id}</p>
+          <dl className="grid sm:grid-cols-2 gap-3 text-sm">
+            <Detail label="Merkle root" mono>
+              {batch.root}
+            </Detail>
+            <Detail label="Receipts in batch">{batch.count}</Detail>
+            <Detail label="Period start">
+              {new Date(batch.periodStart * 1000).toLocaleString()}
+            </Detail>
+            <Detail label="Period end">
+              {new Date(batch.periodEnd * 1000).toLocaleString()}
+            </Detail>
+          </dl>
+          <a
+            href={`https://stellar.expert/explorer/testnet/contract/${result.contract}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-block text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
+          >
+            View the contract on Stellar Expert ↗
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CheckCard({
+  title,
+  subtitle,
+  result,
+}: {
+  title: string;
+  subtitle: string;
+  result: { ok: boolean | null; error?: string };
+}) {
+  const tone =
+    result.ok === true
+      ? 'text-emerald-400'
+      : result.ok === false
+        ? 'text-red-400'
+        : 'text-amber-400';
+  const label =
+    result.ok === true ? 'Valid' : result.ok === false ? 'Not in batch' : 'Unavailable';
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 space-y-1">
+      <p className="text-sm font-medium text-gray-300">{title}</p>
+      <p className={`text-2xl font-semibold ${tone}`}>{label}</p>
+      <p className="text-xs text-gray-500">{subtitle}</p>
+      {result.error && <p className="text-xs text-amber-400/80 pt-1">{result.error}</p>}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block space-y-2">
+      <span className="block text-sm font-medium text-gray-300">{label}</span>
+      {children}
+      <span className="block text-xs text-gray-500">{hint}</span>
+    </label>
+  );
+}
+
+function Detail({
+  label,
+  children,
+  mono,
+}: {
+  label: string;
+  children: React.ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs uppercase tracking-wider text-gray-500">{label}</dt>
+      <dd className={`text-gray-300 break-all ${mono ? 'font-mono text-xs' : ''}`}>
+        {children}
+      </dd>
+    </div>
+  );
+}

--- a/apps/web/src/lib/receipt-anchor.test.ts
+++ b/apps/web/src/lib/receipt-anchor.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { isHash32 } from './receipt-anchor';
+import { verifyReceipt } from '@accensa/sdk/merkle';
+import vectors from '../../../../packages/sdk/merkle-vectors.json';
+
+describe('isHash32', () => {
+  it('accepts a 64-character hex string', () => {
+    expect(isHash32('a'.repeat(64))).toBe(true);
+    expect(isHash32('A'.repeat(64))).toBe(true);
+  });
+
+  it('tolerates surrounding whitespace from pasted input', () => {
+    expect(isHash32(`  ${'a'.repeat(64)}\n`)).toBe(true);
+  });
+
+  it('rejects wrong lengths', () => {
+    expect(isHash32('a'.repeat(63))).toBe(false);
+    expect(isHash32('a'.repeat(65))).toBe(false);
+    expect(isHash32('')).toBe(false);
+  });
+
+  it('rejects non-hex characters', () => {
+    expect(isHash32('z'.repeat(64))).toBe(false);
+    expect(isHash32(`0x${'a'.repeat(62)}`)).toBe(false);
+  });
+});
+
+describe('verifier sample data', () => {
+  // The /verify page ships a preloaded sample so anyone can see the verifier
+  // work without first obtaining a receipt. If that sample drifts from the
+  // conformance vectors, the front page of the product silently starts lying.
+  const live = vectors.cases[0];
+  const forged = vectors.cases[1];
+
+  const SAMPLE_LEAF =
+    'c476fc0553303ec4275bd4cb50ab7fa8182e343dbc4c721d7e2076fd77a5b56c';
+  const SAMPLE_PROOF = [
+    '7ca64ee60e2b975f59f2a1f1cc1526d5b001a5c29f70291f316ba1c012a01bd1',
+    '1733fad16ada0c23d8cdaff52bea66bea308dddddcb79348842acef0065c9615',
+  ];
+  const FORGED_LEAF =
+    '16b138aabc889c21114436424e13132bd8928d2c21b4ac5a9ac5198104efb42c';
+
+  it('valid sample matches the anchored conformance vector', () => {
+    expect(SAMPLE_LEAF).toBe(live.leaf);
+    expect(SAMPLE_PROOF).toEqual(live.proof);
+    expect(live.expected).toBe(true);
+  });
+
+  it('forged sample matches the negative conformance vector', () => {
+    expect(FORGED_LEAF).toBe(forged.leaf);
+    expect(forged.expected).toBe(false);
+  });
+
+  it('valid sample verifies locally against the on-chain root', () => {
+    expect(verifyReceipt(SAMPLE_LEAF, SAMPLE_PROOF, vectors.onchain.root)).toBe(true);
+  });
+
+  it('forged sample fails locally against the on-chain root', () => {
+    expect(verifyReceipt(FORGED_LEAF, SAMPLE_PROOF, vectors.onchain.root)).toBe(false);
+  });
+
+  it('pins the batch that the sample refers to', () => {
+    expect(vectors.onchain.batchId).toBe(1);
+    expect(vectors.onchain.contract).toBe(
+      'CBHRJU7CF4XIFRNDITFHNQHABKBMFM2FYFHLGWN3JGSFYYCDSMDAWPRV',
+    );
+  });
+});

--- a/apps/web/src/lib/receipt-anchor.ts
+++ b/apps/web/src/lib/receipt-anchor.ts
@@ -1,0 +1,118 @@
+import {
+  Account,
+  Address,
+  Contract,
+  Networks,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Reads the ReceiptAnchor contract on Stellar.
+ *
+ * Every call here is a read-only simulation — nothing is signed, nothing is
+ * submitted, and no fees are paid. That matters for the public verifier: an
+ * agent operator must be able to check a receipt without an account, a wallet,
+ * or any trust in this service.
+ */
+
+export const RECEIPT_ANCHOR_ID =
+  process.env.NEXT_PUBLIC_RECEIPT_ANCHOR_ID ??
+  'CBHRJU7CF4XIFRNDITFHNQHABKBMFM2FYFHLGWN3JGSFYYCDSMDAWPRV';
+
+const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+
+const NETWORK_PASSPHRASE =
+  process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+
+/**
+ * Simulation needs a source account, but never uses its balance or sequence.
+ * A well-known address with a zero sequence keeps the verifier usable by
+ * callers who have no Stellar account at all.
+ */
+const SIMULATION_SOURCE =
+  process.env.MERCHANT_ADDRESS ??
+  'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
+
+export interface BatchRecord {
+  root: string;
+  count: number;
+  periodStart: number;
+  periodEnd: number;
+}
+
+/** A hex string of exactly 32 bytes. */
+export function isHash32(value: string): boolean {
+  return /^[0-9a-fA-F]{64}$/.test(value.trim());
+}
+
+function hexToScValBytes(hex: string) {
+  return xdr.ScVal.scvBytes(Buffer.from(hex.trim(), 'hex'));
+}
+
+async function simulate(method: string, args: xdr.ScVal[]): Promise<unknown> {
+  const server = new rpc.Server(RPC_URL, {
+    allowHttp: RPC_URL.startsWith('http://'),
+  });
+  const contract = new Contract(RECEIPT_ANCHOR_ID);
+  const source = new Account(SIMULATION_SOURCE, '0');
+
+  const tx = new TransactionBuilder(source, {
+    fee: '100',
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+
+  if (rpc.Api.isSimulationError(sim)) {
+    throw new Error(sim.error);
+  }
+  if (!('result' in sim) || !sim.result?.retval) {
+    throw new Error(`${method} returned no value`);
+  }
+  return scValToNative(sim.result.retval);
+}
+
+/**
+ * Verifies a receipt against an anchored batch, on-chain.
+ *
+ * Returns the contract's own answer — the point of the verifier is that this
+ * number comes from the ledger, not from us.
+ */
+export async function verifyReceiptOnChain(
+  batchId: number,
+  leaf: string,
+  proof: string[],
+): Promise<boolean> {
+  const result = await simulate('verify_receipt', [
+    nativeToScVal(batchId, { type: 'u64' }),
+    hexToScValBytes(leaf),
+    xdr.ScVal.scvVec(proof.map(hexToScValBytes)),
+  ]);
+  return result === true;
+}
+
+/** Reads an anchored batch. Throws if the batch does not exist. */
+export async function getBatch(batchId: number): Promise<BatchRecord> {
+  const raw = (await simulate('get_batch', [
+    nativeToScVal(batchId, { type: 'u64' }),
+  ])) as Record<string, unknown>;
+
+  const root = raw.root;
+  return {
+    root: Buffer.isBuffer(root)
+      ? root.toString('hex')
+      : Buffer.from(root as Uint8Array).toString('hex'),
+    count: Number(raw.count),
+    periodStart: Number(raw.period_start),
+    periodEnd: Number(raw.period_end),
+  };
+}
+
+export { Address };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,6 +5,10 @@
   "main": "index.ts",
   "types": "index.ts",
   "license": "MIT",
+  "exports": {
+    ".": "./index.ts",
+    "./merkle": "./merkle.ts"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
@@ -19,6 +23,7 @@
     }
   },
   "devDependencies": {
+    "@types/express": "^5.0.0",
     "vitest": "^2.1.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@accensa/sdk':
+        specifier: workspace:^
+        version: link:../../packages/sdk
       '@stellar/stellar-sdk':
         specifier: ^16.0.1
         version: 16.0.1
@@ -119,6 +122,9 @@ importers:
         specifier: '>=4'
         version: 5.2.1
     devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.19.43)(lightningcss@1.32.0)(terser@5.49.0)
@@ -2619,8 +2625,14 @@ packages:
   '@types/express-serve-static-core@4.19.9':
     resolution: {integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==}
 
+  '@types/express-serve-static-core@5.1.2':
+    resolution: {integrity: sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==}
+
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
@@ -2719,6 +2731,9 @@ packages:
 
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
@@ -11049,12 +11064,25 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
+  '@types/express-serve-static-core@5.1.2':
+    dependencies:
+      '@types/node': 20.19.43
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
   '@types/express@4.17.25':
     dependencies:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 4.19.9
       '@types/qs': 6.15.1
       '@types/serve-static': 1.15.10
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.2
+      '@types/serve-static': 2.2.0
 
   '@types/hast@3.0.5':
     dependencies:
@@ -11156,13 +11184,18 @@ snapshots:
 
   '@types/serve-index@1.9.4':
     dependencies:
-      '@types/express': 4.17.25
+      '@types/express': 5.0.6
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 20.19.43
       '@types/send': 0.17.6
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.43
 
   '@types/sockjs@0.3.36':
     dependencies:


### PR DESCRIPTION
First piece of Phase 2. Adds `/verify` — the page that makes the product's argument.

An agent operator can confirm they were charged correctly **without an account, a wallet, or any trust in this service.** Verification that required trusting Accensa's login would defeat the entire premise, so this page is public and read-only.

## Checked twice, independently

| Check | What it does |
|---|---|
| **Local** | Recomputes the root from the proof in this process, via the SDK |
| **On-chain** | Asks `ReceiptAnchor.verify_receipt` on the ledger |

Both results are shown **side by side**. Agreement between an independent computation and the ledger is the whole trust story, so the UI reports each separately rather than collapsing them into a single verdict — and explicitly flags disagreement, which should be impossible since both are pinned to the same conformance vectors.

## No account required

On-chain checks go through `simulateTransaction` with a zero-sequence source account. Nothing is signed, submitted, or charged, and the caller needs no Stellar account of their own.

## Failures explain themselves

- Unanchored batch → *"Batch #999 has not been anchored on this contract."*
- Malformed input → names the offending field, rejected before any network call
- A receipt genuinely not in the batch → distinguished from a check that could not be performed

## Try it in one click

Two buttons load a valid receipt and a forged one from **batch #1, anchored live on testnet**. A test pins those samples to the shared conformance vectors — if the sample ever drifts, the front page of the product starts lying, so it fails the build instead.

## Also

`packages/sdk` gains an exports map, so consumers can import the pure merkle logic (`@accensa/sdk/merkle`) without pulling in the express types the middleware hook needs.

## Verified against the live contract

| Case | local | on-chain |
|---|---|---|
| Valid receipt | valid | valid |
| Forged receipt | not in batch | not in batch |
| Batch #999 | — | reports not anchored |
| Malformed leaf / batchId | rejected before any network call | — |

Rendered in a real browser and exercised end to end: sample loads, verify runs, both cards report Valid, batch metadata reads back from the ledger. Zero console errors.

41 tests pass. `lint`, `tsc --noEmit`, and `next build` clean.

## Still to come in Phase 2

Landing page, and `/batches/[id]` public permalinks. The dashboard currently occupies `/`, so a landing page means moving it to `/dashboard`.
