### PR TITLE
style(web): remove the ambient background orbs

### DIFF
--- a/apps/web/src/app/batches/[id]/page.tsx
+++ b/apps/web/src/app/batches/[id]/page.tsx
@@ -59,11 +59,6 @@ export default async function BatchPage({
 
   return (
     <main className="min-h-screen bg-grid text-slate-900 dark:text-white px-6 py-16 md:py-24 pt-28 md:pt-32 transition-colors duration-300">
-      <div className="fixed inset-0 overflow-hidden -z-10 pointer-events-none">
-        <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-emerald-100/50 dark:bg-emerald-600/20 blur-[120px] transition-colors duration-300" />
-        <div className="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-teal-100/50 dark:bg-teal-600/20 blur-[120px] transition-colors duration-300" />
-      </div>
-
       <div className="max-w-3xl mx-auto space-y-10 relative z-10">
         <header className="space-y-4">
           <h1 className="text-4xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -66,13 +66,6 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-full flex flex-col bg-slate-50 dark:bg-[#04090f] transition-colors duration-300 relative">
-        {/* Global Ambient Background Blobs */}
-        <div className="fixed inset-0 overflow-hidden pointer-events-none z-[-1]">
-          <div className="absolute top-[-10%] left-[-10%] w-[60%] h-[60%] rounded-full bg-emerald-300/40 dark:bg-emerald-600/20 blur-[120px] mix-blend-multiply dark:mix-blend-screen" />
-          <div className="absolute bottom-[-10%] right-[-10%] w-[60%] h-[60%] rounded-full bg-teal-300/40 dark:bg-teal-600/20 blur-[120px] mix-blend-multiply dark:mix-blend-screen" />
-          <div className="absolute top-[20%] left-[40%] w-[40%] h-[40%] rounded-full bg-sky-300/30 dark:bg-sky-600/15 blur-[120px] mix-blend-multiply dark:mix-blend-screen" />
-          <div className="absolute bottom-[20%] left-[10%] w-[40%] h-[40%] rounded-full bg-indigo-300/20 dark:bg-indigo-600/15 blur-[120px] mix-blend-multiply dark:mix-blend-screen" />
-        </div>
         <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
           <Nav />
           {children}


### PR DESCRIPTION
Removes the site-wide gradient wash.

## Changes

- **`layout.tsx`** — deleted the wrapper and its four blurred colour blobs (emerald, teal, sky, indigo at `blur(120px)` with `mix-blend-multiply` / `dark:mix-blend-screen`). These were introduced in `ac1f5ad` and applied to every page.
- **`batches/[id]/page.tsx`** — deleted the page-local pair of orbs, which used the same device and would otherwise have left that one route still washed.

Pages now sit on the flat body background: `bg-slate-50` / `#04090f`.

## Deliberately kept

The hero radial glows on `/` (`page.tsx:21`) and `/coming-soon` (`page.tsx:9`) are a separate, page-scoped effect and are untouched. The `bg-grid` dot texture is also untouched.

## Verification

- `next build` clean, 69/69 vitest pass
- The only remaining `blur-[120px]` in `src/` are the two hero glows above

Note this partly unwinds the ambient-orb change from #54 — that PR removed an opaque `<main>` background so these orbs would show. The `<main>` change stays (it was also needed for the `bg-grid` texture to be visible); it's the orbs themselves that are now gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maipo9Nrh22sAhCUk4Gyyd