### PR TITLE
feat(web): add a Sync now button to the dashboard

### DIFF
--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -9,6 +9,7 @@ import {
   ensureSchema,
   getLastSyncedLedger,
   setLastSyncedLedger,
+  getSyncState,
 } from '@/lib/db';
 import {
   drainEvents,
@@ -16,6 +17,7 @@ import {
   EVENTS_PAGE_LIMIT,
   type EventPage,
 } from '@/lib/event-pager';
+import { cooldownRemaining } from '@/lib/sync-status';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -50,6 +52,18 @@ const MAX_LOOKBACK = 100_000;
  */
 const PAGING_BUDGET_MS = 45_000;
 
+/**
+ * Minimum gap between manual syncs.
+ *
+ * The dashboard is public and unauthenticated, so the POST entry point is too.
+ * Indexing is idempotent, so repeated calls cannot corrupt anything, but each
+ * one costs Soroban RPC round trips, a database connection and a function
+ * invocation. This bounds what a held-down button, or anyone with curl, can
+ * spend. A scheduled run counts too - if the data is already current, there is
+ * nothing for a manual sync to do.
+ */
+const MANUAL_COOLDOWN_MS = 60_000;
+
 async function rpc<T>(method: string, params: unknown): Promise<T> {
   const res = await fetch(RPC_URL, {
     method: 'POST',
@@ -63,33 +77,30 @@ async function rpc<T>(method: string, params: unknown): Promise<T> {
   return body.result as T;
 }
 
+/** Reports a cooldown rather than syncing, when one is in force. */
+interface CooldownResult {
+  cooldown: true;
+  retryAfterMs: number;
+}
+
 /**
  * Indexes Stellar Asset Contract transfers into the merchant's payment ledger.
  *
- * Invoked by Vercel Cron. Protected by CRON_SECRET when set - Vercel sends it
- * as a bearer token - so the endpoint cannot be driven by arbitrary callers.
+ * Shared by both entry points: the scheduled GET, and the POST behind the
+ * dashboard's manual trigger. `cooldownMs`, when set, makes the run a no-op if
+ * the last sync is more recent than that.
  */
-export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret) {
-    const auth = request.headers.get('authorization');
-    if (auth !== `Bearer ${secret}`) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
+  return withClient(async (client) => {
+    await ensureSchema(client);
+
+    if (opts.cooldownMs) {
+      const state = await getSyncState(client);
+      const retryAfterMs = cooldownRemaining(state?.updatedAt, opts.cooldownMs);
+      if (retryAfterMs > 0) return { cooldown: true, retryAfterMs } as CooldownResult;
     }
-  }
 
-  const merchant = process.env.MERCHANT_ADDRESS;
-  if (!merchant) {
-    return NextResponse.json({ error: 'MERCHANT_ADDRESS is not configured' }, { status: 500 });
-  }
-  if (!process.env.DATABASE_URL) {
-    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
-  }
-
-  try {
-    const result = await withClient(async (client) => {
-      await ensureSchema(client);
-
+    {
       const { sequence: latestLedger } = await rpc<{ sequence: number }>('getLatestLedger', {});
 
       const cursor = await getLastSyncedLedger(client);
@@ -200,11 +211,76 @@ export async function GET(request: Request) {
         decoded,
         inserted,
       };
-    });
+    }
+  });
+}
 
-    return NextResponse.json({ success: true, ...result });
+/** Maps a run to a response, so both entry points answer identically. */
+function respond(result: Awaited<ReturnType<typeof runSync>>) {
+  if ('cooldown' in result) {
+    const retryAfterMs = Math.ceil(result.retryAfterMs);
+    return NextResponse.json(
+      { success: true, cooldown: true, retryAfterMs },
+      { status: 429, headers: { 'Retry-After': String(Math.ceil(retryAfterMs / 1000)) } },
+    );
+  }
+  return NextResponse.json({ success: true, ...result });
+}
+
+function configError(): NextResponse | null {
+  if (!process.env.MERCHANT_ADDRESS) {
+    return NextResponse.json({ error: 'MERCHANT_ADDRESS is not configured' }, { status: 500 });
+  }
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+  return null;
+}
+
+function failed(error: unknown) {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  return NextResponse.json({ success: false, error: message }, { status: 500 });
+}
+
+/**
+ * Scheduled entry point.
+ *
+ * Driven by Vercel Cron and by .github/workflows/sync.yml. Protected by
+ * CRON_SECRET when set - both senders pass it as a bearer token - so the
+ * endpoint cannot be driven by arbitrary callers. No cooldown: a scheduled run
+ * is already rate limited by its schedule.
+ */
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const bad = configError();
+  if (bad) return bad;
+
+  try {
+    return respond(await runSync(process.env.MERCHANT_ADDRESS as string));
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
+    return failed(error);
+  }
+}
+
+/**
+ * Manual entry point, behind the dashboard's "Sync now" button.
+ *
+ * Deliberately not behind CRON_SECRET: the dashboard is public and a browser
+ * cannot hold a secret. MANUAL_COOLDOWN_MS is what bounds the cost instead.
+ */
+export async function POST() {
+  const bad = configError();
+  if (bad) return bad;
+
+  try {
+    return respond(
+      await runSync(process.env.MERCHANT_ADDRESS as string, { cooldownMs: MANUAL_COOLDOWN_MS }),
+    );
+  } catch (error: unknown) {
+    return failed(error);
   }
 }

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -104,7 +104,10 @@ export default function Dashboard() {
         <section className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl rounded-3xl overflow-hidden shadow-[0_8px_30px_rgba(0,0,0,0.12),inset_0_1px_1px_rgba(255,255,255,0.8)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.15)] transition-colors duration-300">
           <div className="px-8 py-6 flex justify-between items-center bg-white/30 dark:bg-black/30 backdrop-blur-xl transition-colors duration-300">
             <h2 className="text-xl font-black tracking-tight text-slate-900 dark:text-white transition-colors duration-300">Recent Settlements</h2>
-            <StatusPill state={state} onRetry={reload} />
+            <div className="flex items-center gap-4">
+              <StatusPill state={state} onRetry={reload} />
+              <SyncNowButton onSynced={reload} />
+            </div>
           </div>
 
           <div className="min-h-[400px]">
@@ -339,6 +342,109 @@ function StatusPill({ state, onRetry }: { state: LoadState; onRetry: () => void 
       <span className="sr-only">{detail}</span>
       <span aria-hidden="true">{label}</span>
     </span>
+  );
+}
+
+type SyncPhase =
+  | { phase: 'idle' }
+  | { phase: 'running' }
+  | { phase: 'done'; message: string }
+  | { phase: 'cooldown'; until: number }
+  | { phase: 'error'; message: string };
+
+/**
+ * Runs the indexer on demand.
+ *
+ * The scheduled sync is nominally every 5 minutes but GitHub drops most of
+ * those runs, so in practice the dashboard can sit hours behind with no way to
+ * catch up. This posts to /api/sync, which enforces its own cooldown - the
+ * button reflects that, it does not enforce it.
+ */
+function SyncNowButton({ onSynced }: { onSynced: () => void }) {
+  const [state, setState] = useState<SyncPhase>({ phase: 'idle' });
+  const [now, setNow] = useState(() => Date.now());
+
+  // Expiry is derived, not stored: a timer that writes state back on every tick
+  // would re-render the whole header once a second for no benefit.
+  const cooling = state.phase === 'cooldown' && now < state.until;
+
+  // Tick only while counting down. When `cooling` flips false the effect
+  // re-runs, returns early, and the interval is cleared.
+  useEffect(() => {
+    if (!cooling) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [cooling]);
+
+  // Clear a result message after a few seconds so it does not read as current.
+  useEffect(() => {
+    if (state.phase !== 'done' && state.phase !== 'error') return;
+    const timer = setTimeout(() => setState({ phase: 'idle' }), 6000);
+    return () => clearTimeout(timer);
+  }, [state.phase]);
+
+  const trigger = useCallback(async () => {
+    setState({ phase: 'running' });
+    try {
+      const res = await fetch('/api/sync', { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+
+      if (res.status === 429) {
+        setState({ phase: 'cooldown', until: Date.now() + (data.retryAfterMs ?? 60_000) });
+        return;
+      }
+      if (!res.ok || data.success === false) {
+        setState({ phase: 'error', message: data.error ?? `Error ${res.status}` });
+        return;
+      }
+
+      const inserted = data.inserted ?? 0;
+      setState({
+        phase: 'done',
+        message: inserted > 0 ? `Indexed ${inserted} payment${inserted === 1 ? '' : 's'}` : 'Up to date',
+      });
+      // Refresh the table even when nothing was inserted - the sync timestamp
+      // moved, and the pill reads from that.
+      onSynced();
+    } catch (error) {
+      setState({ phase: 'error', message: error instanceof Error ? error.message : 'Failed' });
+    }
+  }, [onSynced]);
+
+  const secondsLeft = state.phase === 'cooldown' ? Math.max(0, Math.ceil((state.until - now) / 1000)) : 0;
+  const disabled = state.phase === 'running' || cooling;
+
+  const label =
+    state.phase === 'running'
+      ? 'Syncing…'
+      : state.phase === 'done'
+        ? state.message
+        : state.phase === 'error'
+          ? 'Retry sync'
+          : cooling
+            ? `Wait ${secondsLeft}s`
+            : 'Sync now';
+
+  return (
+    <button
+      type="button"
+      onClick={trigger}
+      disabled={disabled}
+      title={
+        state.phase === 'error'
+          ? state.message
+          : state.phase === 'cooldown'
+            ? 'A sync ran moments ago. The indexer is rate limited to avoid hammering the network.'
+            : 'Index new payments now instead of waiting for the scheduled run'
+      }
+      className={`px-3 py-2 rounded-lg text-[10px] font-bold uppercase tracking-widest border transition-colors cursor-pointer disabled:cursor-not-allowed ${
+        state.phase === 'error'
+          ? 'border-red-200 dark:border-red-500/20 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10'
+          : 'border-slate-200 dark:border-white/10 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/5 disabled:opacity-50 disabled:hover:bg-transparent'
+      }`}
+    >
+      <span aria-live="polite">{label}</span>
+    </button>
   );
 }
 

--- a/apps/web/src/lib/sync-status.test.ts
+++ b/apps/web/src/lib/sync-status.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { describeSync, formatAge, LIVE_WITHIN_MS, LAGGING_WITHIN_MS } from './sync-status';
+import {
+  describeSync,
+  formatAge,
+  cooldownRemaining,
+  LIVE_WITHIN_MS,
+  LAGGING_WITHIN_MS,
+} from './sync-status';
 
 const NOW = Date.parse('2026-08-04T12:00:00Z');
 const ago = (ms: number) => ({ lastLedger: 3_741_196, updatedAt: new Date(NOW - ms).toISOString() });
@@ -73,5 +79,38 @@ describe('describeSync', () => {
     for (const hours of [2, 4, 12, 48]) {
       expect(describeSync(ago(hours * HOUR), NOW).level).not.toBe('live');
     }
+  });
+});
+
+describe('cooldownRemaining', () => {
+  const COOLDOWN = 60_000;
+  const at = (ms: number) => new Date(NOW - ms).toISOString();
+
+  it('blocks with the remaining time while inside the window', () => {
+    expect(cooldownRemaining(at(20_000), COOLDOWN, NOW)).toBe(40_000);
+  });
+
+  it('allows once the window has passed', () => {
+    expect(cooldownRemaining(at(COOLDOWN), COOLDOWN, NOW)).toBe(0);
+    expect(cooldownRemaining(at(COOLDOWN + 1), COOLDOWN, NOW)).toBe(0);
+  });
+
+  it('allows when the indexer has never run', () => {
+    // Refusing here would leave a cold database with no way to trigger a sync.
+    expect(cooldownRemaining(null, COOLDOWN, NOW)).toBe(0);
+    expect(cooldownRemaining(undefined, COOLDOWN, NOW)).toBe(0);
+  });
+
+  it('allows rather than locking out on an unreadable timestamp', () => {
+    expect(cooldownRemaining('not a date', COOLDOWN, NOW)).toBe(0);
+  });
+
+  it('allows when the stored time is in the future', () => {
+    // Clock skew, not a fresh sync. Blocking would last as long as the skew.
+    expect(cooldownRemaining(at(-5 * 60_000), COOLDOWN, NOW)).toBe(0);
+  });
+
+  it('never returns more than the cooldown itself', () => {
+    expect(cooldownRemaining(at(1), COOLDOWN, NOW)).toBeLessThanOrEqual(COOLDOWN);
   });
 });

--- a/apps/web/src/lib/sync-status.ts
+++ b/apps/web/src/lib/sync-status.ts
@@ -32,6 +32,28 @@ export interface SyncStatus {
   detail: string;
 }
 
+/**
+ * Milliseconds left before a manual sync is allowed again, or 0 if it is.
+ *
+ * Guards a public, unauthenticated trigger, so it fails open only where failing
+ * closed would be worse: an absent or unreadable timestamp means the indexer's
+ * state is unknown, and refusing forever would leave no way to recover.
+ */
+export function cooldownRemaining(
+  updatedAt: string | null | undefined,
+  cooldownMs: number,
+  now: number = Date.now(),
+): number {
+  if (!updatedAt) return 0;
+  const updated = Date.parse(updatedAt);
+  if (Number.isNaN(updated)) return 0;
+  const since = now - updated;
+  // A timestamp in the future means clock skew, not a fresh sync; do not let it
+  // lock the button out for however long the skew happens to be.
+  if (since < 0) return 0;
+  return since >= cooldownMs ? 0 : cooldownMs - since;
+}
+
 /** Formats a duration as a single coarse unit: 4s, 12m, 3h, 2d. */
 export function formatAge(ms: number): string {
   if (ms < 0) return '0s';


### PR DESCRIPTION
## Why

The scheduled sync is configured for `*/5` but GitHub drops most scheduled runs. Measured over 34 hours of run history, it fires roughly every **2.3 hours** — about 97% of scheduled runs never happen:

```
12:18  10:07  07:20  04:32  01:09  23:42  22:30  21:17  20:00  18:11 ...
```

All succeed; they simply do not run. Until now there was no way to catch up without waiting, which is why the live dashboard reads "Synced 2h ago".

## What

`POST /api/sync` runs the same indexing path as the scheduled `GET`. Both now share a `runSync()` helper instead of duplicating the logic, and both answer through the same `respond()` mapper.

The dashboard gets a **Sync now** button beside the status pill, with states: idle → `Syncing…` → `Indexed 3 payments` / `Up to date`, plus `Wait 42s` during cooldown and `Retry sync` on failure. On success it refreshes the table even when nothing was inserted, because the sync timestamp moved and the pill reads from that.

## Security

The endpoint is **deliberately not behind `CRON_SECRET`** — the dashboard is public and a browser cannot hold a secret. A **60s cooldown** bounds the cost instead, returning `429` with a `Retry-After` header.

Worth being explicit about the exposure: this is a publicly triggerable endpoint. Indexing is idempotent, so the risk is **spend, not corruption** — RPC round trips, a database connection, and a function invocation, once a minute at most. If that is not an acceptable trade, the alternative is putting the dashboard behind auth; a client-side secret would not be one.

`cooldownRemaining()` fails open on an absent, unreadable or future timestamp. Those mean the indexer's state is unknown, and refusing forever would leave a cold database with no way to recover. Clock skew is treated as skew, not as a fresh sync.

The button *reflects* the server's cooldown rather than enforcing its own, so a second tab or a curl cannot bypass it.

## Verification

96 tests, up from 90. The 6 new ones cover the cooldown edges: inside the window returning exact remaining time, the boundary being inclusive, null/undefined/unparseable/future timestamps all failing open, and the result never exceeding the cooldown.

`tsc --noEmit`, `eslint src`, `next build` all clean. One real lint finding fixed along the way — the countdown originally wrote state from an effect, which cascades renders; expiry is now derived and the interval clears itself when it lapses.

## Not verified

No live database from this sandbox (Supabase is IPv6-only and unreachable here), so the button has not been clicked against a real backend. The cooldown arithmetic is unit-tested and the wiring type-checks, but the 429 path and the "Indexed N payments" message have not been observed end to end. Worth one click on the preview deploy, then a second click within a minute to confirm the cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Maipo9Nrh22sAhCUk4Gyyd