### PR TITLE
fix(web): page through getEvents instead of dropping the tail

### DIFF
--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -3,7 +3,6 @@ import {
   decodeTransferEvent,
   transferTopicFilter,
   addressTopicFilter,
-  type RawEvent,
 } from '@/lib/stellar-events';
 import {
   withClient,
@@ -11,6 +10,12 @@ import {
   getLastSyncedLedger,
   setLastSyncedLedger,
 } from '@/lib/db';
+import {
+  drainEvents,
+  safeCursorLedger,
+  EVENTS_PAGE_LIMIT,
+  type EventPage,
+} from '@/lib/event-pager';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -35,6 +40,15 @@ const COLD_START_LOOKBACK = 2_000;
 
 /** Soroban RPC retains only a limited window of ledgers for getEvents. */
 const MAX_LOOKBACK = 100_000;
+
+/**
+ * Wall-clock budget for paging, in milliseconds.
+ *
+ * Held below `maxDuration` so that a backlog too large for one invocation stops
+ * cleanly and commits its progress, rather than being killed mid-range with
+ * nothing written. The next run resumes from the committed cursor.
+ */
+const PAGING_BUDGET_MS = 45_000;
 
 async function rpc<T>(method: string, params: unknown): Promise<T> {
   const res = await fetch(RPC_URL, {
@@ -86,28 +100,46 @@ export async function GET(request: Request) {
       );
 
       if (startLedger > latestLedger) {
-        return { latestLedger, startLedger, scanned: 0, decoded: 0, inserted: 0 };
+        return {
+          latestLedger,
+          startLedger,
+          syncedTo: startLedger - 1,
+          drained: true,
+          pages: 0,
+          scanned: 0,
+          decoded: 0,
+          inserted: 0,
+        };
       }
 
       // Filter server-side to transfers addressed to this merchant. The asset
       // topic is optional across protocol versions, so match both arities.
       const toTopic = addressTopicFilter(merchant);
       const transfer = transferTopicFilter();
-      const { events } = await rpc<{ events: RawEvent[] }>('getEvents', {
-        startLedger,
-        filters: [
-          {
-            type: 'contract',
-            contractIds: ASSET_CONTRACT_IDS,
-            topics: [
-              [transfer, '*', toTopic, '*'],
-              [transfer, '*', toTopic],
-            ],
-          },
-        ],
-        limit: 200,
-        xdrFormat: 'base64',
-      });
+      const filters = [
+        {
+          type: 'contract',
+          contractIds: ASSET_CONTRACT_IDS,
+          topics: [
+            [transfer, '*', toTopic, '*'],
+            [transfer, '*', toTopic],
+          ],
+        },
+      ];
+
+      // The limit belongs under `pagination`; sent at the top level the RPC
+      // ignores it and applies its own default.
+      const deadline = Date.now() + PAGING_BUDGET_MS;
+      const { events, drained, pages } = await drainEvents(
+        ({ startLedger: from, cursor: pageCursor }) =>
+          rpc<EventPage>('getEvents', {
+            ...(pageCursor ? {} : { startLedger: from }),
+            filters,
+            pagination: { limit: EVENTS_PAGE_LIMIT, ...(pageCursor ? { cursor: pageCursor } : {}) },
+            xdrFormat: 'base64',
+          }),
+        { startLedger, withinBudget: () => Date.now() < deadline },
+      );
 
       let inserted = 0;
       let decoded = 0;
@@ -153,10 +185,21 @@ export async function GET(request: Request) {
         inserted += res.rowCount ?? 0;
       }
 
-      // Only advance the cursor across the range actually examined.
-      await setLastSyncedLedger(client, Math.max(maxLedger, startLedger - 1));
+      // Only advance across ledgers known to be fully consumed. A partial read
+      // stops one ledger short so the remainder is picked up next run.
+      const syncedTo = safeCursorLedger(maxLedger, drained, startLedger);
+      await setLastSyncedLedger(client, syncedTo);
 
-      return { latestLedger, startLedger, scanned: events.length, decoded, inserted };
+      return {
+        latestLedger,
+        startLedger,
+        syncedTo,
+        drained,
+        pages,
+        scanned: events.length,
+        decoded,
+        inserted,
+      };
     });
 
     return NextResponse.json({ success: true, ...result });

--- a/apps/web/src/lib/event-pager.test.ts
+++ b/apps/web/src/lib/event-pager.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { drainEvents, safeCursorLedger, EVENTS_PAGE_LIMIT, type EventPage } from './event-pager';
+import type { RawEvent } from './stellar-events';
+
+/** Builds `count` events spread across ledgers, ids ascending from `from`. */
+function makeEvents(count: number, ledgerOf: (i: number) => number, from = 0): RawEvent[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `evt-${from + i}`,
+    txHash: `tx-${from + i}`,
+    ledger: ledgerOf(from + i),
+  }));
+}
+
+/** A fake RPC that serves a fixed event list in pages of EVENTS_PAGE_LIMIT. */
+function pagedSource(all: RawEvent[], opts: { omitCursor?: boolean } = {}) {
+  const calls: Array<{ startLedger?: number; cursor?: string }> = [];
+  const fetchPage = async (params: { startLedger?: number; cursor?: string }): Promise<EventPage> => {
+    calls.push(params);
+    const offset = params.cursor ? all.findIndex((e) => e.id === params.cursor) + 1 : 0;
+    const events = all.slice(offset, offset + EVENTS_PAGE_LIMIT);
+    const cursor = events.length ? events[events.length - 1].id : undefined;
+    return opts.omitCursor ? { events } : { events, cursor };
+  };
+  return { fetchPage, calls };
+}
+
+describe('drainEvents', () => {
+  it('returns a single short page without asking for more', async () => {
+    const { fetchPage, calls } = pagedSource(makeEvents(4, () => 100));
+
+    const result = await drainEvents(fetchPage, { startLedger: 100 });
+
+    expect(result.events).toHaveLength(4);
+    expect(result.drained).toBe(true);
+    expect(result.pages).toBe(1);
+    expect(calls).toEqual([{ startLedger: 100 }]);
+  });
+
+  it('follows the cursor across every page', async () => {
+    // 512 events => 200 + 200 + 112, i.e. three pages.
+    const all = makeEvents(512, (i) => 100 + Math.floor(i / 10));
+    const { fetchPage, calls } = pagedSource(all);
+
+    const result = await drainEvents(fetchPage, { startLedger: 100 });
+
+    expect(result.events).toHaveLength(512);
+    expect(result.pages).toBe(3);
+    expect(result.drained).toBe(true);
+    // The first call ranges by ledger, every later one by cursor - never both.
+    expect(calls[0]).toEqual({ startLedger: 100 });
+    expect(calls[1]).toEqual({ cursor: 'evt-199' });
+    expect(calls[2]).toEqual({ cursor: 'evt-399' });
+  });
+
+  it('does not drop events that straddle a page boundary', async () => {
+    // Every event sits in ledger 500, so a naive single-page read would take
+    // 200 of them and then advance the sync cursor past ledger 500 entirely.
+    const all = makeEvents(250, () => 500);
+    const { fetchPage } = pagedSource(all);
+
+    const result = await drainEvents(fetchPage, { startLedger: 500 });
+
+    expect(result.events).toHaveLength(250);
+    expect(result.events.map((e) => e.txHash)).toContain('tx-249');
+  });
+
+  it('falls back to the last event id when the page carries no cursor', async () => {
+    const all = makeEvents(300, () => 100);
+    const { fetchPage, calls } = pagedSource(all, { omitCursor: true });
+
+    const result = await drainEvents(fetchPage, { startLedger: 100 });
+
+    expect(result.events).toHaveLength(300);
+    expect(calls[1]).toEqual({ cursor: 'evt-199' });
+  });
+
+  it('stops on a full page that yields no cursor, rather than looping', async () => {
+    const fetchPage = async (): Promise<EventPage> => ({
+      events: Array.from({ length: EVENTS_PAGE_LIMIT }, () => ({ ledger: 1 })),
+    });
+
+    const result = await drainEvents(fetchPage, { startLedger: 1 });
+
+    expect(result.pages).toBe(1);
+    expect(result.events).toHaveLength(EVENTS_PAGE_LIMIT);
+  });
+
+  it('reports a partial read when the budget runs out', async () => {
+    const all = makeEvents(1000, (i) => 100 + i);
+    const { fetchPage } = pagedSource(all);
+    let calls = 0;
+
+    const result = await drainEvents(fetchPage, {
+      startLedger: 100,
+      withinBudget: () => ++calls < 2,
+    });
+
+    expect(result.drained).toBe(false);
+    expect(result.pages).toBe(2);
+    expect(result.events).toHaveLength(400);
+  });
+});
+
+describe('safeCursorLedger', () => {
+  it('advances to the last ledger seen on a complete read', () => {
+    expect(safeCursorLedger(520, true, 500)).toBe(520);
+  });
+
+  it('stops one short on a partial read, so the split ledger is replayed', () => {
+    expect(safeCursorLedger(520, false, 500)).toBe(519);
+  });
+
+  it('makes no progress when nothing decodable was seen', () => {
+    expect(safeCursorLedger(0, true, 500)).toBe(499);
+    expect(safeCursorLedger(0, false, 500)).toBe(499);
+  });
+
+  it('never regresses below the start of the range', () => {
+    // A partial read whose only ledger is the first in range must not rewind.
+    expect(safeCursorLedger(500, false, 500)).toBe(499);
+    expect(safeCursorLedger(499, true, 500)).toBe(499);
+  });
+});

