### PR TITLE
feat(web): report how current the indexed data actually is

### DIFF
--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { withClient, ensureSchema } from '@/lib/db';
+import { withClient, ensureSchema, getSyncState } from '@/lib/db';
+import type { SyncState } from '@/lib/sync-status';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,13 +16,19 @@ export interface PaymentRow {
   method: string | null;
 }
 
+export interface PaymentsResponse {
+  payments: PaymentRow[];
+  /** Null until the indexer has run at least once. */
+  sync: SyncState | null;
+}
+
 export async function GET() {
   if (!process.env.DATABASE_URL) {
     return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
   }
 
   try {
-    const rows = await withClient(async (client) => {
+    const { rows, sync } = await withClient(async (client) => {
       await ensureSchema(client);
       const result = await client.query(
         `SELECT tx_hash, ledger, payer, amount::text AS amount, asset,
@@ -31,15 +38,15 @@ export async function GET() {
        ORDER BY ts DESC
           LIMIT 100`,
       );
-      return result.rows;
+      return { rows: result.rows, sync: await getSyncState(client) };
     });
 
     // amount is cast to text in SQL and stays a string all the way to the
     // client. node-postgres already returns NUMERIC as a string to avoid
     // precision loss; making that explicit stops anyone "fixing" it into a
     // Number later, which is how money silently loses cents.
-    return NextResponse.json(
-      rows.map(
+    const body: PaymentsResponse = {
+      payments: rows.map(
         (row): PaymentRow => ({
           tx_hash: row.tx_hash,
           ledger: row.ledger === null ? null : Number(row.ledger),
@@ -51,7 +58,9 @@ export async function GET() {
           method: row.method,
         }),
       ),
-    );
+      sync,
+    };
+    return NextResponse.json(body);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { formatAmount, sumAmounts, assetLabel } from '@/lib/money';
+import { describeSync, type SyncState } from '@/lib/sync-status';
 
 interface Payment {
   tx_hash: string;
@@ -16,7 +17,7 @@ interface Payment {
 
 type LoadState =
   | { status: 'loading' }
-  | { status: 'ready'; payments: Payment[]; fetchedAt: number }
+  | { status: 'ready'; payments: Payment[]; fetchedAt: number; sync: SyncState | null }
   | { status: 'error'; message: string };
 
 const POLL_INTERVAL_MS = 15_000;
@@ -41,7 +42,13 @@ export default function Dashboard() {
         const res = await fetch('/api/payments', { signal: controller.signal, cache: 'no-store' });
         if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error ?? `Error ${res.status}`);
         const data = await res.json();
-        if (!controller.signal.aborted) setState({ status: 'ready', payments: data, fetchedAt: Date.now() });
+        // Tolerate both shapes: the endpoint used to return a bare array, and
+        // a deploy can briefly serve an older build to an already-open tab.
+        const payments: Payment[] = Array.isArray(data) ? data : (data.payments ?? []);
+        const sync: SyncState | null = Array.isArray(data) ? null : (data.sync ?? null);
+        if (!controller.signal.aborted) {
+          setState({ status: 'ready', payments, fetchedAt: Date.now(), sync });
+        }
       } catch (error) {
         if (!controller.signal.aborted) setState({ status: 'error', message: error instanceof Error ? error.message : 'Failed' });
       }
@@ -291,13 +298,46 @@ function StatusPill({ state, onRetry }: { state: LoadState; onRetry: () => void 
       <span className="w-2 h-2 rounded-full bg-red-500" /> Retry Connection
     </button>
   );
+  // Deliberately reports the indexer's timestamp, not state.fetchedAt. The poll
+  // succeeding says nothing about how current the data behind it is, and the
+  // sync job lands every 1-3 hours in practice.
+  const { level, age, detail } = describeSync(state.sync);
+
+  const tone = {
+    live: 'text-emerald-600 dark:text-emerald-400',
+    lagging: 'text-amber-600 dark:text-amber-400',
+    stale: 'text-red-600 dark:text-red-400',
+    unknown: 'text-slate-500 dark:text-slate-400',
+  }[level];
+
+  const dot = {
+    live: 'bg-emerald-500',
+    lagging: 'bg-amber-500',
+    stale: 'bg-red-500',
+    unknown: 'bg-slate-400',
+  }[level];
+
+  const label = {
+    live: `Live · synced ${age} ago`,
+    lagging: `Synced ${age} ago`,
+    stale: `Stale · ${age} old`,
+    unknown: 'Sync time unknown',
+  }[level];
+
   return (
-    <span className="flex gap-2 items-center text-[10px] font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-400 transition-colors duration-300">
+    <span
+      title={detail}
+      className={`flex gap-2 items-center text-[10px] font-bold uppercase tracking-widest transition-colors duration-300 ${tone}`}
+    >
       <span className="relative flex h-2 w-2">
-        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-        <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+        {/* The ping animation claims activity; only show it when that is true. */}
+        {level === 'live' && (
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+        )}
+        <span className={`relative inline-flex rounded-full h-2 w-2 ${dot}`} />
       </span>
-      Live · {new Date(state.fetchedAt).toLocaleTimeString()}
+      <span className="sr-only">{detail}</span>
+      <span aria-hidden="true">{label}</span>
     </span>
   );
 }

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -159,6 +159,26 @@ export async function getLastSyncedLedger(client: Client): Promise<number | null
   return res.rows.length ? Number(res.rows[0].last_ledger) : null;
 }
 
+/**
+ * The indexer's own record of when it last committed progress.
+ *
+ * Read by /api/payments so the dashboard can say how current its data is,
+ * rather than implying the freshness of its own poll.
+ */
+export async function getSyncState(
+  client: Client,
+): Promise<{ lastLedger: number; updatedAt: string } | null> {
+  const res = await client.query<{ last_ledger: string; updated_at: Date | string }>(
+    `SELECT last_ledger, updated_at FROM sync_state WHERE id = 1`,
+  );
+  if (!res.rows.length) return null;
+  const { last_ledger, updated_at } = res.rows[0];
+  return {
+    lastLedger: Number(last_ledger),
+    updatedAt: updated_at instanceof Date ? updated_at.toISOString() : String(updated_at),
+  };
+}
+
 export async function setLastSyncedLedger(client: Client, ledger: number): Promise<void> {
   await client.query(
     `INSERT INTO sync_state (id, last_ledger, updated_at) VALUES (1, $1, now())

--- a/apps/web/src/lib/sync-status.test.ts
+++ b/apps/web/src/lib/sync-status.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { describeSync, formatAge, LIVE_WITHIN_MS, LAGGING_WITHIN_MS } from './sync-status';
+
+const NOW = Date.parse('2026-08-04T12:00:00Z');
+const ago = (ms: number) => ({ lastLedger: 3_741_196, updatedAt: new Date(NOW - ms).toISOString() });
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+describe('formatAge', () => {
+  it('picks a single coarse unit', () => {
+    expect(formatAge(4_000)).toBe('4s');
+    expect(formatAge(12 * MINUTE)).toBe('12m');
+    expect(formatAge(3 * HOUR)).toBe('3h');
+    expect(formatAge(50 * HOUR)).toBe('2d');
+  });
+
+  it('rounds down rather than up, so an age is never overstated', () => {
+    expect(formatAge(59_999)).toBe('59s');
+    expect(formatAge(119 * MINUTE)).toBe('1h');
+  });
+
+  it('clamps a negative duration to zero', () => {
+    expect(formatAge(-5_000)).toBe('0s');
+  });
+});
+
+describe('describeSync', () => {
+  it('is live within the fresh window', () => {
+    const status = describeSync(ago(2 * MINUTE), NOW);
+    expect(status.level).toBe('live');
+    expect(status.age).toBe('2m');
+  });
+
+  it('is lagging past the fresh window', () => {
+    expect(describeSync(ago(47 * MINUTE), NOW).level).toBe('lagging');
+  });
+
+  it('is stale past the lagging window', () => {
+    const status = describeSync(ago(5 * HOUR), NOW);
+    expect(status.level).toBe('stale');
+    expect(status.detail).toContain('out of date');
+  });
+
+  it('treats the thresholds as inclusive', () => {
+    expect(describeSync(ago(LIVE_WITHIN_MS), NOW).level).toBe('live');
+    expect(describeSync(ago(LIVE_WITHIN_MS + 1), NOW).level).toBe('lagging');
+    expect(describeSync(ago(LAGGING_WITHIN_MS), NOW).level).toBe('lagging');
+    expect(describeSync(ago(LAGGING_WITHIN_MS + 1), NOW).level).toBe('stale');
+  });
+
+  it('reports unknown before the indexer has ever run', () => {
+    const status = describeSync(null, NOW);
+    expect(status.level).toBe('unknown');
+    expect(status.age).toBe('');
+  });
+
+  it('reports unknown rather than NaN for an unparseable timestamp', () => {
+    const status = describeSync({ lastLedger: 1, updatedAt: 'not a date' }, NOW);
+    expect(status.level).toBe('unknown');
+    expect(status.detail).not.toContain('NaN');
+  });
+
+  it('does not show a negative age when the server clock runs ahead', () => {
+    const status = describeSync(ago(-30 * 1000), NOW);
+    expect(status.level).toBe('live');
+    expect(status.age).toBe('0s');
+  });
+
+  it('never claims live for data the indexer has not touched in hours', () => {
+    // The regression this guards: the pill used to read "Live" off the browser
+    // poll, so it stayed green no matter how far behind the indexer was.
+    for (const hours of [2, 4, 12, 48]) {
+      expect(describeSync(ago(hours * HOUR), NOW).level).not.toBe('live');
+    }
+  });
+});

--- a/apps/web/src/lib/sync-status.ts
+++ b/apps/web/src/lib/sync-status.ts
@@ -1,0 +1,86 @@
+/** When the indexer last committed progress. Null before it has ever run. */
+export interface SyncState {
+  lastLedger: number;
+  /** ISO 8601. */
+  updatedAt: string;
+}
+
+/**
+ * How much to trust what is on screen.
+ *
+ * `live`    - indexed recently; the table reflects the chain.
+ * `lagging` - a sync is overdue but the data is still of the right order.
+ * `stale`   - old enough that a merchant should not read the total as current.
+ * `unknown` - the indexer has never run, or its timestamp is unreadable.
+ */
+export type SyncLevel = 'live' | 'lagging' | 'stale' | 'unknown';
+
+/**
+ * The scheduled sync nominally runs every 5 minutes, but GitHub throttles
+ * high-frequency workflows and it lands every 1-3 hours in practice. These
+ * thresholds describe observed behaviour rather than the configured schedule,
+ * so a normal gap is not reported as a fault.
+ */
+export const LIVE_WITHIN_MS = 15 * 60 * 1000;
+export const LAGGING_WITHIN_MS = 3 * 60 * 60 * 1000;
+
+export interface SyncStatus {
+  level: SyncLevel;
+  /** Human-readable age, e.g. "47m". Empty when the age is unknown. */
+  age: string;
+  /** Full sentence for a title attribute / screen readers. */
+  detail: string;
+}
+
+/** Formats a duration as a single coarse unit: 4s, 12m, 3h, 2d. */
+export function formatAge(ms: number): string {
+  if (ms < 0) return '0s';
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/**
+ * Describes how current the indexed data is.
+ *
+ * The dashboard polls every 15s, which says how fresh the *request* is and
+ * nothing about how fresh the *data* is. Reporting the poll time as "Live"
+ * tells a merchant their totals are current when they can be hours behind, so
+ * this is measured from the indexer's own timestamp instead.
+ */
+export function describeSync(sync: SyncState | null, now: number = Date.now()): SyncStatus {
+  if (!sync?.updatedAt) {
+    return { level: 'unknown', age: '', detail: 'The indexer has not reported a sync yet.' };
+  }
+
+  const updated = Date.parse(sync.updatedAt);
+  if (Number.isNaN(updated)) {
+    return { level: 'unknown', age: '', detail: 'The indexer reported an unreadable sync time.' };
+  }
+
+  // A clock skew between server and browser can put the timestamp slightly in
+  // the future; treat that as "just now" rather than showing a negative age.
+  const ms = Math.max(0, now - updated);
+  const age = formatAge(ms);
+  const at = new Date(updated).toLocaleString();
+
+  if (ms <= LIVE_WITHIN_MS) {
+    return { level: 'live', age, detail: `Indexed ${age} ago, at ${at}.` };
+  }
+  if (ms <= LAGGING_WITHIN_MS) {
+    return {
+      level: 'lagging',
+      age,
+      detail: `Last indexed ${age} ago, at ${at}. Payments settled since then are not shown yet.`,
+    };
+  }
+  return {
+    level: 'stale',
+    age,
+    detail: `Last indexed ${age} ago, at ${at}. This total is out of date - the sync job may not be running.`,
+  };
+}


### PR DESCRIPTION
Refs #63 — the remaining item after the correction on that issue.

## Problem

The dashboard status pill read `Live · <time>`, where the time came from `state.fetchedAt` — the moment the browser's poll returned. That reports that the *request* succeeded, not that the *data* is current.

Polling runs every 15s. The sync job lands every 1-3 hours in practice (see the run-history evidence in #63). So the pill sat green, with a ping animation, while a merchant's settled total could be hours behind the chain. That is the screen actively asserting something false.

## Change

**`api/payments`** now returns `{ payments, sync }`, where `sync` carries the indexer's own `sync_state.updated_at` and `last_ledger` via a new `getSyncState()` in `lib/db.ts`.

**`lib/sync-status.ts`** (new) grades that timestamp:

| Level | Age | Pill |
|---|---|---|
| `live` | ≤ 15m | emerald, ping animation, "Live · synced 4m ago" |
| `lagging` | ≤ 3h | amber, static dot, "Synced 47m ago" |
| `stale` | > 3h | red, static dot, "Stale · 5h old" |
| `unknown` | never run / unparseable | slate, "Sync time unknown" |

Thresholds describe observed cadence rather than the configured `*/5`, so an ordinary gap between runs is not reported as a fault.

The ping animation now renders only at `live` — it claims activity, so it should only appear when there is some. The full sentence ("Last indexed 47m ago, at … Payments settled since then are not shown yet.") goes to a `title` attribute and to screen readers via `sr-only`, with the short label marked `aria-hidden` so it is not announced twice.

## Compatibility

The response shape changed from a bare array. The dashboard is the only consumer (verified by grep), and it accepts both shapes — a deploy can serve an older build to an already-open tab.

## Verification

11 new tests (90 total, up from 79): threshold boundaries treated as inclusive, unknown for both null and unparseable input, no negative age when the server clock runs ahead, `formatAge` rounding down so an age is never overstated, and a regression guard asserting `live` is never returned for data 2/4/12/48 hours old.

`tsc --noEmit`, `eslint`, `next build` all clean.

## Not verified

The pill states were not exercised against a live database — this sandbox has no route to the Supabase host (IPv6). The grading logic is unit-tested, but the end-to-end path from `sync_state` through the API to the rendered pill has only been type-checked. Worth a look on the preview deploy, where `lagging` is the state you should expect to see rather than `live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maipo9Nrh22sAhCUk4Gyyd