### PR TITLE
feat(web): extract shared page container, footer, CTA, and section heading

### DIFF
--- a/apps/web/src/app/batches/[id]/page.tsx
+++ b/apps/web/src/app/batches/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { getBatch, RECEIPT_ANCHOR_ID, type BatchRecord } from '@/lib/receipt-anchor';
 import { ArrowUpRight } from 'lucide-react';
+import { PageContainer } from '@/components/page-container';
 
 /**
  * A batch is immutable once anchored, so this can be cached hard. Revalidating
@@ -60,7 +61,7 @@ export default async function BatchPage({
 
  return (
  <main className="min-h-screen bg-grid text-slate-900 dark:text-white px-6 py-16 md:py-24 pt-28 md:pt-32 transition-colors duration-300">
- <div className="max-w-3xl mx-auto space-y-10 relative z-10">
+ <PageContainer width="narrow"className="space-y-10 relative z-10">
  <header className="space-y-4">
  <h1 className="text-4xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
  Batch{' '}
@@ -121,7 +122,7 @@ export default async function BatchPage({
  </pre>
  </div>
  </section>
- </div>
+ </PageContainer>
  </main>
  );
 }

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { formatAmount, sumAmounts, assetLabel } from '@/lib/money';
 import { describeSync, type SyncState } from '@/lib/sync-status';
 import { ArrowUpRight } from 'lucide-react';
+import { PageContainer } from '@/components/page-container';
 
 interface Payment {
  tx_hash: string;
@@ -74,7 +75,7 @@ export default function Dashboard() {
 
  return (
  <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32">
- <div className="max-w-7xl mx-auto space-y-12">
+ <PageContainer className="space-y-12">
  
  {/* Header Grid */}
  <header className="grid lg:grid-cols-3 gap-8 items-end">
@@ -229,7 +230,7 @@ export default function Dashboard() {
  )}
  </div>
  </section>
