### PR TITLE
fix(ci): warn when a sync run indexes only part of the backlog

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -47,3 +47,12 @@ jobs:
           if printf '%s' "$body" | grep -q '"success":false'; then
             echo "Sync reported failure"; exit 1
           fi
+
+          # A run can succeed having indexed only part of the backlog: paging
+          # stops against the function's time budget and commits what it has.
+          # That is correct behaviour, but it means the ledger is not caught up
+          # and the next run has more to do. Left unreported it looks identical
+          # to a clean sync, so surface it as a warning on the run.
+          if printf '%s' "$body" | grep -q '"drained":false'; then
+            echo "::warning::Incomplete sync: paging stopped against the time budget. The next run resumes from the committed cursor. If this repeats, the backlog is growing faster than the schedule drains it."
+          fi


### PR DESCRIPTION
Refs #63 (item 2 of the revised scope).

## Problem

Since #64, `/api/sync` stops paging when it reaches its 45s budget, commits the ledgers it fully consumed, and returns `drained: false`. That behaviour is correct — the next run resumes from the committed cursor and nothing is lost.

But `.github/workflows/sync.yml` only checked the HTTP status and `"success":false`. A run that indexed part of a backlog reported as a clean success, indistinguishable from one that caught up.

## Change

Emit a `::warning::` on the run when the response carries `"drained":false`. The step still exits 0 — a partial sync is not a failure, and failing it would produce noise on every run during a legitimate catch-up.

The signal that matters is *repetition*: a warning every run means the backlog is growing faster than the schedule drains it, which points at cadence rather than code.

## Verification

- YAML parses; schedule and step structure unchanged.
- Checked the grep against both real response shapes — `{"success":true,"drained":false,...}` warns, `{"success":true,"drained":true,...}` stays silent.

## Context found while investigating #63

Worth recording, since it corrects that issue:

- The daily Vercel cron is a deliberate **backstop**, not the real schedule. `f3dcd65` set up `.github/workflows/sync.yml` at `*/5` on the same day as #47. The "288x regression" in #63 was my misreading — I checked `vercel.json` without checking `.github/workflows/`.
- **The `*/5` schedule is not honoured in practice.** The last 12 runs fired between ~1h13m and ~3h23m apart. GitHub deprioritises high-frequency scheduled workflows on shared runners. Not fixable here; if sub-hour freshness is required it is a Vercel Pro decision.

The remaining item in #63 is surfacing `sync_state.updated_at` in the dashboard, so staleness is legible rather than silent. Not included here — it needs an API and UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maipo9Nrh22sAhCUk4Gyyd