### PR TITLE
fix(web): iOS theme toggle, mobile centring, nav clipping, ambient orbs

### DIFF
--- a/apps/web/src/app/batches/[id]/page.tsx
+++ b/apps/web/src/app/batches/[id]/page.tsx
@@ -58,7 +58,7 @@ export default async function BatchPage({
   };
 
   return (
-    <main className="min-h-screen bg-slate-50 dark:bg-[#04090f] text-slate-900 dark:text-white px-6 py-16 md:py-24 transition-colors duration-300">
+    <main className="min-h-screen bg-grid text-slate-900 dark:text-white px-6 py-16 md:py-24 pt-28 md:pt-32 transition-colors duration-300">
       <div className="fixed inset-0 overflow-hidden -z-10 pointer-events-none">
         <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-emerald-100/50 dark:bg-emerald-600/20 blur-[120px] transition-colors duration-300" />
         <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-teal-100/50 dark:bg-teal-600/20 blur-[120px] transition-colors duration-300" />

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -65,12 +65,12 @@ export default function Dashboard() {
   const totalAsset = assets.size === 1 ? [...assets][0] : '';
 
   return (
-    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-white dark:bg-[#04090f] bg-grid p-6 md:p-12 lg:p-20">
+    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32">
       <div className="max-w-7xl mx-auto space-y-12">
         
         {/* Header Grid */}
         <header className="grid lg:grid-cols-3 gap-8 items-end">
-          <div className="lg:col-span-2 space-y-6">
+          <div className="lg:col-span-2 space-y-6 text-center lg:text-left">
             <div>
               <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-3">Dashboard</p>
               <h1 className="text-4xl sm:text-5xl md:text-6xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">Settled Volume</h1>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,7 +12,7 @@ const explorer = (id: string) =>
 
 export default function Landing() {
   return (
-    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-white dark:bg-[#04090f] bg-grid">
+    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-grid">
 
       {/* Hero Section */}
       <section className="relative px-6 pt-32 pb-24 md:pt-48 md:pb-32 overflow-hidden flex flex-col items-center justify-center min-h-[85vh] relative">
@@ -20,7 +20,7 @@ export default function Landing() {
         {/* Subtle radial glow matching emerald theme */}
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-transparent dark:bg-emerald-500/5 rounded-full blur-[100px] dark:blur-[120px] pointer-events-none transition-colors duration-300" />
         
-        <div className="max-w-5xl mx-auto text-left md:text-center space-y-8 relative z-10">
+        <div className="max-w-5xl mx-auto text-center space-y-8 relative z-10">
           <div className="inline-flex items-center mb-4 transition-colors duration-300">
             <span className="text-sm font-camiro font-bold tracking-[0.35em] text-emerald-600 dark:text-emerald-400 uppercase">— Live on Stellar Testnet —</span>
           </div>
@@ -37,7 +37,7 @@ export default function Landing() {
             custodian risk. Verifiable by anyone, anchored on Stellar.
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-start md:justify-center pt-8">
+          <div className="flex flex-col sm:flex-row gap-4 justify-center pt-8">
             <Link
               href="/verify"
               className="px-8 py-4 rounded-xl bg-white/40 dark:bg-white/10 backdrop-blur-xl border border-slate-200/50 dark:border-white/20 text-slate-900 dark:text-white font-bold text-sm uppercase tracking-wider hover:bg-white/60 dark:hover:bg-white/20 transition-all hover:scale-[1.02] active:scale-[0.98] shadow-sm dark:shadow-none"
@@ -57,7 +57,7 @@ export default function Landing() {
       {/* Bento Grid Architecture */}
       <ScrollReveal as="section" className="px-6 py-24 md:py-32 relative">
         <div className="max-w-6xl mx-auto">
-          <div className="mb-16 text-left md:text-center">
+          <div className="mb-16 text-center">
             <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Architecture</p>
             <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">How it <span className="text-slate-400 dark:text-slate-500 italic font-normal">works.</span></h2>
           </div>
@@ -95,7 +95,7 @@ export default function Landing() {
       {/* The Protocol Benefits */}
       <ScrollReveal as="section" className="px-6 py-24 md:py-32 transition-colors duration-300">
         <div className="max-w-6xl mx-auto">
-          <div className="flex flex-col md:flex-row justify-between items-start md:items-end gap-6 md:gap-10 mb-16">
+          <div className="flex flex-col md:flex-row justify-between items-center md:items-end gap-6 md:gap-10 mb-16 text-center md:text-left">
             <div className="max-w-2xl">
               <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Protocol</p>
               <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">Why <span className="text-slate-400 dark:text-slate-500 italic font-normal">Stellar?</span></h2>
@@ -115,7 +115,7 @@ export default function Landing() {
       {/* Contracts Live */}
       <ScrollReveal as="section" className="px-6 py-24 md:py-32 transition-colors duration-300">
         <div className="max-w-4xl mx-auto">
-          <div className="text-left md:text-center mb-16">
+          <div className="text-center mb-16">
             <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Network</p>
             <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">Live <span className="text-slate-400 dark:text-slate-500 italic font-normal">Contracts.</span></h2>
             <p className="text-slate-600 dark:text-slate-400 leading-relaxed mt-6 text-lg font-medium max-w-2xl mx-auto transition-colors duration-300">
@@ -132,7 +132,7 @@ export default function Landing() {
       {/* Integration Code block */}
       <ScrollReveal as="section" className="px-6 py-24 md:py-32 transition-colors duration-300">
         <div className="max-w-4xl mx-auto">
-          <div className="mb-10">
+          <div className="mb-10 text-center md:text-left">
             <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Integration</p>
             <h2 className="text-4xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">SDK Drop-in</h2>
           </div>

--- a/apps/web/src/app/verify/page.tsx
+++ b/apps/web/src/app/verify/page.tsx
@@ -55,9 +55,9 @@ export default function VerifyPage() {
   }
 
   return (
-    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-white dark:bg-[#04090f] bg-grid p-6 md:p-12 lg:p-20">
+    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32">
       <div className="max-w-4xl mx-auto space-y-12">
-        <header className="space-y-6 text-left md:text-center max-w-2xl mx-auto relative">
+        <header className="space-y-6 text-center max-w-2xl mx-auto relative">
           <h1 className="text-4xl sm:text-5xl md:text-6xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
             Verify a Receipt
           </h1>

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -19,15 +19,20 @@ export function ThemeToggle() {
     )
   }
 
+  // No backdrop-blur on the button: the nav behind it is already blurred at 64px,
+  // and nesting backdrop-filters breaks layer invalidation on iOS Safari, so the
+  // button keeps its old paint when next-themes flips the class on <html>.
+  // before:-inset-1 grows the hit area to 44x44 (Apple HIG) without resizing the
+  // visible circle; pointer-events-none keeps the icons from eating the tap.
   return (
     <button
       type="button"
       onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-      className="relative inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/40 dark:bg-white/5 backdrop-blur-md text-slate-500 dark:text-slate-400 md:hover:bg-white/60 dark:md:hover:bg-white/10 active:bg-white/60 dark:active:bg-white/10 transition-colors shadow-sm dark:shadow-[0_4px_12px_rgba(0,0,0,0.5)] cursor-pointer"
+      className="relative inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/40 dark:bg-white/5 text-slate-500 dark:text-slate-400 md:hover:bg-white/60 dark:md:hover:bg-white/10 active:bg-white/60 dark:active:bg-white/10 transition-colors shadow-sm dark:shadow-[0_4px_12px_rgba(0,0,0,0.5)] cursor-pointer before:absolute before:-inset-1 before:content-['']"
       aria-label="Toggle theme"
     >
-      <Sun className="h-4 w-4 dark:hidden" />
-      <Moon className="hidden h-4 w-4 dark:block" />
+      <Sun className="h-4 w-4 dark:hidden pointer-events-none" />
+      <Moon className="hidden h-4 w-4 dark:block pointer-events-none" />
     </button>
   )
 }


### PR DESCRIPTION
Four frontend fixes from the 2026-08-03 design audit of the live site (desktop/mobile × light/dark, home + /verify + /dashboard).

## Changes

**iOS theme toggle** — `components/theme-toggle.tsx`
Dropped `backdrop-blur-md`. Nesting a backdrop-filter inside the nav's `blur(64px)` breaks layer invalidation on iOS Safari, so the button kept its old paint when next-themes flipped the class on `<html>`. Icons get `pointer-events-none` (matching the existing fix at `nav.tsx:36`), and `before:-inset-1` grows the hit area from 36px to 44px per Apple HIG.

**Mobile centre-alignment** — landing, `/verify`, `/dashboard`
Hero, buttons and all four section headers centre on mobile. Card body copy stays left-aligned deliberately.

**Fixed-nav clipping** — `/verify`, `/dashboard`, `/batches/[id]`
Added `pt-28 md:pt-32 lg:pt-32`. The h1s on `/verify` and `/dashboard` were rendering fully behind the fixed nav. The `lg:` value is required: `lg:p-20` (80px) sits under the 85px desktop nav.

**Ambient orbs** — landing, `/verify`, `/dashboard`, `/batches/[id]`
Removed the opaque `bg-white dark:bg-[#04090f]` from `<main>`. The four orb layers at `layout.tsx:61-66` were rendering but fully covered.

## Verification

- `next build` clean
- 69/69 vitest pass
- 12/12 route × breakpoint clipping checks clear

## Reviewer notes

- **The iOS toggle fix has not been verified on real hardware.** The nested-backdrop-filter diagnosis is the suspected cause, not a confirmed one.
- The `<main>` background removal means text now sits directly on `bg-grid` over the layout backdrop. Worth eyeballing in both themes before merge.

