### PR TITLE
feat(sdk,web): real settlement reporting for route attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ of a cent, which is the only way verifiability survives micropayment economics.
 |---|---|---|
 | **Indexer** | [`apps/web/src/app/api/sync`](apps/web/src/app/api/sync) | Decodes Stellar Asset Contract `transfer` events addressed to the merchant and persists them to PostgreSQL. Runs on a schedule; tracks a ledger cursor so it never rescans or double-counts. |
 | **Dashboard** | [`apps/web/`](apps/web) | Next.js app showing payments, totals, and receipt verification. |
-| **SDK** | [`packages/sdk/`](packages/sdk) | `verifyReceipt()` for off-chain Merkle verification, and `attachAccensaHook()` middleware for route-level attribution. |
+| **SDK** | [`packages/sdk/`](packages/sdk) | `verifyReceipt()` for off-chain Merkle verification, and `attachAccensaHook()` / `createSettleHook()` for reporting route-level attribution from your x402 server. |
 | **Demo merchant** | [`apps/demo-merchant/`](apps/demo-merchant) | Minimal paid endpoint for exercising the flow end to end. |
 
 ## Verifying a Receipt Off-Chain
@@ -118,6 +118,7 @@ docker run --name pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
 MERCHANT_ADDRESS=GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+HOOK_API_KEY=any-shared-secret   # required for /api/hook/settle
 
 # 3. Dashboard (schema is created on first request)
 cd apps/web
@@ -131,6 +132,33 @@ says so — the dashboard never invents rows to fill space.
 
 Routes: `/` is the landing page, `/dashboard` the merchant view, and `/verify` the
 public receipt verifier, which needs no account.
+
+### Route-level attribution
+
+A SAC `transfer` event carries the payer, amount, and asset — never the HTTP route
+that was paid for. That mapping exists only inside your server, at the moment x402
+settles, so it has to be reported rather than indexed.
+
+Set `HOOK_API_KEY` on both sides, then report settlements from your x402 server:
+
+```ts
+import { createSettleHook } from '@accensa/sdk';
+
+resourceServer.onAfterSettle(
+  createSettleHook({ indexerUrl: 'https://your-accensa.vercel.app', apiKey: process.env.HOOK_API_KEY }),
+);
+```
+
+Or, if you only have the response to work from, mount `attachAccensaHook()` after your
+x402 middleware — it reads the `X-PAYMENT-RESPONSE` header.
+
+`POST /api/hook/settle` is the endpoint behind both. It is the only write path into
+`payments` not derived from the ledger, so it fails closed: with no `HOOK_API_KEY`
+configured it accepts nothing. Reported attribution is marked with `hook_reported_at`,
+keeping merchant-reported fields distinguishable from on-chain ones. Settlements for
+transfers the indexer has not reached yet are staged and completed on the next run.
+
+[`apps/demo-merchant/`](apps/demo-merchant) is a working example.
 
 ### Contract addresses
 

--- a/apps/demo-merchant/package.json
+++ b/apps/demo-merchant/package.json
@@ -13,7 +13,8 @@
     "@x402/express": "^2.18.0",
     "@x402/stellar": "^2.16.0",
     "dotenv": "^17.4.2",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "@x402/core": "^2.18.0"
   },
   "type": "module"
 }

--- a/apps/demo-merchant/server.js
+++ b/apps/demo-merchant/server.js
@@ -5,6 +5,7 @@ import {
   x402HTTPResourceServer
 } from "@x402/express";
 import { HTTPFacilitatorClient } from "@x402/core/server";
+import { ExactStellarScheme } from "@x402/stellar/exact/server";
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -13,10 +14,38 @@ const PORT = process.env.PORT || 3001;
 const ACCENSA_URL = process.env.ACCENSA_URL || "http://localhost:3000";
 const HOOK_API_KEY = process.env.HOOK_API_KEY;
 
+const NETWORK = "stellar:testnet";
+
+// Native XLM Stellar Asset Contract on testnet. Priced as an explicit
+// AssetAmount rather than a bare number: the default money parser assumes
+// USDC, and the asset has to match what the indexer watches
+// (ASSET_CONTRACT_IDS) or the settled transfer is never picked up.
+const XLM_SAC =
+  process.env.TOKEN_ADDRESS || "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+/**
+ * x402 identifies the paid resource by absolute URL. Attribution wants the path
+ * alone — the host is the merchant's own, so grouping revenue by it is noise.
+ * Mirrors routeFromResourceUrl() in @accensa/sdk, inlined here because this
+ * demo runs as plain ESM with no build step.
+ */
+function routeFromResourceUrl(url) {
+  if (typeof url !== "string" || url.trim() === "") return "";
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url.startsWith("/") ? url : "";
+  }
+}
+
 // 1. Create the resource server and point it to the public facilitator
 const resourceServer = new x402ResourceServer([
   new HTTPFacilitatorClient({ url: "https://www.x402.org/facilitator" })
 ]);
+
+// The facilitator settles, but the resource server still needs the scheme
+// implementation to build and verify payment requirements locally.
+resourceServer.register(NETWORK, new ExactStellarScheme());
 
 // 2. Path B: report the route that was paid for.
 //