--- a/apps/web/src/lib/event-pager.ts
+++ b/apps/web/src/lib/event-pager.ts
@@ -1,0 +1,85 @@
+import type { RawEvent } from './stellar-events';
+
+/** Events requested per `getEvents` call. The RPC caps this server-side. */
+export const EVENTS_PAGE_LIMIT = 200;
+
+/** One page of `getEvents` output. */
+export interface EventPage {
+  events: RawEvent[];
+  /** Opaque cursor for the next page. Absent once the range is exhausted. */
+  cursor?: string;
+}
+
+export interface DrainResult {
+  events: RawEvent[];
+  /**
+   * True when the range was consumed to the end. False when paging stopped
+   * early against the deadline, which means the final ledger seen may be only
+   * partially consumed and the sync cursor must not advance past it.
+   */
+  drained: boolean;
+  /** Number of RPC round trips made. */
+  pages: number;
+}
+
+/**
+ * Reads every page of a `getEvents` range.
+ *
+ * `getEvents` returns at most one page per call. Taking only the first page and
+ * then advancing the sync cursor past it silently discards the remainder --
+ * payments that exist on chain but never reach the merchant's ledger. So this
+ * follows the cursor until the range is exhausted.
+ *
+ * `withinBudget` bounds the work: a serverless invocation has a wall clock
+ * limit, and a large backlog can exceed it. When the budget runs out mid-range
+ * the caller is told, via `drained: false`, that it is holding a partial result.
+ */
+export async function drainEvents(
+  fetchPage: (params: { startLedger?: number; cursor?: string }) => Promise<EventPage>,
+  opts: { startLedger: number; withinBudget?: () => boolean },
+): Promise<DrainResult> {
+  const { startLedger, withinBudget } = opts;
+  const events: RawEvent[] = [];
+  let cursor: string | undefined;
+  let pages = 0;
+
+  for (;;) {
+    // A cursor supersedes startLedger; sending both is rejected by the RPC.
+    const page = await fetchPage(cursor ? { cursor } : { startLedger });
+    pages++;
+    events.push(...page.events);
+
+    // A short page means the range is exhausted, whether or not a cursor came
+    // back with it. Trusting the cursor alone would loop forever against an
+    // RPC that always returns one.
+    if (page.events.length < EVENTS_PAGE_LIMIT) return { events, drained: true, pages };
+
+    const next = page.cursor ?? page.events[page.events.length - 1]?.id;
+    if (!next) return { events, drained: true, pages };
+    cursor = next;
+
+    if (withinBudget && !withinBudget()) return { events, drained: false, pages };
+  }
+}
+
+/**
+ * The ledger the sync cursor may safely advance to.
+ *
+ * Events arrive in ledger order, so a partial read ends somewhere inside a
+ * ledger rather than on a boundary. Advancing to that ledger would skip the
+ * events in it that were never fetched, and nothing would ever look at that
+ * range again. Stopping one short replays it instead -- the payments upsert is
+ * idempotent, so replay costs a little work and loses nothing.
+ *
+ * Returns `startLedger - 1` (no progress) when nothing decodable was seen,
+ * never a value below it.
+ */
+export function safeCursorLedger(
+  maxLedgerSeen: number,
+  drained: boolean,
+  startLedger: number,
+): number {
+  const floor = startLedger - 1;
+  if (maxLedgerSeen < startLedger) return floor;
+  return Math.max(floor, drained ? maxLedgerSeen : maxLedgerSeen - 1);
+}