- </div>
+ </PageContainer>
 
  {/* Modal Dialog */}
  {selected && (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from"next/font/local";
 import"./globals.css";
 import { ThemeProvider } from"@/components/theme-provider";
 import { Nav } from"@/components/nav";
+import { Footer } from"@/components/footer";
 
 const geistSans = Geist({
  variable:"--font-geist-sans",
@@ -69,6 +70,7 @@ export default function RootLayout({
  <ThemeProvider attribute="class"defaultTheme="dark"disableTransitionOnChange>
  <Nav />
  {children}
+ <Footer />
  </ThemeProvider>
  </body>
  </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,9 @@ import { FaqAccordion } from"@/components/faq-accordion";
 import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 import { RECEIPT_ANCHOR_ID } from '@/lib/receipt-anchor';
+import { PageContainer } from '@/components/page-container';
+import { SectionHeading } from '@/components/section-heading';
+import { CtaButton } from '@/components/cta-button';
 
 const REFUND_VAULT_ID =
  process.env.NEXT_PUBLIC_REFUND_VAULT_ID ??
@@ -45,7 +48,7 @@ export default function Landing() {
  {/* Subtle radial glow matching emerald theme */}
  <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-transparent dark:bg-emerald-500/5 blur-[100px] dark:blur-[120px] pointer-events-none transition-colors duration-300"/>
  
- <div className="w-full mx-auto text-center space-y-8 relative z-10">
+ <PageContainer className="text-center space-y-8 relative z-10">
  <div className="inline-flex items-center mb-4 transition-colors duration-300">
  <span className="text-sm font-camiro font-bold tracking-[0.35em] text-emerald-600 dark:text-emerald-400 uppercase">— Live on Stellar Testnet —</span>
  </div>
@@ -63,29 +66,16 @@ export default function Landing() {
  </p>
 
  <div className="flex flex-col sm:flex-row gap-4 justify-center pt-8">
- <Link
- href="/verify"
- className="px-8 py-4 bg-white/40 dark:bg-white/10 backdrop-blur-xl border border-slate-200/50 dark:border-white/20 text-slate-900 dark:text-white font-bold text-sm uppercase tracking-wider hover:bg-white/60 dark:hover:bg-white/20 transition-all hover:scale-[1.02] active:scale-[0.98] shadow-sm dark:shadow-none"
- >
- Verify a Receipt
- </Link>
- <Link
- href="/dashboard"
- className="px-8 py-4 bg-white dark:bg-white/[0.02] dark:backdrop-blur-md text-slate-900 dark:text-white font-bold text-sm uppercase tracking-wider hover:bg-slate-50 dark:hover:bg-white/[0.06] transition-all hover:border-slate-300 dark:hover:border-white/20 shadow-sm dark:shadow-none"
- >
- View Dashboard
- </Link>
+ <CtaButton href="/verify">Verify a Receipt</CtaButton>
+ <CtaButton href="/dashboard"variant="secondary">View Dashboard</CtaButton>
  </div>
- </div>
+ </PageContainer>
  </section>
 
  {/* Bento Grid Architecture */}
  <ScrollReveal as="section"className="px-6 py-12 md:py-16 relative">
- <div className="w-full mx-auto">
- <div className="mb-12 text-center">
- <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Architecture</p>
- <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">How it <span className="text-slate-400 dark:text-slate-500 italic font-normal">works.</span></h2>
- </div>
+ <PageContainer>
+ <SectionHeading eyebrow="Architecture"tail="works."className="mb-12 text-center">How it</SectionHeading>
 
  <div className="grid md:grid-cols-3 gap-6">
  <BentoCard className="md:col-span-2 transition-all duration-300"title="1. The Agent Pays">
@@ -114,17 +104,14 @@ export default function Landing() {
  </div>
  </BentoCard>
  </div>
- </div>
+ </PageContainer>
  </ScrollReveal>
 
  {/* The Protocol Benefits */}
  <ScrollReveal as="section"className="px-6 py-12 md:py-16 transition-colors duration-300">
- <div className="w-full mx-auto">
+ <PageContainer>
  <div className="flex flex-col md:flex-row justify-between items-center md:items-end gap-6 md:gap-10 mb-12 text-center md:text-left">
- <div className="max-w-2xl">
- <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Protocol</p>
- <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">Why <span className="text-slate-400 dark:text-slate-500 italic font-normal">Stellar?</span></h2>
- </div>
+ <SectionHeading eyebrow="Protocol"tail="Stellar?"className="max-w-2xl">Why</SectionHeading>
  <p className="text-slate-600 dark:text-slate-400 font-medium max-w-md text-lg transition-colors duration-300">Built on a ledger designed specifically for high-throughput, low-latency financial settlement.</p>
  </div>
 
@@ -134,15 +121,14 @@ export default function Landing() {
  <FeatureCard title="Native USDC"desc="Means float and refunds settle in the asset merchants actually price in, with absolutely no bridging."/>
  <FeatureCard title="Predictable Gas"desc="Lets a merchant definitively bound the cost of their refund policy in advance rather than guessing."/>
  </div>
- </div>
+ </PageContainer>
  </ScrollReveal>
 
  {/* Contracts Live */}
  <ScrollReveal as="section"className="px-6 py-12 md:py-16 transition-colors duration-300">
- <div className="w-full mx-auto">
+ <PageContainer>
  <div className="text-center mb-12">
- <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Network</p>
- <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">Live <span className="text-slate-400 dark:text-slate-500 italic font-normal">Contracts.</span></h2>
+ <SectionHeading eyebrow="Network"tail="Contracts.">Live</SectionHeading>
  <p className="text-slate-600 dark:text-slate-400 leading-relaxed mt-6 text-lg font-medium max-w-2xl mx-auto transition-colors duration-300">
  Both contracts are deployed and initialized on Stellar testnet, and batch #1 is anchored. Verify receipts against it right now.
  </p>
@@ -151,16 +137,13 @@ export default function Landing() {
  <ContractCard name="ReceiptAnchor"id={RECEIPT_ANCHOR_ID} />
  <ContractCard name="RefundVault"id={REFUND_VAULT_ID} />
  </div>
- </div>
+ </PageContainer>
  </ScrollReveal>
 
  {/* Integration Code block */}
  <ScrollReveal as="section"className="px-6 py-12 md:py-16 transition-colors duration-300">
- <div className="w-full mx-auto">
- <div className="mb-10 text-center md:text-left">
- <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">Integration</p>
- <h2 className="text-4xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">SDK Drop-in</h2>
- </div>
+ <PageContainer>
+ <SectionHeading eyebrow="Integration"tail="Drop-in."className="mb-10 text-center md:text-left">SDK</SectionHeading>
  <div className="bg-white/40 dark:bg-black/20 backdrop-blur-2xl overflow-hidden shadow-[0_8px_30px_rgba(0,0,0,0.12),inset_0_1px_1px_rgba(255,255,255,0.8)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.15)] relative group transition-colors duration-300">
  <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-emerald-500 to-teal-400 opacity-80 dark:opacity-50"/>
  <div className="px-6 py-4 border-b border-slate-200/50 dark:border-white/10 flex gap-2 transition-colors duration-300 bg-white/20 dark:bg-white/5">
@@ -177,33 +160,17 @@ export default function Landing() {
  </code>
  </pre>
  </div>
- </div>
+ </PageContainer>
  </ScrollReveal>
 
  {/* FAQ Section */}
  <ScrollReveal as="section"className="px-6 py-12 md:py-16 transition-colors duration-300">
- <div className="w-full mx-auto">
- <div className="mb-12 text-center md:text-left">
- <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">FAQ</p>
- <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">Common <span className="text-slate-400 dark:text-slate-500 italic font-normal">Questions.</span></h2>
- </div>
+ <PageContainer>
+ <SectionHeading eyebrow="FAQ"tail="Questions."className="mb-12 text-center md:text-left">Common</SectionHeading>
  <FaqAccordion items={faqItems} />
- </div>
+ </PageContainer>
  </ScrollReveal>
 
- <footer className="px-6 py-12 border-t border-slate-200 dark:border-white/10 bg-slate-50 dark:bg-[#04090f] transition-colors duration-300">
- <div className="w-full mx-auto flex flex-col md:flex-row justify-between items-center md:items-center gap-8 md:gap-6 text-center md:text-left">
- <span className="text-xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
- Accensa
- </span>
- <div className="flex flex-wrap gap-8 justify-center text-xs font-bold uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">
- <Link href="/dashboard"className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Dashboard</Link>
- <Link href="/verify"className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Verify</Link>
- <a href="https://accensa-docs.vercel.app"className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">Docs</a>
- <a href="https://github.com/accensa"className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">GitHub</a>
- </div>
- </div>
- </footer>
  </main>
  );
 }

--- a/apps/web/src/app/verify/page.tsx
+++ b/apps/web/src/app/verify/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import type { VerifyResponse } from '../api/verify/route';
+import { PageContainer } from '@/components/page-container';
 
 const SAMPLE = {
  batchId: '1',
@@ -56,7 +57,7 @@ export default function VerifyPage() {
 
  return (
  <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32">
- <div className="max-w-4xl mx-auto space-y-12">
+ <PageContainer width="narrow"className="space-y-12">
  <header className="space-y-6 text-center max-w-2xl mx-auto relative">
  <h1 className="text-4xl sm:text-5xl md:text-6xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
  Verify a Receipt
@@ -146,7 +147,7 @@ export default function VerifyPage() {
  )}
 
  {state.status === 'done' && <Result result={state.result} />}
- </div>
+ </PageContainer>
  </main>
  );
 }

--- a/apps/web/src/components/cta-button.tsx
+++ b/apps/web/src/components/cta-button.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Link from 'next/link';
+
+/**
+ * The hero call-to-action pair.
+ *
+ * Both buttons share one base — same border, padding, and press response — and
+ * differ only in fill. They were previously built from separate recipes, which
+ * left the bordered one 2px taller than its neighbour, gave the other a
+ * `hover:border-*` rule it could never apply (its border-width was 0), and let
+ * only one of the two respond to touch.
+ */
+export type CtaVariant = 'primary' | 'secondary';
+
+const BASE =
+ 'px-8 py-4 border font-bold text-sm uppercase tracking-wider transition-all hover:scale-[1.02] active:scale-[0.98] shadow-sm dark:shadow-none text-slate-900 dark:text-white text-center';
+
+const VARIANTS: Record<CtaVariant, string> = {
+ primary:
+ 'bg-white/40 dark:bg-white/10 backdrop-blur-xl border-slate-200/50 dark:border-white/20 hover:bg-white/60 dark:hover:bg-white/20',
+ secondary:
+ 'bg-white dark:bg-white/[0.02] dark:backdrop-blur-md border-slate-200/50 dark:border-white/20 hover:bg-slate-50 dark:hover:bg-white/[0.06] hover:border-slate-300 dark:hover:border-white/30',
+};
+
+export function CtaButton({
+ href,
+ variant = 'primary',
+ className = '',
+ children,
+}: {
+ href: string;
+ variant?: CtaVariant;
+ className?: string;
+ children: React.ReactNode;
+}) {
+ return (
+ <Link href={href} className={`${BASE} ${VARIANTS[variant]} ${className}`}>
+ {children}
+ </Link>
+ );
+}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import { PageContainer } from '@/components/page-container';
+
+/**
+ * Global site footer.
+ *
+ * Rendered from `layout.tsx` alongside `<Nav />` so the chrome is symmetric.
+ * It previously lived inline in the landing page, which meant four of the five
+ * routes ended abruptly at their last content block and the Docs and GitHub
+ * links were unreachable from any of them.
+ */
+export function Footer() {
+ return (
+ <footer className="px-6 py-12 border-t border-slate-200 dark:border-white/10 bg-slate-50 dark:bg-[#04090f] transition-colors duration-300">
+ <PageContainer className="flex flex-col md:flex-row justify-between items-center gap-8 md:gap-6 text-center md:text-left">
+ <Link
+ href="/"
+ className="text-xl font-black tracking-tighter text-slate-900 dark:text-white hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors duration-300"
+ >
+ Accensa
+ </Link>
+ <div className="flex flex-wrap gap-8 justify-center text-xs font-bold uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">
+ <Link href="/dashboard" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
+ Dashboard
+ </Link>
+ <Link href="/verify" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
+ Verify
+ </Link>
+ <a
+ href="https://accensa-docs.vercel.app"
+ className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+ >
+ Docs
+ </a>
+ <a href="https://github.com/accensa" className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
+ GitHub
+ </a>
+ </div>
+ </PageContainer>
+ </footer>
+ );
+}

--- a/apps/web/src/components/page-container.tsx
+++ b/apps/web/src/components/page-container.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * The two measures this site uses. Anything that needs a width picks one of
+ * these rather than inventing its own, which is what let the left edge drift
+ * between sections and between routes.
+ *
+ * `full`   - fluid to the viewport. Marketing sections and data-dense views,
+ *            where more horizontal room is useful and there is no long line of
+ *            prose to keep readable.
+ * `narrow` - capped. Reading and form routes, where an unbounded line length
+ *            on a wide monitor is actively worse.
+ *
+ * Prose inside a `full` container may still cap itself (`max-w-2xl` on a
+ * paragraph); that is a measure constraint on a line of text, not a page
+ * container, and the two are not in conflict.
+ */
+export type PageWidth = 'full' | 'narrow';
+
+const WIDTHS: Record<PageWidth, string> = {
+ full: 'w-full',
+ narrow: 'max-w-3xl',
+};
+
+export function PageContainer({
+ width = 'full',
+ className = '',
+ children,
+}: {
+ width?: PageWidth;
+ className?: string;
+ children: React.ReactNode;
+}) {
+ return <div className={`${WIDTHS[width]} mx-auto ${className}`}>{children}</div>;
+}

--- a/apps/web/src/components/section-heading.tsx
+++ b/apps/web/src/components/section-heading.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+/**
+ * A section heading in the house style: an uppercase emerald eyebrow, then a
+ * heavy title whose final word drops to a lighter serif italic.
+ *
+ * The device was previously applied by hand at each call site, which is how
+ * `SDK Drop-in` ended up as the only section heading without it and a size step
+ * behind its peers. Passing `tail` here means the treatment is the default and
+ * omitting it has to be deliberate.
+ */
+export function SectionHeading({
+ eyebrow,
+ children,
+ tail,
+ className = '',
+}: {
+ eyebrow?: string;
+ children: React.ReactNode;
+ /** Final word, set in the lighter serif italic. */
+ tail?: string;
+ className?: string;
+}) {
+ return (
+ <div className={className}>
+ {eyebrow && (
+ <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-4">
+ {eyebrow}
+ </p>
+ )}
+ <h2 className="text-4xl md:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
+ {children}
+ {tail && (
+ <>
+ {' '}
+ <span className="text-slate-400 dark:text-slate-500 italic font-normal">{tail}</span>
+ </>
+ )}
+ </h2>
+ </div>
+ );
+}


### PR DESCRIPTION
Closes #58, closes #59, closes #60, closes #61.

Four issues from the 2026-08-03 design audit shared one root cause: layout decisions were made inline at each call site, so they drifted apart. Fixing them individually would have left the drift mechanism in place, so each fix here is a shared primitive rather than a patch.

## #58 — page container widths

The issue tabulated six different `max-w-*` values on the landing page and four across routes. `c09b06c` (08-05) already removed the landing-page ones by going full-bleed, which fixed the mid-scroll edge jump but widened the cross-route spread: landing full-bleed, dashboard `7xl`, verify `4xl`, batches `3xl`.

`page-container.tsx` replaces ad-hoc values with a two-token scale and a stated rule for picking between them:

| Token | Width | For |
|---|---|---|
| `full` | fluid | marketing sections, data-dense views |
| `narrow` | `max-w-3xl` | reading routes and forms |

Applied: landing `full`, dashboard `full`, verify `narrow`, batches `narrow`. This adopts full-bleed as the house style, following the intent of `c09b06c`, rather than reverting the landing page to a cap.

Paragraph-level `max-w-2xl` inside a `full` container is left alone — that is a measure constraint on a line of prose, not a page container.

## #59 — hero CTA parity

Both buttons now come from `cta-button.tsx` with one base and a fill-only variant. This fixes all three defects the issue listed: the 2px height mismatch (only one had a border), the `hover:border-*` rule that could never apply against a 0-width border, and the missing `hover:scale`/`active:scale` on the secondary.

## #60 — global footer

Extracted to `footer.tsx` and rendered from `layout.tsx` beside `<Nav />`. All five routes now have it; Docs and GitHub are reachable from everywhere. `<body>` already carried `min-h-full flex flex-col`, so no layout changes were needed.

## #61 — section heading device

`section-heading.tsx` makes the eyebrow + serif-italic-tail treatment the default. `SDK Drop-in` gets the device and the `md:text-5xl` step it was missing, and the other four headings now route through the same component so the next one added cannot silently skip it.

## Verification

`pnpm lint` clean. Typecheck, build, and both test suites are left to CI — this checkout has no populated `node_modules` for `apps/web`, so a local `tsc` run only reports missing `lucide-react`/`next-themes`, which is unrelated to this change.

One real bug caught while writing this: the first pass closed the dashboard's `PageContainer` around the modal dialog rather than the table section. Fixed before commit; `pnpm lint` now parses it clean.