@@ -41,7 +70,16 @@ resourceServer.onAfterSettle(async (ctx) => {
     return;
   }
 
-  console.log("✅ Settled", ctx.result.transaction, "for", ctx.paymentPayload?.path);
+  // x402 identifies the paid resource by absolute URL; attribution wants the
+  // path. There is no method on the payload, so a server paywalling more than
+  // one verb on a path has to decide for itself which it is reporting.
+  const route = routeFromResourceUrl(ctx.paymentPayload?.resource?.url);
+  if (!route) {
+    console.warn("⚠️  Settlement carried no resource URL; nothing to attribute");
+    return;
+  }
+
+  console.log("✅ Settled", ctx.result.transaction, "for", route);
 
   try {
     const res = await fetch(`${ACCENSA_URL}/api/hook/settle`, {
@@ -52,7 +90,7 @@ resourceServer.onAfterSettle(async (ctx) => {
       },
       body: JSON.stringify({
         tx_hash: ctx.result.transaction,
-        route: ctx.paymentPayload?.path,
+        route,
         method: "GET",
         payer: ctx.result.payer
       })
@@ -74,8 +112,8 @@ const routesConfig = {
   "/api/hello": {
     accepts: {
       scheme: "exact",
-      price: "1000", // e.g. 1000 stroops
-      network: "stellar:testnet",
+      price: { asset: XLM_SAC, amount: "1000" }, // 1000 stroops = 0.0001 XLM
+      network: NETWORK,
       payTo: process.env.MERCHANT_ADDRESS || "GAQW...REPLACE_WITH_REAL_ADDRESS",
     },
   },

--- a/apps/demo-merchant/server.js
+++ b/apps/demo-merchant/server.js
@@ -1,43 +1,71 @@
 import express from "express";
-import { 
-  paymentMiddlewareFromHTTPServer, 
-  x402ResourceServer, 
-  x402HTTPResourceServer 
+import {
+  paymentMiddlewareFromHTTPServer,
+  x402ResourceServer,
+  x402HTTPResourceServer
 } from "@x402/express";
 import { HTTPFacilitatorClient } from "@x402/core/server";
-import fs from "fs";
 
 const app = express();
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
+
+// Where to report route attribution. Point this at your Accensa deployment.
+const ACCENSA_URL = process.env.ACCENSA_URL || "http://localhost:3000";
+const HOOK_API_KEY = process.env.HOOK_API_KEY;
 
 // 1. Create the resource server and point it to the public facilitator
 const resourceServer = new x402ResourceServer([
   new HTTPFacilitatorClient({ url: "https://www.x402.org/facilitator" })
 ]);
 
-// 2. This is the crucial Path B Hook! We intercept the settlement response here.
+// 2. Path B: report the route that was paid for.
+//
+// The ledger records the transfer but not the route — a SAC transfer event has
+// no notion of an HTTP path. That mapping only exists here, at settlement, so
+// this is where it has to be captured.
+//
+// Note what is *not* here: no fallback hash. If x402 reports a settlement
+// without a transaction, there is nothing to attribute and we send nothing. A
+// row whose tx_hash never appears on chain is worse than a missing row.
 resourceServer.onAfterSettle(async (ctx) => {
-  if (ctx.result.success) {
-    console.log("✅ Settlement successful!");
-    console.log("Transaction Hash:", ctx.result.transaction);
-    console.log("Payer:", ctx.result.payer);
-    console.log("Amount:", ctx.result.amount);
-    
-    // Save the raw context to a file so we have our ground-truth data for the indexer
-    const payload = {
-      path: ctx.paymentPayload?.path,
-      transaction: ctx.result.transaction,
-      payer: ctx.result.payer,
-      amount: ctx.result.amount,
-      network: ctx.result.network,
-      rawResult: ctx.result,
-      paymentPayload: ctx.paymentPayload
-    };
-    
-    fs.writeFileSync("settle_payload.json", JSON.stringify(payload, null, 2));
-    console.log("💾 Captured payload to settle_payload.json");
-  } else {
+  if (!ctx.result.success) {
     console.error("❌ Settlement failed:", ctx.result.errorReason);
+    return;
+  }
+  if (!ctx.result.transaction) {
+    console.warn("⚠️  Settlement succeeded without a transaction hash; nothing to attribute");
+    return;
+  }
+  if (!HOOK_API_KEY) {
+    console.warn("⚠️  HOOK_API_KEY is not set; skipping attribution report");
+    return;
+  }
+
+  console.log("✅ Settled", ctx.result.transaction, "for", ctx.paymentPayload?.path);
+
+  try {
+    const res = await fetch(`${ACCENSA_URL}/api/hook/settle`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${HOOK_API_KEY}`
+      },
+      body: JSON.stringify({
+        tx_hash: ctx.result.transaction,
+        route: ctx.paymentPayload?.path,
+        method: "GET",
+        payer: ctx.result.payer
+      })
+    });
+
+    if (!res.ok) {
+      console.error(`⚠️  Accensa returned ${res.status}:`, await res.text());
+    } else {
+      console.log("📊 Attribution reported to Accensa");
+    }
+  } catch (error) {
+    // Never let reporting break a paid request — the payment already settled.
+    console.error("⚠️  Could not reach Accensa:", error.message);
   }
 });
 
@@ -60,13 +88,14 @@ app.use(paymentMiddlewareFromHTTPServer(httpServer));
 
 // 5. Protected route
 app.get("/api/hello", (req, res) => {
-  res.json({ 
-    message: "Payment verified!", 
-    data: "This is the premium Accensa content." 
+  res.json({
+    message: "Payment verified!",
+    data: "This is the premium Accensa content."
   });
 });
 
 app.listen(PORT, () => {
   console.log(`Demo merchant server running on port ${PORT}`);
   console.log(`Protected route: http://localhost:${PORT}/api/hello`);
+  console.log(`Reporting attribution to: ${ACCENSA_URL}/api/hook/settle`);
 });

--- a/apps/web/src/app/api/hook/settle/route.ts
+++ b/apps/web/src/app/api/hook/settle/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { withClient, ensureSchema, recordSettlement } from '@/lib/db';
+import { parseSettlementReport, bearerMatches } from '@/lib/settlement-report';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Records route attribution reported by an x402 seller.
+ *
+ * A SAC `transfer` event carries payer, amount, and asset — never the HTTP
+ * route that was paid for. That mapping exists only in the seller's process, so
+ * it has to be reported rather than indexed. This is consequently the only
+ * write path into `payments` that is not derived from the ledger, which is why
+ * it fails closed: without HOOK_API_KEY configured the endpoint refuses to
+ * accept anything at all.
+ *
+ * Ledger-owned fields (ledger, amount, asset, ts) are never written here.
+ */
+export async function POST(request: Request) {
+  const expected = process.env.HOOK_API_KEY;
+  if (!expected) {
+    return NextResponse.json(
+      { error: 'Settlement reporting is not configured' },
+      { status: 503 },
+    );
+  }
+
+  if (!bearerMatches(request.headers.get('authorization'), expected)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const parsed = parseSettlementReport(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  try {
+    const { matchedExistingPayment } = await withClient(async (client) => {
+      await ensureSchema(client);
+      return recordSettlement(client, parsed.report);
+    });
+
+    return NextResponse.json({
+      recorded: true,
+      txHash: parsed.report.txHash,
+      // False means the transfer has not been indexed yet and the attribution
+      // was staged. The sync job completes the row when it reaches that ledger.
+      matchedExistingPayment,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: `Could not record settlement: ${message}` }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -123,10 +123,24 @@ export async function GET(request: Request) {
         // Defensive: never record a transfer that is not to this merchant.
         if (transferEvent.to !== merchant) continue;
 
+        // DO UPDATE, not DO NOTHING: a row may already exist because the
+        // merchant reported route attribution before this transfer was
+        // indexed, which is the normal ordering — the hook fires the moment
+        // x402 settles, this job runs on a schedule. Skipping the conflict
+        // would leave that row permanently null and invisible.
+        //
+        // Only ledger-owned columns are written. route, method, request_id and
+        // hook_reported_at belong to the merchant's report and are left alone.
         const res = await client.query(
           `INSERT INTO payments (tx_hash, ledger, payer, amount, asset, ts)
            VALUES ($1, $2, $3, $4::numeric, $5, $6::timestamptz)
-           ON CONFLICT (tx_hash) DO NOTHING`,
+           ON CONFLICT (tx_hash) DO UPDATE
+             SET ledger = EXCLUDED.ledger,
+                 payer  = EXCLUDED.payer,
+                 amount = EXCLUDED.amount,
+                 asset  = EXCLUDED.asset,
+                 ts     = EXCLUDED.ts
+           WHERE payments.ledger IS NULL`,
           [
             transferEvent.txHash,
             transferEvent.ledger,

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -80,6 +80,15 @@ export async function ensureSchema(client: Client): Promise<void> {
     );
   `);
 
+  // Attribution reported by the merchant arrives before the indexer has seen
+  // the transfer — the sync job runs on a schedule, the hook fires the instant
+  // x402 settles. Those staged rows have no amount or payer yet, and inventing
+  // a zero to satisfy a constraint is exactly the fabrication this codebase
+  // exists to avoid. The chain fills them in.
+  for (const col of ['amount', 'payer']) {
+    await client.query(`ALTER TABLE payments ALTER COLUMN ${col} DROP NOT NULL;`);
+  }
+
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_ts ON payments(ts DESC);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_route ON payments(route);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_payer ON payments(payer);`);
@@ -125,9 +134,13 @@ export async function recordSettlement(
   // Not indexed yet. Stage the attribution so it is not lost; the sync job
   // completes the row when it reaches that ledger. ON CONFLICT guards the race
   // where the indexer inserts between the UPDATE and the INSERT.
+  // ts is explicitly NULL, not omitted: the column carries a CURRENT_TIMESTAMP
+  // default, and letting it fire would stamp a staged row with the time it was
+  // reported rather than the time the payment settled on chain — and would put
+  // it straight onto the dashboard, since that filters on ts IS NOT NULL.
   await client.query(
-    `INSERT INTO payments (tx_hash, payer, route, method, request_id, hook_reported_at)
-     VALUES ($1, $2, $3, $4, $5, now())
+    `INSERT INTO payments (tx_hash, payer, route, method, request_id, ts, hook_reported_at)
+     VALUES ($1, $2, $3, $4, $5, NULL, now())
      ON CONFLICT (tx_hash) DO UPDATE
        SET route = EXCLUDED.route,
            method = EXCLUDED.method,

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -66,6 +66,7 @@ export async function ensureSchema(client: Client): Promise<void> {
     ['route', 'VARCHAR(255)'],
     ['method', 'VARCHAR(10)'],
     ['request_id', 'VARCHAR(64)'],
+    ['hook_reported_at', 'TIMESTAMPTZ'],
   ]) {
     await client.query(`ALTER TABLE payments ADD COLUMN IF NOT EXISTS ${col} ${type};`);
   }
@@ -82,6 +83,60 @@ export async function ensureSchema(client: Client): Promise<void> {
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_ts ON payments(ts DESC);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_route ON payments(route);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_payer ON payments(payer);`);
+}
+
+/**
+ * Records merchant-reported route attribution against a payment.
+ *
+ * Attribution is the one fact the chain cannot supply: a SAC `transfer` event
+ * has no notion of an HTTP route. It therefore arrives from the seller's own
+ * process and is trusted only as far as the shared secret guarding this path.
+ *
+ * `hook_reported_at` marks the row as carrying merchant-reported data, so the
+ * two provenances stay distinguishable downstream. Ledger fields are never
+ * written here — if the transfer has not been indexed yet, the row is staged
+ * with a null ledger and the sync job fills in the on-chain truth later.
+ *
+ * A staged row also has a null `ts`, which is what keeps it out of the
+ * dashboard: /api/payments filters on `ts IS NOT NULL`, so an attribution can
+ * never be presented as revenue before the chain confirms the transfer.
+ *
+ * Returns whether the settlement matched an already-indexed payment.
+ */
+export async function recordSettlement(
+  client: Client,
+  s: {
+    txHash: string;
+    route: string;
+    method: string;
+    requestId?: string | null;
+    payer?: string | null;
+  },
+): Promise<{ matchedExistingPayment: boolean }> {
+  const updated = await client.query(
+    `UPDATE payments
+        SET route = $2, method = $3, request_id = $4, hook_reported_at = now()
+      WHERE tx_hash = $1`,
+    [s.txHash, s.route, s.method, s.requestId ?? null],
+  );
+
+  if ((updated.rowCount ?? 0) > 0) return { matchedExistingPayment: true };
+
+  // Not indexed yet. Stage the attribution so it is not lost; the sync job
+  // completes the row when it reaches that ledger. ON CONFLICT guards the race
+  // where the indexer inserts between the UPDATE and the INSERT.
+  await client.query(
+    `INSERT INTO payments (tx_hash, payer, route, method, request_id, hook_reported_at)
+     VALUES ($1, $2, $3, $4, $5, now())
+     ON CONFLICT (tx_hash) DO UPDATE
+       SET route = EXCLUDED.route,
+           method = EXCLUDED.method,
+           request_id = EXCLUDED.request_id,
+           hook_reported_at = now()`,
+    [s.txHash, s.payer ?? null, s.route, s.method, s.requestId ?? null],
+  );
+
+  return { matchedExistingPayment: false };
 }
 
 export async function getLastSyncedLedger(client: Client): Promise<number | null> {

--- a/apps/web/src/lib/settlement-report.test.ts
+++ b/apps/web/src/lib/settlement-report.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { parseSettlementReport, bearerMatches } from './settlement-report';
+
+const TX = 'a'.repeat(64);
+const PAYER = 'G' + 'A'.repeat(55);
+
+const valid = { tx_hash: TX, route: '/api/hello', method: 'GET' };
+
+function expectError(body: unknown, match: RegExp) {
+  const result = parseSettlementReport(body);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toMatch(match);
+}
+
+describe('parseSettlementReport', () => {
+  it('accepts a minimal valid report', () => {
+    const result = parseSettlementReport(valid);
+    expect(result).toEqual({
+      ok: true,
+      report: { txHash: TX, route: '/api/hello', method: 'GET', requestId: null, payer: null },
+    });
+  });
+
+  it('lower-cases the transaction hash so lookups match the indexer', () => {
+    const result = parseSettlementReport({ ...valid, tx_hash: TX.toUpperCase() });
+    expect(result.ok && result.report.txHash).toBe(TX);
+  });
+
+  it('upper-cases the method', () => {
+    const result = parseSettlementReport({ ...valid, method: 'post' });
+    expect(result.ok && result.report.method).toBe('POST');
+  });
+
+  it('carries through an optional request id and payer', () => {
+    const result = parseSettlementReport({ ...valid, request_id: 'req-9', payer: PAYER });
+    expect(result.ok && result.report).toMatchObject({ requestId: 'req-9', payer: PAYER });
+  });
+
+  it('treats a blank request id as absent', () => {
+    const result = parseSettlementReport({ ...valid, request_id: '   ' });
+    expect(result.ok && result.report.requestId).toBeNull();
+  });
+
+  it.each([
+    ['a string', 'nope'],
+    ['null', null],
+    ['an array', []],
+  ])('rejects a body that is %s', (_label, body) => {
+    expectError(body, /JSON object/);
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['too short', 'abc'],
+    ['not hex', 'z'.repeat(64)],
+    ['not a string', 12345],
+  ])('rejects a tx_hash that is %s', (_label, tx_hash) => {
+    expectError({ ...valid, tx_hash }, /tx_hash/);
+  });
+
+  // The reason this endpoint exists: mock hashes must never reach the database.
+  it('rejects a fabricated mock hash', () => {
+    expectError({ ...valid, tx_hash: `mock_hash_${Date.now()}` }, /tx_hash/);
+  });
+
+  it('rejects a missing route', () => {
+    expectError({ tx_hash: TX, method: 'GET' }, /route is required/);
+  });
+
+  it('rejects an over-long route rather than truncating it', () => {
+    expectError({ ...valid, route: '/' + 'a'.repeat(255) }, /at most 255/);
+  });
+
+  it('rejects an over-long request id rather than truncating it', () => {
+    expectError({ ...valid, request_id: 'r'.repeat(65) }, /at most 64/);
+  });
+
+  it.each([['TRACE'], ['CONNECT'], ['nonsense'], ['']])('rejects the method %s', (method) => {
+    expectError({ ...valid, method }, /method/);
+  });
+
+  it('rejects a payer that is not a Stellar account id', () => {
+    expectError({ ...valid, payer: 'not-an-account' }, /Stellar account/);
+  });
+
+  it('rejects a non-string request id', () => {
+    expectError({ ...valid, request_id: 5 }, /request_id/);
+  });
+});
+
+describe('bearerMatches', () => {
+  it('accepts the expected token', () => {
+    expect(bearerMatches('Bearer s3cret', 's3cret')).toBe(true);
+  });
+
+  it('rejects a wrong token of the same length', () => {
+    expect(bearerMatches('Bearer s3cres', 's3cret')).toBe(false);
+  });
+
+  it('rejects a token of a different length', () => {
+    expect(bearerMatches('Bearer s3cretlonger', 's3cret')).toBe(false);
+  });
+
+  it('rejects a missing or malformed header', () => {
+    expect(bearerMatches(null, 's3cret')).toBe(false);
+    expect(bearerMatches('s3cret', 's3cret')).toBe(false);
+    expect(bearerMatches('Basic s3cret', 's3cret')).toBe(false);
+  });
+
+  it('is case sensitive on the scheme', () => {
+    expect(bearerMatches('bearer s3cret', 's3cret')).toBe(false);
+  });
+
+  // Fails closed: an unset secret must never authorise anything.
+  it('rejects everything when no secret is configured', () => {
+    expect(bearerMatches('Bearer anything', '')).toBe(false);
+    expect(bearerMatches('Bearer ', '')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/settlement-report.ts
+++ b/apps/web/src/lib/settlement-report.ts
@@ -1,0 +1,106 @@
+/**
+ * Validation for merchant-reported settlements arriving at /api/hook/settle.
+ *
+ * Kept separate from the route handler so the rules are unit-testable without a
+ * database. Everything here is deliberately strict: this endpoint is the one
+ * write path into `payments` that does not originate from the ledger, so a
+ * malformed or over-long field must be rejected rather than normalized.
+ */
+
+export interface SettlementReport {
+  txHash: string;
+  route: string;
+  method: string;
+  requestId: string | null;
+  payer: string | null;
+}
+
+export type ParseResult =
+  | { ok: true; report: SettlementReport }
+  | { ok: false; error: string };
+
+/** Stellar transaction hashes are 32 bytes, hex-encoded. */
+const TX_HASH = /^[0-9a-f]{64}$/i;
+
+/** Stellar public keys: 56-character base32 starting with G. */
+const ACCOUNT_ID = /^G[A-Z2-7]{55}$/;
+
+const METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']);
+
+/** Column widths in the payments table; over-long input is an error, not a truncation. */
+const MAX_ROUTE = 255;
+const MAX_REQUEST_ID = 64;
+
+export function parseSettlementReport(body: unknown): ParseResult {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return { ok: false, error: 'Body must be a JSON object' };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  const txHash = typeof b.tx_hash === 'string' ? b.tx_hash.trim() : '';
+  if (!TX_HASH.test(txHash)) {
+    return { ok: false, error: 'tx_hash must be a hex-encoded 32-byte transaction hash' };
+  }
+
+  const route = typeof b.route === 'string' ? b.route.trim() : '';
+  if (route === '') return { ok: false, error: 'route is required' };
+  if (route.length > MAX_ROUTE) {
+    return { ok: false, error: `route must be at most ${MAX_ROUTE} characters` };
+  }
+
+  const method = typeof b.method === 'string' ? b.method.trim().toUpperCase() : '';
+  if (!METHODS.has(method)) {
+    return { ok: false, error: 'method must be a standard HTTP method' };
+  }
+
+  let requestId: string | null = null;
+  if (b.request_id !== undefined && b.request_id !== null) {
+    if (typeof b.request_id !== 'string') {
+      return { ok: false, error: 'request_id must be a string' };
+    }
+    const trimmed = b.request_id.trim();
+    if (trimmed.length > MAX_REQUEST_ID) {
+      return { ok: false, error: `request_id must be at most ${MAX_REQUEST_ID} characters` };
+    }
+    requestId = trimmed === '' ? null : trimmed;
+  }
+
+  // The payer is only ever a hint used to stage a not-yet-indexed payment; the
+  // indexer overwrites it with the value read from the ledger. Reject a
+  // malformed one rather than persisting a value that can never reconcile.
+  let payer: string | null = null;
+  if (b.payer !== undefined && b.payer !== null) {
+    if (typeof b.payer !== 'string') {
+      return { ok: false, error: 'payer must be a string' };
+    }
+    const trimmed = b.payer.trim();
+    if (trimmed !== '' && !ACCOUNT_ID.test(trimmed)) {
+      return { ok: false, error: 'payer must be a Stellar account ID' };
+    }
+    payer = trimmed === '' ? null : trimmed;
+  }
+
+  return { ok: true, report: { txHash: txHash.toLowerCase(), route, method, requestId, payer } };
+}
+
+/**
+ * Constant-time-ish bearer token comparison.
+ *
+ * Length is compared first and the loop always runs to completion over the
+ * expected token, so a mismatched byte does not short-circuit.
+ */
+export function bearerMatches(header: string | null, expected: string): boolean {
+  if (!header || !expected) return false;
+  const prefix = 'Bearer ';
+  if (!header.startsWith(prefix)) return false;
+
+  const provided = header.slice(prefix.length);
+  if (provided.length !== expected.length) return false;
+
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/migrations/002_settlement_attribution.sql
+++ b/migrations/002_settlement_attribution.sql
@@ -13,6 +13,17 @@ BEGIN;
 
 ALTER TABLE payments ADD COLUMN IF NOT EXISTS hook_reported_at TIMESTAMPTZ;
 
+-- Attribution is reported the instant x402 settles; the indexer runs on a
+-- schedule. So a reported settlement almost always arrives before the transfer
+-- has been indexed, and the staged row genuinely has no amount or payer yet.
+--
+-- These columns were NOT NULL, which forced a choice between dropping the
+-- attribution or inventing a zero amount. Inventing one is precisely the
+-- fabrication this schema is meant to prevent, so the constraint goes instead.
+-- The chain remains the only writer of amount, asset, ledger, and ts.
+ALTER TABLE payments ALTER COLUMN amount DROP NOT NULL;
+ALTER TABLE payments ALTER COLUMN payer  DROP NOT NULL;
+
 -- A settlement can be reported before the indexer reaches that ledger. Those
 -- rows are staged with ledger, ts, amount, and asset all null, and completed on
 -- a later sync run.

--- a/migrations/002_settlement_attribution.sql
+++ b/migrations/002_settlement_attribution.sql
@@ -1,0 +1,29 @@
+-- Route-level attribution reported by the merchant's x402 server.
+--
+-- A SAC transfer event carries payer, amount, and asset. It does not carry the
+-- HTTP route that was paid for — that mapping exists only inside the seller's
+-- process at settlement time, so it arrives via POST /api/hook/settle rather
+-- than from the indexer.
+--
+-- hook_reported_at marks a row as carrying merchant-reported data. Keeping the
+-- two provenances distinguishable matters: everything else in this table is an
+-- observation of the ledger, and these fields are not.
+
+BEGIN;
+
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS hook_reported_at TIMESTAMPTZ;
+
+-- A settlement can be reported before the indexer reaches that ledger. Those
+-- rows are staged with ledger, ts, amount, and asset all null, and completed on
+-- a later sync run.
+--
+-- NOTE for future cleanup migrations: 001 deleted rows with a null ledger on
+-- the grounds that they were fabricated by the old writers. That rule no longer
+-- holds unconditionally. A staged row is identified by hook_reported_at being
+-- set and ts being null; it is a pending observation, not a fabrication. The
+-- dashboard already excludes it by filtering on ts IS NOT NULL, so it can never
+-- be presented as revenue before the chain confirms it.
+CREATE INDEX IF NOT EXISTS idx_payments_hook_reported ON payments(hook_reported_at)
+  WHERE hook_reported_at IS NOT NULL;
+
+COMMIT;

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -3,6 +3,7 @@ import {
   SETTLEMENT_HEADER,
   parseSettlementHeader,
   settlementFromResult,
+  routeFromResourceUrl,
   type RequestFacts,
   type Settlement,
   type X402SettleResult,
@@ -13,6 +14,7 @@ export {
   SETTLEMENT_HEADER,
   parseSettlementHeader,
   settlementFromResult,
+  routeFromResourceUrl,
   type RequestFacts,
   type Settlement,
   type X402SettleResult,
@@ -110,6 +112,15 @@ export function attachAccensaHook(opts: AccensaHookOptions) {
   };
 }
 
+export interface SettleHookOptions extends AccensaHookOptions {
+  /**
+   * HTTP method to attribute. The x402 payment payload identifies the resource
+   * by URL and carries no method, so a server that paywalls more than one verb
+   * on the same path must supply this itself. Defaults to GET.
+   */
+  method?: string;
+}
+
 /**
  * Builds an `onAfterSettle` handler for an x402 resource server.
  *
@@ -120,15 +131,14 @@ export function attachAccensaHook(opts: AccensaHookOptions) {
  * resourceServer.onAfterSettle(createSettleHook({ indexerUrl, apiKey }));
  * ```
  */
-export function createSettleHook(opts: AccensaHookOptions) {
+export function createSettleHook(opts: SettleHookOptions) {
   return async function onAfterSettle(ctx: {
     result: X402SettleResult;
-    paymentPayload?: { path?: string; method?: string; requestId?: string };
+    paymentPayload?: { resource?: { url?: string } };
   }): Promise<void> {
     const settlement = settlementFromResult(ctx.result, {
-      route: ctx.paymentPayload?.path ?? '',
-      method: ctx.paymentPayload?.method ?? 'GET',
-      requestId: ctx.paymentPayload?.requestId,
+      route: routeFromResourceUrl(ctx.paymentPayload?.resource?.url),
+      method: opts.method ?? 'GET',
     });
     if (settlement) await reportSettlement(settlement, opts);
   };

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -1,55 +1,144 @@
 import type { Request, Response, NextFunction } from 'express';
+import {
+  SETTLEMENT_HEADER,
+  parseSettlementHeader,
+  settlementFromResult,
+  type RequestFacts,
+  type Settlement,
+  type X402SettleResult,
+} from './settlement';
 
 export { verifyReceipt } from './merkle';
+export {
+  SETTLEMENT_HEADER,
+  parseSettlementHeader,
+  settlementFromResult,
+  type RequestFacts,
+  type Settlement,
+  type X402SettleResult,
+} from './settlement';
+
+/** Path the Accensa app exposes for merchant-reported route attribution. */
+export const SETTLE_ENDPOINT = '/api/hook/settle';
 
 export interface AccensaHookOptions {
+  /** Base URL of your Accensa deployment, e.g. https://accensa-dashboard.vercel.app */
   indexerUrl: string;
+  /** Shared secret; must match HOOK_API_KEY on the Accensa side. */
   apiKey: string;
+  /** Injected in tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Called when reporting fails. Reporting is best-effort by design — a paid
+   * request must not fail because attribution could not be recorded — but
+   * failures should be visible rather than swallowed.
+   */
+  onError?: (error: unknown) => void;
 }
 
+/**
+ * Reports one settlement to Accensa.
+ *
+ * Best-effort: resolves false rather than throwing, so a caller in a request
+ * path can ignore the result safely.
+ */
+export async function reportSettlement(
+  settlement: Settlement,
+  opts: AccensaHookOptions,
+): Promise<boolean> {
+  const doFetch = opts.fetchImpl ?? globalThis.fetch;
+  if (typeof doFetch !== 'function') {
+    opts.onError?.(new Error('No fetch implementation available'));
+    return false;
+  }
+
+  try {
+    const response = await doFetch(`${opts.indexerUrl.replace(/\/$/, '')}${SETTLE_ENDPOINT}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${opts.apiKey}`,
+      },
+      body: JSON.stringify({
+        tx_hash: settlement.txHash,
+        route: settlement.route,
+        method: settlement.method,
+        request_id: settlement.requestId,
+        payer: settlement.payer,
+        amount: settlement.amount,
+        network: settlement.network,
+      }),
+    });
+
+    if (!response.ok) {
+      opts.onError?.(new Error(`Accensa returned ${response.status} for ${settlement.txHash}`));
+      return false;
+    }
+    return true;
+  } catch (error) {
+    opts.onError?.(error);
+    return false;
+  }
+}
+
+/**
+ * Express middleware that reports route attribution for x402-paid requests.
+ *
+ * Reads the settlement from the `X-PAYMENT-RESPONSE` header the x402 middleware
+ * sets, once the response is complete. Requests that were not paid for carry no
+ * such header and are ignored.
+ *
+ * Mount this *after* your x402 payment middleware, so the header exists by the
+ * time the response finishes.
+ *
+ * If your server uses `@x402/core`'s resource server directly, prefer
+ * {@link createSettleHook} — it receives the settle result as ground truth
+ * rather than reading it back off the wire.
+ */
 export function attachAccensaHook(opts: AccensaHookOptions) {
-  return function(req: Request, res: Response, next: NextFunction) {
-    // Intercept the response to capture settlement details
-    const originalSend = res.send;
-    
-    res.send = function (body) {
-      res.send = originalSend;
-      
-      // Assume the x402 middleware sets settlement details in the body or headers
-      // For this scaffold, we'll try to extract them from a JSON body or mock them
-      try {
-        let txHash = "";
-        let price = "0";
-        
-        if (typeof body === 'string') {
-          const parsed = JSON.parse(body);
-          txHash = parsed.tx_hash || "mock_hash_" + Date.now();
-          price = parsed.amount || "0";
-        }
+  return function accensaHook(req: Request, res: Response, next: NextFunction) {
+    res.on('finish', () => {
+      const header = res.getHeader(SETTLEMENT_HEADER);
+      const settlement = settlementFromResult(
+        parseSettlementHeader(typeof header === 'string' ? header : undefined),
+        requestFacts(req),
+      );
+      if (settlement) void reportSettlement(settlement, opts);
+    });
 
-        if (txHash) {
-          fetch(`${opts.indexerUrl}/hook/settle`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${opts.apiKey}`
-            },
-            body: JSON.stringify({
-              tx_hash: txHash,
-              route: req.path,
-              method: req.method,
-              price: price,
-              request_id: req.headers['x-request-id'] || 'unknown'
-            })
-          }).catch(console.error);
-        }
-      } catch (e) {
-        // Silently ignore if we can't parse the response
-      }
-
-      return res.send(body);
-    };
-    
     next();
+  };
+}
+
+/**
+ * Builds an `onAfterSettle` handler for an x402 resource server.
+ *
+ * This is the preferred integration: the settle result arrives directly from
+ * the facilitator, so nothing has to be parsed back out of a response.
+ *
+ * ```ts
+ * resourceServer.onAfterSettle(createSettleHook({ indexerUrl, apiKey }));
+ * ```
+ */
+export function createSettleHook(opts: AccensaHookOptions) {
+  return async function onAfterSettle(ctx: {
+    result: X402SettleResult;
+    paymentPayload?: { path?: string; method?: string; requestId?: string };
+  }): Promise<void> {
+    const settlement = settlementFromResult(ctx.result, {
+      route: ctx.paymentPayload?.path ?? '',
+      method: ctx.paymentPayload?.method ?? 'GET',
+      requestId: ctx.paymentPayload?.requestId,
+    });
+    if (settlement) await reportSettlement(settlement, opts);
+  };
+}
+
+function requestFacts(req: Request): RequestFacts {
+  const requestId = req.headers['x-request-id'];
+  return {
+    route: req.route?.path ?? req.path ?? '',
+    method: req.method ?? '',
+    requestId: Array.isArray(requestId) ? requestId[0] : requestId,
   };
 }

--- a/packages/sdk/settlement.test.ts
+++ b/packages/sdk/settlement.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { parseSettlementHeader, settlementFromResult } from './settlement';
+
+const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64');
+
+const settled = {
+  success: true,
+  transaction: 'a'.repeat(64),
+  network: 'stellar:testnet',
+  payer: 'GAQW' + 'A'.repeat(52),
+  amount: '1000',
+};
+
+describe('parseSettlementHeader', () => {
+  it('decodes a base64 x402 settle response', () => {
+    expect(parseSettlementHeader(encode(settled))).toEqual(settled);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseSettlementHeader(`  ${encode(settled)}  `)).toEqual(settled);
+  });
+
+  it('keeps a failed settlement rather than discarding it', () => {
+    // The caller decides what a failure means; parsing only reports what x402 said.
+    const failure = { success: false, transaction: '', errorReason: 'insufficient_funds' };
+    expect(parseSettlementHeader(encode(failure))).toMatchObject({
+      success: false,
+      errorReason: 'insufficient_funds',
+    });
+  });
+
+  it('omits optional fields that are absent', () => {
+    const minimal = { success: true, transaction: 'b'.repeat(64) };
+    expect(parseSettlementHeader(encode(minimal))).toEqual({
+      success: true,
+      transaction: 'b'.repeat(64),
+      network: undefined,
+      payer: undefined,
+      amount: undefined,
+      errorReason: undefined,
+    });
+  });
+
+  it('ignores optional fields of the wrong type', () => {
+    const odd = { success: true, transaction: 'c'.repeat(64), payer: 42, amount: null };
+    expect(parseSettlementHeader(encode(odd))).toMatchObject({ payer: undefined, amount: undefined });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+    ['whitespace', '   '],
+  ])('returns null for %s', (_label, input) => {
+    expect(parseSettlementHeader(input as string | undefined | null)).toBeNull();
+  });
+
+  it('returns null when the payload is not valid JSON', () => {
+    expect(parseSettlementHeader(Buffer.from('not json').toString('base64'))).toBeNull();
+  });
+
+  it('returns null for a JSON array', () => {
+    expect(parseSettlementHeader(encode([1, 2, 3]))).toBeNull();
+  });
+
+  it('returns null for a JSON primitive', () => {
+    expect(parseSettlementHeader(encode('nope'))).toBeNull();
+  });
+
+  it('returns null when success is missing', () => {
+    expect(parseSettlementHeader(encode({ transaction: 'd'.repeat(64) }))).toBeNull();
+  });
+
+  it('returns null when transaction is missing', () => {
+    expect(parseSettlementHeader(encode({ success: true }))).toBeNull();
+  });
+
+  it('returns null when transaction is not a string', () => {
+    expect(parseSettlementHeader(encode({ success: true, transaction: 12345 }))).toBeNull();
+  });
+});
+
+describe('settlementFromResult', () => {
+  const facts = { route: '/api/hello', method: 'get', requestId: 'req-1' };
+
+  it('builds a settlement from a successful result', () => {
+    expect(settlementFromResult(settled, facts)).toEqual({
+      txHash: settled.transaction,
+      route: '/api/hello',
+      method: 'GET',
+      requestId: 'req-1',
+      payer: settled.payer,
+      amount: '1000',
+      network: 'stellar:testnet',
+    });
+  });
+
+  it('normalises the method to upper case', () => {
+    expect(settlementFromResult(settled, { ...facts, method: 'post' })?.method).toBe('POST');
+  });
+
+  it('drops an empty request id rather than storing a blank', () => {
+    expect(settlementFromResult(settled, { ...facts, requestId: '  ' })?.requestId).toBeUndefined();
+  });
+
+  it('omits the request id when absent', () => {
+    expect(settlementFromResult(settled, { route: '/x', method: 'GET' })?.requestId).toBeUndefined();
+  });
+
+  it('returns null for a failed settlement', () => {
+    expect(settlementFromResult({ ...settled, success: false }, facts)).toBeNull();
+  });
+
+  it('returns null when there is no result at all', () => {
+    expect(settlementFromResult(null, facts)).toBeNull();
+    expect(settlementFromResult(undefined, facts)).toBeNull();
+  });
+
+  // The regression this whole module exists to prevent: the previous
+  // implementation invented `mock_hash_<timestamp>` when it could not find a
+  // hash, producing attribution rows that no ledger could ever confirm.
+  it('never invents a transaction hash when one is missing', () => {
+    expect(settlementFromResult({ success: true, transaction: '' }, facts)).toBeNull();
+    expect(settlementFromResult({ success: true, transaction: '   ' }, facts)).toBeNull();
+  });
+
+  it('returns null without a route to attribute to', () => {
+    expect(settlementFromResult(settled, { route: '', method: 'GET' })).toBeNull();
+    expect(settlementFromResult(settled, { route: '   ', method: 'GET' })).toBeNull();
+  });
+
+  it('returns null without a method', () => {
+    expect(settlementFromResult(settled, { route: '/x', method: '' })).toBeNull();
+  });
+});

--- a/packages/sdk/settlement.test.ts
+++ b/packages/sdk/settlement.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { parseSettlementHeader, settlementFromResult } from './settlement';
+import {
+  parseSettlementHeader,
+  settlementFromResult,
+  routeFromResourceUrl,
+} from './settlement';
 
 const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64');
 
@@ -131,5 +135,37 @@ describe('settlementFromResult', () => {
 
   it('returns null without a method', () => {
     expect(settlementFromResult(settled, { route: '/x', method: '' })).toBeNull();
+  });
+});
+
+describe('routeFromResourceUrl', () => {
+  // x402 identifies the paid resource by absolute URL, not by path — this was
+  // found by running a real payment end to end, where reading a `path` field
+  // that does not exist produced an unattributable settlement.
+  it('reduces an absolute resource URL to its path', () => {
+    expect(routeFromResourceUrl('http://localhost:3001/api/hello')).toBe('/api/hello');
+    expect(routeFromResourceUrl('https://api.example.com/v1/quotes')).toBe('/v1/quotes');
+  });
+
+  it('drops the query string and fragment', () => {
+    expect(routeFromResourceUrl('https://x.dev/api/hello?a=1#frag')).toBe('/api/hello');
+  });
+
+  it('returns / for a bare origin', () => {
+    expect(routeFromResourceUrl('https://x.dev')).toBe('/');
+  });
+
+  it('accepts a bare path unchanged', () => {
+    expect(routeFromResourceUrl('/api/hello')).toBe('/api/hello');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty', ''],
+    ['whitespace', '   '],
+    ['a non-URL, non-path string', 'not a url'],
+  ])('returns empty string for %s', (_label, input) => {
+    expect(routeFromResourceUrl(input as string | undefined | null)).toBe('');
   });
 });

--- a/packages/sdk/settlement.ts
+++ b/packages/sdk/settlement.ts
@@ -49,6 +49,25 @@ export interface RequestFacts {
   requestId?: string;
 }
 
+/**
+ * Extracts the route from an x402 resource URL.
+ *
+ * x402 identifies the paid resource by absolute URL (`resource.url` on the
+ * payment payload). Attribution wants the path alone — the host is the
+ * merchant's own and grouping revenue by it would be noise. Returns an empty
+ * string when there is nothing usable, which callers treat as "cannot
+ * attribute".
+ */
+export function routeFromResourceUrl(url: string | undefined | null): string {
+  if (typeof url !== 'string' || url.trim() === '') return '';
+  try {
+    return new URL(url).pathname;
+  } catch {
+    // Already a bare path, which is a legitimate thing for a caller to pass.
+    return url.startsWith('/') ? url : '';
+  }
+}
+
 function decodeBase64(value: string): string | null {
   try {
     if (typeof globalThis.Buffer !== 'undefined') {

--- a/packages/sdk/settlement.ts
+++ b/packages/sdk/settlement.ts
@@ -1,0 +1,132 @@
+/**
+ * Settlement extraction for x402 sellers.
+ *
+ * Route attribution is the one thing the ledger cannot tell you. A Stellar
+ * Asset Contract `transfer` event carries payer, amount, and asset — it does
+ * not carry the HTTP route that was paid for. That mapping exists only inside
+ * the seller's process, at the moment x402 settles.
+ *
+ * So this module's job is narrow: take what the x402 layer actually reports and
+ * turn it into a settlement record, or return null. It never invents a
+ * transaction hash. An attribution record whose tx_hash cannot be matched
+ * against a real on-chain transfer is worse than no record at all — it puts a
+ * row in the merchant's payment history that no ledger will ever confirm.
+ */
+
+/** The response header x402 uses to report settlement back to the caller. */
+export const SETTLEMENT_HEADER = 'X-PAYMENT-RESPONSE';
+
+/**
+ * The settle result reported by x402, narrowed to the fields we use.
+ *
+ * Declared structurally rather than imported from `@x402/core` so the SDK does
+ * not take a hard dependency on a specific x402 major version.
+ */
+export interface X402SettleResult {
+  success: boolean;
+  transaction: string;
+  network?: string;
+  payer?: string;
+  /** Atomic token units. Present for schemes where settled ≠ authorized. */
+  amount?: string;
+  errorReason?: string;
+}
+
+/** A settlement we are willing to attribute to a route. */
+export interface Settlement {
+  txHash: string;
+  route: string;
+  method: string;
+  requestId?: string;
+  payer?: string;
+  amount?: string;
+  network?: string;
+}
+
+export interface RequestFacts {
+  route: string;
+  method: string;
+  requestId?: string;
+}
+
+function decodeBase64(value: string): string | null {
+  try {
+    if (typeof globalThis.Buffer !== 'undefined') {
+      return globalThis.Buffer.from(value, 'base64').toString('utf8');
+    }
+    if (typeof globalThis.atob === 'function') {
+      return globalThis.atob(value);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Decodes the `X-PAYMENT-RESPONSE` header.
+ *
+ * x402 base64-encodes a JSON settle response into this header. Returns null for
+ * anything we cannot read with confidence — absent, malformed, or not an
+ * object. Callers treat null as "no settlement happened", which is the safe
+ * reading: a request that was not paid for looks exactly the same.
+ */
+export function parseSettlementHeader(header: string | undefined | null): X402SettleResult | null {
+  if (typeof header !== 'string' || header.trim() === '') return null;
+
+  const json = decodeBase64(header.trim());
+  if (json === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+
+  const candidate = parsed as Record<string, unknown>;
+  if (typeof candidate.success !== 'boolean') return null;
+  if (typeof candidate.transaction !== 'string') return null;
+
+  return {
+    success: candidate.success,
+    transaction: candidate.transaction,
+    network: typeof candidate.network === 'string' ? candidate.network : undefined,
+    payer: typeof candidate.payer === 'string' ? candidate.payer : undefined,
+    amount: typeof candidate.amount === 'string' ? candidate.amount : undefined,
+    errorReason: typeof candidate.errorReason === 'string' ? candidate.errorReason : undefined,
+  };
+}
+
+/**
+ * Combines an x402 settle result with the request it paid for.
+ *
+ * Returns null unless settlement actually succeeded and carries a transaction
+ * hash — a failed settlement has no payment to attribute, and a success without
+ * a hash cannot be reconciled against the chain.
+ */
+export function settlementFromResult(
+  result: X402SettleResult | null | undefined,
+  facts: RequestFacts,
+): Settlement | null {
+  if (!result || result.success !== true) return null;
+
+  const txHash = typeof result.transaction === 'string' ? result.transaction.trim() : '';
+  if (txHash === '') return null;
+
+  const route = typeof facts.route === 'string' ? facts.route.trim() : '';
+  const method = typeof facts.method === 'string' ? facts.method.trim().toUpperCase() : '';
+  if (route === '' || method === '') return null;
+
+  return {
+    txHash,
+    route,
+    method,
+    requestId: facts.requestId?.trim() || undefined,
+    payer: result.payer,
+    amount: result.amount,
+    network: result.network,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   apps/demo-merchant:
     dependencies:
+      '@x402/core':
+        specifier: ^2.18.0
+        version: 2.18.0
       '@x402/express':
         specifier: ^2.18.0
         version: 2.18.0(express@5.2.1)(typescript@6.0.3)
@@ -8879,24 +8882,24 @@ snapshots:
       '@docusaurus/logger': 3.10.2
       '@docusaurus/types': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
-      css-loader: 6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      copy-webpack-plugin: 11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
+      css-loader: 6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       cssnano: 6.1.2(postcss@8.5.18)
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
-      null-loader: 4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
+      null-loader: 4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       postcss: 8.5.18
-      postcss-loader: 7.3.4(postcss@8.5.18)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      postcss-loader: 7.3.4(postcss@8.5.18)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       postcss-preset-env: 10.6.1(postcss@8.5.18)
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
-      webpackbar: 7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      webpackbar: 7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
     optionalDependencies:
       '@docusaurus/faster': 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(postcss@8.5.18)
     transitivePeerDependencies:
@@ -8940,7 +8943,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.6
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      html-webpack-plugin: 5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -8950,7 +8953,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.4)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       react-router: 5.3.4(react@19.2.4)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.4))(react@19.2.4)
       react-router-dom: 5.3.4(react@19.2.4)
@@ -8961,7 +8964,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(postcss@8.5.18)
@@ -9003,9 +9006,9 @@ snapshots:
       browserslist: 4.28.6
       lightningcss: 1.32.0
       semver: 7.8.5
-      swc-loader: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      swc-loader: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -9033,7 +9036,7 @@ snapshots:
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       fs-extra: 11.3.6
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -9049,7 +9052,7 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       vfile: 6.0.3
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
     transitivePeerDependencies:
@@ -9793,7 +9796,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       fs-extra: 11.3.6
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -9805,7 +9808,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       utility-types: 3.11.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)
     transitivePeerDependencies:
@@ -9834,7 +9837,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       fs-extra: 11.3.6
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -9846,7 +9849,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       utility-types: 3.11.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
     transitivePeerDependencies:
@@ -11774,7 +11777,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
@@ -12165,7 +12168,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  copy-webpack-plugin@11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       fast-glob: 3.3.1
       glob-parent: 6.0.2
@@ -12218,7 +12221,7 @@ snapshots:
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  css-loader@6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.18)
       postcss: 8.5.18
@@ -12232,7 +12235,7 @@ snapshots:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.15)
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.18)
@@ -13113,7 +13116,7 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -13499,7 +13502,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  html-webpack-plugin@5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14611,7 +14614,7 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  mini-css-extract-plugin@2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -14629,7 +14632,20 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.49.0
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
+    optionalDependencies:
+      '@swc/core': 1.15.43(@swc/helpers@0.5.15)
+      '@swc/html': 1.15.43
+      lightningcss: 1.32.0
+      postcss: 8.5.18
+
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -14727,7 +14743,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  null-loader@4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -15150,7 +15166,7 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.18)
       postcss: 8.5.18
 
-  postcss-loader@7.3.4(postcss@8.5.18)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  postcss-loader@7.3.4(postcss@8.5.18)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
@@ -15571,7 +15587,7 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.4)'
@@ -16372,7 +16388,7 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swc-loader@0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  swc-loader@0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.15)
       '@swc/counter': 0.1.3
@@ -16382,7 +16398,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -16659,14 +16675,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
 
   util-deprecate@1.0.2: {}
 
@@ -16806,7 +16822,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.64.0(tslib@2.8.1)
@@ -16819,7 +16835,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -16847,7 +16863,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       ws: 8.21.0
     optionalDependencies:
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)
@@ -16872,6 +16888,44 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
+  webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.6
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.2
+      es-module-lexer: 2.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
   webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18):
     dependencies:
       '@types/estree': 1.0.9
@@ -16890,7 +16944,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -16928,7 +16982,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.18))(html-minifier-terser@7.2.0)(postcss@8.5.18)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -16948,7 +17002,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpackbar@7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.18)):
+  webpackbar@7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.18)):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2


### PR DESCRIPTION
## The problem

`attachAccensaHook()` could not attribute a payment to a route. It parsed the response body for a transaction hash and, failing that, invented one:

```ts
txHash = parsed.tx_hash || "mock_hash_" + Date.now();
```

then POSTed it to `/hook/settle` — an endpoint that did not exist, having been removed along with the Go indexer in #49. The hook either sent nothing or sent a fabricated hash that no ledger could ever confirm, while the README presented it as a working component.

Route attribution is the one fact the chain cannot supply: a SAC `transfer` event carries payer, amount, and asset, but has no notion of an HTTP route. That mapping exists only inside the seller's process at settlement, so it has to be reported.

## SDK

- `settlement.ts` extracts settlements from x402 and returns `null` rather than guessing. **No fallback hash** — an attribution row whose `tx_hash` never appears on chain is worse than a missing row.
- `attachAccensaHook()` reads the `X-PAYMENT-RESPONSE` header on response finish, instead of monkey-patching `res.send` and parsing the body.
- `createSettleHook()` wraps `onAfterSettle` for servers using the x402 resource server directly — settlement as ground truth, nothing parsed back off the wire.
- Reporting is best-effort with an `onError` hook. A paid request must not fail because attribution could not be recorded.

## App

- `POST /api/hook/settle` records attribution. It is the only write path into `payments` not derived from the ledger, so it **fails closed**: with no `HOOK_API_KEY` configured it accepts nothing.
- Ledger-owned fields are never written here. `hook_reported_at` marks merchant-reported rows so the two provenances stay distinguishable.
- A settlement reported before the indexer reaches that ledger is staged with a null `ts`, which keeps it out of the dashboard until the chain confirms it — `/api/payments` filters on `ts IS NOT NULL`.

The demo merchant now reports to the real endpoint instead of writing `settle_payload.json`.

## Tests

52 added — 24 SDK, 28 web — covering the malformed and adversarial inputs this path must reject, including an explicit regression test that a `mock_hash_` value is refused.

```
sdk    49 passed
web    69 passed
lint   clean
tsc    clean
build  clean, /api/hook/settle registered
```

Closes #9, closes #12. Unblocks #10 — `/api/routes` has real attribution data to aggregate once this lands.