### PR TITLE
fix(web): keep landing sections visible when JS never runs

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -56,19 +56,27 @@
   }
 }
 
-.scroll-reveal {
+/* The hidden state is scoped to html.js, which the inline script in layout.tsx
+   sets before first paint. Anything that stops that script from running -- JS
+   disabled, a blocking extension, a CSP rejection -- leaves the class off and
+   the sections render as plain static content instead of a blank page. The same
+   script clears the class if React has not mounted within 3s, which covers the
+   bundle failing to load after the inline script has already run. */
+.js .scroll-reveal {
   opacity: 0;
+  transform: translateY(28px);
 }
 
-.scroll-reveal.is-visible {
+.js .scroll-reveal.is-visible {
   animation: 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards scroll-reveal;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .scroll-reveal {
+  .js .scroll-reveal {
     opacity: 1;
+    transform: none;
   }
-  .scroll-reveal.is-visible {
+  .js .scroll-reveal.is-visible {
     animation: none;
   }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -56,6 +56,15 @@ export default function RootLayout({
       suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable} ${bellavoir.variable} ${camiro.variable} ${harabara.variable} h-full antialiased`}
     >
+      <head>
+        {/* Runs before first paint so the reveal animation never flashes, and
+            gates it on scripting actually working. See globals.css. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var d=document.documentElement;d.classList.add('js');setTimeout(function(){if(d.dataset.srReady!=='1')d.classList.remove('js')},3000)})()`,
+          }}
+        />
+      </head>
       <body className="min-h-full flex flex-col bg-slate-50 dark:bg-[#04090f] transition-colors duration-300 relative">
         {/* Global Ambient Background Blobs */}
         <div className="fixed inset-0 overflow-hidden pointer-events-none z-[-1]">

--- a/apps/web/src/components/scroll-reveal.tsx
+++ b/apps/web/src/components/scroll-reveal.tsx
@@ -14,6 +14,10 @@ export function ScrollReveal({ children, className = "", as: Component = "div" }
   const [isRevealed, setIsRevealed] = useState(false);
 
   useEffect(() => {
+    // Tells the failsafe timer in layout.tsx that the bundle made it. Until this
+    // is set, the timer assumes hydration failed and unhides everything.
+    document.documentElement.dataset.srReady = "1";
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -40,11 +44,13 @@ export function ScrollReveal({ children, className = "", as: Component = "div" }
   }, []);
 
   return (
-    <Component 
-      ref={ref as any} 
-      className={`transition-all duration-700 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none motion-reduce:opacity-100 motion-reduce:translate-y-0 ${
-        isRevealed ? "opacity-100 translate-y-0" : "opacity-0 translate-y-7"
-      } ${className}`}
+    // The hidden state lives in globals.css under `.js .scroll-reveal` rather
+    // than in Tailwind classes here, so that the server-rendered HTML is only
+    // hidden once the inline script has confirmed scripting works. Rendering
+    // `opacity-0` directly would leave the page blank whenever JS never runs.
+    <Component
+      ref={ref as any}
+      className={`scroll-reveal ${isRevealed ? "is-visible" : ""} ${className}`}
     >
       {children}
     </Component>


### PR DESCRIPTION
Fixes the highest-impact item from the 2026-08-03 design audit.

## Problem

`ScrollReveal` rendered `opacity-0 translate-y-7` directly into the server HTML, so the four sections below the hero on `/` were invisible until React hydrated. With JS disabled, blocked by an extension, or refused by CSP, the landing page stayed blank below the fold permanently.

## Fix

- The hidden state moves to `globals.css`, scoped to `.js .scroll-reveal`.
- An inline script in `layout.tsx` adds `js` to `<html>` before first paint. If it never runs, the rule does not match and the sections render as ordinary static content.
- The inline script can succeed while the main bundle still fails, so it also drops the class after 3s unless `ScrollReveal` has mounted and set `data-sr-ready`.

This reuses the `.scroll-reveal` / `.is-visible` CSS that was already in `globals.css` but unreferenced, which also clears the dead-CSS finding from the same audit. Reduced-motion behaviour is unchanged.

## Verification

Confirmed against the prerendered `.next/server/app/index.html`:

- all four sections now ship as `class="scroll-reveal ..."` with no opacity or transform classes
- the only remaining `opacity-0` in the document are `group-hover:opacity-100` decorations, not content
- headline copy is present in the HTML
- compiled CSS contains all four `.js .scroll-reveal` rules, including the reduced-motion pair

`next build` clean, 69/69 vitest pass.

**Not verified in a real browser** — the project has no Playwright/Puppeteer, so the JS-enabled path (no flash of content before the reveal, animation still firing on scroll) has only been reasoned through, not observed. Worth a look on the preview deploy before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maipo9Nrh22sAhCUk4Gyyd