### PR TITLE
fix(web): point the nav Docs link at the docs site instead of a 404

### DIFF
--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -24,7 +24,7 @@ export function Nav() {
           {pathname !== "/" && <Link href="/" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Home</Link>}
           {pathname !== "/verify" && <Link href="/verify" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Verify</Link>}
           {pathname !== "/dashboard" && <Link href="/dashboard" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Dashboard</Link>}
-          <Link href="/docs" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Docs</Link>
+          <a href="https://accensa-docs.vercel.app" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Docs</a>
           <a href="https://github.com/accensa" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">GitHub</a>
         </div>
 
@@ -54,7 +54,7 @@ export function Nav() {
           {pathname !== "/" && <Link onClick={() => setIsOpen(false)} href="/" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors block">Home</Link>}
           {pathname !== "/verify" && <Link onClick={() => setIsOpen(false)} href="/verify" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors block">Verify</Link>}
           {pathname !== "/dashboard" && <Link onClick={() => setIsOpen(false)} href="/dashboard" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors block">Dashboard</Link>}
-          <Link onClick={() => setIsOpen(false)} href="/docs" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors block">Docs</Link>
+          <a onClick={() => setIsOpen(false)} href="https://accensa-docs.vercel.app" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors block">Docs</a>
           <a onClick={() => setIsOpen(false)} href="https://github.com/accensa" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors block">GitHub</a>
           <Link onClick={() => setIsOpen(false)} href="/coming-soon" className="px-4 py-3 rounded-lg bg-white/40 dark:bg-white/10 backdrop-blur-xl border border-slate-200/50 dark:border-white/20 text-slate-900 dark:text-white hover:bg-white/60 dark:hover:bg-white/20 transition-all block">Connect Wallet</Link>
         </div>


### PR DESCRIPTION
## Problem

Both the desktop and mobile nav used `<Link href="/docs">`, but the web app has no `/docs` route — `apps/web/src/app/` contains only `verify`, `dashboard`, `coming-soon`, `batches/[id]` and the landing page. Clicking Docs 404'd.

The footer on the landing page (`page.tsx:166`) already pointed at the real URL, which is why the bug was easy to miss.

## Fix

`nav.tsx:27` and `nav.tsx:57` now use a plain anchor to `https://accensa-docs.vercel.app`, matching the GitHub link sitting next to them in both menus. The mobile one keeps its `onClick` menu-close handler for consistency with the adjacent GitHub link.

## Verification

- `https://accensa-docs.vercel.app/` returns 200, so the docs site is reachable — the Vercel SSO / Deployment Protection blocker recorded earlier appears to have been resolved.
- Prerendered `index.html` has zero `href="/docs"` and three Docs links pointing at the external URL (desktop nav, mobile nav, footer).
- Audited every other internal link in the app: `/`, `/verify`, `/dashboard`, `/coming-soon` — all resolve to real routes. `/docs` was the only dangling one.
- `next build` clean, 69/69 vitest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maipo9Nrh22sAhCUk4Gyyd