--- a/apps/web/src/lib/stellar-events.ts
+++ b/apps/web/src/lib/stellar-events.ts
@@ -20,6 +20,8 @@ export interface TransferEvent {
 
 /** Raw event as returned by Soroban RPC `getEvents`. */
 export interface RawEvent {
+  /** Paging cursor for this event, used when the page carries no cursor. */
+  id?: string;
   txHash?: string;
   ledger?: number;
   ledgerClosedAt?: string;


### PR DESCRIPTION
Closes #62.

## The bug

`/api/sync` read one page of `getEvents` and then advanced the sync cursor past it. Events arrive in ledger order, so a ledger whose transfers straddled the page boundary lost its tail — those payments were never fetched, and the next run started beyond them, so nothing ever looked at that range again. Recovery meant hand-editing `sync_state`, and only while the ledgers stayed inside RPC retention.

## The fix

**`lib/event-pager.ts`** (new)

- `drainEvents()` follows the cursor until the range is exhausted. A short page ends the loop, so an RPC that always returns a cursor cannot spin it forever. When a page carries no cursor, the last event's `id` is used instead.
- `safeCursorLedger()` decides how far the sync cursor may move. On a complete read that is the last ledger seen; on a partial read it stops one ledger short, because a partial read ends *inside* a ledger rather than on a boundary. The payments upsert is idempotent (`ON CONFLICT ... DO UPDATE`), so replaying that ledger costs a little work and loses nothing.

**`api/sync/route.ts`**

- Paging is bounded by `PAGING_BUDGET_MS` (45s, under the 60s `maxDuration`), so a backlog too large for one invocation commits its progress and resumes on the next run instead of being killed with nothing written.
- The page limit moves into `pagination`, where the RPC actually reads it. At the top level it was ignored and the server applied its own default — so the effective page size was never the 200 the code appeared to request.
- The response now reports `syncedTo`, `drained` and `pages`, which makes a partial sync visible rather than silent.

## Verification

10 new tests (79 total, up from 69), covering:

- cursor followed across three pages, with `startLedger` used only on the first call and never alongside a cursor
- **250 events sharing a single ledger across a page boundary** — the case that previously lost data
- fallback to the last event `id` when the page omits a cursor
- a full page with no cursor terminating rather than looping
- budget exhaustion reporting `drained: false`
- `safeCursorLedger` advancing, stopping short, making no progress on an empty read, and never regressing below the range start

`tsc --noEmit`, `eslint` and `next build` all clean.

## Not covered

No integration test against a real RPC — the fake source models the paging contract as documented, not the live server's behaviour. Worth watching `pages` and `drained` in the response on the first few production runs to confirm the cursor round-trips as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maipo9Nrh22sAhCUk4Gyyd