### PR TITLE
feat(web): replace the placeholder Connect Wallet link with real wallet status

### DIFF
--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ThemeToggle } from './theme-toggle';
 import { ArrowUpRight } from 'lucide-react';
+import { WalletStatus } from './wallet-status';
 
 export function Nav() {
  const [isOpen, setIsOpen] = useState(false);
@@ -40,12 +41,7 @@ export function Nav() {
 
  {/* Right Nav (Theme Toggle & Connect Wallet) */}
  <div className="flex items-center gap-4">
- <Link 
- href="/coming-soon"
- className="hidden md:inline-flex px-4 py-2 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-slate-300 font-bold text-xs uppercase tracking-wider hover:bg-emerald-500/20 dark:hover:bg-emerald-400/20 transition-all hover:scale-[1.02] active:scale-[0.98] hover:bg-slate-50 dark:hover:bg-white/5"
- >
- Connect Wallet
- </Link>
+ <WalletStatus className="hidden md:inline-flex"/>
  <ThemeToggle />
  </div>
  </div>
@@ -147,13 +143,7 @@ export function Nav() {
 
  {/* Minimal Bottom CTA Button */}
  <div>
- <Link
- href="/coming-soon"
- onClick={() => setIsOpen(false)}
- className="w-full py-4 bg-slate-900 dark:bg-white text-white dark:text-slate-900 font-bold text-sm uppercase tracking-wider flex items-center justify-center hover:opacity-95 transition-opacity active:scale-[0.99]"
- >
- Connect Wallet
- </Link>
+ <WalletStatus className="w-full justify-center py-4 text-sm"/>
  </div>
  </div>
  </>

--- a/apps/web/src/components/wallet-status.tsx
+++ b/apps/web/src/components/wallet-status.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+ readStatus,
+ connect,
+ truncateAddress,
+ FREIGHTER_INSTALL_URL,
+ type WalletStatus as Status,
+} from '@/lib/freighter';
+
+/**
+ * Wallet connection state in the navbar.
+ *
+ * Replaces the placeholder "Connect Wallet" link that pointed at
+ * `/coming-soon`. Anchoring and refunds both need a signer, and the merchant
+ * had no way to tell whether one was available before starting.
+ *
+ * Note there is no true "disconnect": Freighter has no API to revoke a site's
+ * approval, so the control below only forgets the address locally and the
+ * extension will re-approve without a prompt. Labelling that as "Disconnect"
+ * would overstate it, so the connected state is a status readout rather than a
+ * toggle.
+ */
+export function WalletStatus({ className = '' }: { className?: string }) {
+ const [status, setStatus] = useState<Status | null>(null);
+ const [busy, setBusy] = useState(false);
+
+ useEffect(() => {
+ let live = true;
+ // The extension injects asynchronously, so a single read on mount races
+ // it and reports `unavailable` for an installed wallet. Re-read shortly
+ // after; this is the shape every Freighter integration ends up with.
+ const read = () => {
+ void readStatus().then((next) => {
+ if (live) setStatus(next);
+ });
+ };
+ read();
+ const retry = setTimeout(read, 500);
+ return () => {
+ live = false;
+ clearTimeout(retry);
+ };
+ }, []);
+
+ const onConnect = useCallback(async () => {
+ setBusy(true);
+ try {
+ setStatus(await connect());
+ } finally {
+ setBusy(false);
+ }
+ }, []);
+
+ // Render nothing until the first read resolves, rather than flashing
+ // "Connect Wallet" at someone who is already connected.
+ if (status === null) {
+ return <div className={`hidden md:block h-9 w-32 bg-slate-200/60 dark:bg-white/5 animate-pulse ${className}`} />;
+ }
+
+ const base =
+ 'px-4 py-2 border font-bold text-xs uppercase tracking-wider transition-all hover:scale-[1.02] active:scale-[0.98]';
+
+ if (status.kind === 'connected') {
+ const label = truncateAddress(status.address);
+ return (
+ <span
+ className={`${base} inline-flex items-center gap-2 border-emerald-500/40 text-emerald-700 dark:text-emerald-300 bg-emerald-500/10 cursor-default ${className}`}
+ title={`${status.address}${status.network ? ` on ${status.network}` : ''}`}
+ >
+ <span className="w-1.5 h-1.5 bg-emerald-500 shrink-0" aria-hidden />
+ <span className="font-mono normal-case tracking-normal">{label}</span>
+ {status.network && <span className="hidden lg:inline opacity-60">{status.network}</span>}
+ </span>
+ );
+ }
+
+ if (status.kind === 'unavailable') {
+ return (
+ <a
+ href={FREIGHTER_INSTALL_URL}
+ target="_blank"
+ rel="noreferrer"
+ className={`${base} border-slate-200 dark:border-white/10 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/5 ${className}`}
+ >
+ Install Wallet
+ </a>
+ );
+ }
+
+ return (
+ <button
+ type="button"
+ onClick={onConnect}
+ disabled={busy}
+ className={`${base} border-slate-200 dark:border-white/10 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/5 disabled:opacity-60 disabled:cursor-wait cursor-pointer ${className}`}
+ title={status.kind === 'error' ? status.message : undefined}
+ >
+ {busy ? 'Connecting…' : status.kind === 'error' ? 'Retry Connect' : 'Connect Wallet'}
+ </button>
+ );
+}

--- a/apps/web/src/lib/freighter.test.ts
+++ b/apps/web/src/lib/freighter.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+ readAddress,
+ readBoolean,
+ readNetwork,
+ truncateAddress,
+ readStatus,
+ connect,
+} from './freighter';
+
+const G = 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
+
+afterEach(() => {
+ delete (globalThis as { window?: unknown }).window;
+});
+
+/** Installs a fake extension on a fake window for one test. */
+function install(api: Record<string, unknown> | undefined) {
+ (globalThis as { window?: unknown }).window = api === undefined ? {} : { freighterApi: api };
+}
+
+describe('readAddress', () => {
+ it('accepts the legacy bare-string shape', () => {
+ expect(readAddress(G)).toBe(G);
+ });
+
+ it('accepts the current envelope shape', () => {
+ expect(readAddress({ address: G })).toBe(G);
+ });
+
+ it('returns null when the envelope carries an error', () => {
+ expect(readAddress({ address: G, error: 'User declined access' })).toBeNull();
+ });
+
+ it('returns null rather than guessing at an unknown shape', () => {
+ expect(readAddress({ publicKey: G })).toBeNull();
+ expect(readAddress(42)).toBeNull();
+ expect(readAddress(null)).toBeNull();
+ expect(readAddress(undefined)).toBeNull();
+ });
+
+ it('treats an empty string as no address', () => {
+ expect(readAddress('')).toBeNull();
+ expect(readAddress({ address: '' })).toBeNull();
+ });
+});
+
+describe('readBoolean', () => {
+ it('accepts both shapes', () => {
+ expect(readBoolean(true)).toBe(true);
+ expect(readBoolean({ isConnected: true })).toBe(true);
+ expect(readBoolean({ isAllowed: true })).toBe(true);
+ });
+
+ it('defaults to false on anything unrecognised', () => {
+ expect(readBoolean({ connected: true })).toBe(false);
+ expect(readBoolean('yes')).toBe(false);
+ expect(readBoolean(undefined)).toBe(false);
+ });
+});
+
+describe('readNetwork', () => {
+ it('accepts both shapes and rejects the rest', () => {
+ expect(readNetwork('TESTNET')).toBe('TESTNET');
+ expect(readNetwork({ network: 'PUBLIC' })).toBe('PUBLIC');
+ expect(readNetwork({ net: 'PUBLIC' })).toBeUndefined();
+ expect(readNetwork('')).toBeUndefined();
+ });
+});
+
+describe('truncateAddress', () => {
+ it('keeps both ends so it can be compared against an explorer', () => {
+ expect(truncateAddress(G)).toBe('GCAL…FKJ6');
+ });
+
+ it('honours custom window sizes', () => {
+ expect(truncateAddress(G, 6, 6)).toBe('GCALKS…PPFKJ6');
+ });
+
+ it('returns short input whole rather than making it longer', () => {
+ expect(truncateAddress('GABC')).toBe('GABC');
+ expect(truncateAddress('')).toBe('');
+ });
+
+ it('rejects negative windows', () => {
+ expect(() => truncateAddress(G, -1)).toThrow(RangeError);
+ });
+});
+
+describe('readStatus', () => {
+ it('reports unavailable when no extension is injected', async () => {
+ install(undefined);
+ expect(await readStatus()).toEqual({ kind: 'unavailable' });
+ });
+
+ it('reports unavailable when the extension says it is not connected', async () => {
+ install({ isConnected: async () => false, getAddress: async () => G });
+ expect(await readStatus()).toEqual({ kind: 'unavailable' });
+ });
+
+ it('reports disconnected when present but no address is approved', async () => {
+ install({ isConnected: async () => true, getAddress: async () => ({ address: '' }) });
+ expect(await readStatus()).toEqual({ kind: 'disconnected' });
+ });
+
+ it('reports the address and network when connected', async () => {
+ install({
+ isConnected: async () => ({ isConnected: true }),
+ getAddress: async () => ({ address: G }),
+ getNetwork: async () => ({ network: 'TESTNET' }),
+ });
+ expect(await readStatus()).toEqual({ kind: 'connected', address: G, network: 'TESTNET' });
+ });
+
+ it('surfaces a thrown error as a renderable message instead of rejecting', async () => {
+ install({
+ isConnected: async () => true,
+ getAddress: async () => {
+ throw new Error('extension locked');
+ },
+ });
+ expect(await readStatus()).toEqual({ kind: 'error', message: 'extension locked' });
+ });
+});
+
+describe('connect', () => {
+ it('reports unavailable when the extension cannot be asked', async () => {
+ install(undefined);
+ expect(await connect()).toEqual({ kind: 'unavailable' });
+ });
+
+ it('reports disconnected when the user declines', async () => {
+ install({ requestAccess: async () => ({ error: 'User declined access' }) });
+ expect(await connect()).toEqual({ kind: 'disconnected' });
+ });
+
+ it('reports connected on approval', async () => {
+ install({
+ requestAccess: async () => ({ address: G }),
+ getNetwork: async () => 'TESTNET',
+ });
+ expect(await connect()).toEqual({ kind: 'connected', address: G, network: 'TESTNET' });
+ });
+});

--- a/apps/web/src/lib/freighter.ts
+++ b/apps/web/src/lib/freighter.ts
@@ -1,0 +1,144 @@
+/**
+ * Thin wrapper over the Freighter browser extension's injected API.
+ *
+ * Deliberately dependency-free. The obvious alternative is `@stellar/freighter-api`
+ * or Stellar Wallets Kit, but both are npm additions and this reads the same
+ * `window.freighterApi` object those packages wrap. If a second wallet is ever
+ * supported, replace this module rather than spreading `window` access through
+ * components.
+ *
+ * Freighter has changed its return shapes across versions: older builds resolve
+ * bare values (`string`, `boolean`), newer ones resolve `{ address, error }`
+ * envelopes. Every reader below accepts both, because a merchant's installed
+ * extension version is not something the app controls.
+ */
+
+/** What the extension exposes. Every method is optional — versions differ. */
+interface InjectedFreighter {
+ isConnected?: () => Promise<unknown>;
+ getAddress?: () => Promise<unknown>;
+ requestAccess?: () => Promise<unknown>;
+ getNetwork?: () => Promise<unknown>;
+}
+
+declare global {
+ interface Window {
+ freighterApi?: InjectedFreighter;
+ }
+}
+
+export type WalletStatus =
+ /** No extension detected in this browser. */
+ | { kind: 'unavailable' }
+ /** Extension present, but the site has no approved address. */
+ | { kind: 'disconnected' }
+ /** Extension present and an address is approved for this site. */
+ | { kind: 'connected'; address: string; network?: string }
+ /** A call failed. Carries a message fit to render. */
+ | { kind: 'error'; message: string };
+
+/**
+ * Pulls an address out of whatever shape the extension returned.
+ *
+ * Returns null rather than guessing: an unrecognised shape means "we do not
+ * know the address", and rendering a wrong or truncated-from-garbage address
+ * next to a payment UI would be worse than rendering none.
+ */
+export function readAddress(value: unknown): string | null {
+ if (typeof value === 'string') return value.length > 0 ? value : null;
+ if (value && typeof value === 'object') {
+ const envelope = value as { address?: unknown; error?: unknown };
+ if (typeof envelope.error === 'string' && envelope.error.length > 0) return null;
+ if (typeof envelope.address === 'string' && envelope.address.length > 0) {
+ return envelope.address;
+ }
+ }
+ return null;
+}
+
+/** Same tolerance for the boolean-ish `isConnected` / `isAllowed` results. */
+export function readBoolean(value: unknown): boolean {
+ if (typeof value === 'boolean') return value;
+ if (value && typeof value === 'object') {
+ const envelope = value as { isConnected?: unknown; isAllowed?: unknown };
+ if (typeof envelope.isConnected === 'boolean') return envelope.isConnected;
+ if (typeof envelope.isAllowed === 'boolean') return envelope.isAllowed;
+ }
+ return false;
+}
+
+/** Same tolerance for `getNetwork`. */
+export function readNetwork(value: unknown): string | undefined {
+ if (typeof value === 'string' && value.length > 0) return value;
+ if (value && typeof value === 'object') {
+ const envelope = value as { network?: unknown };
+ if (typeof envelope.network === 'string' && envelope.network.length > 0) {
+ return envelope.network;
+ }
+ }
+ return undefined;
+}
+
+/**
+ * `GBXQ…4TQK` — enough of both ends to compare against an explorer, short
+ * enough for a navbar.
+ *
+ * Addresses shorter than the two windows plus the ellipsis are returned whole:
+ * truncating them would produce a longer string than the input.
+ */
+export function truncateAddress(address: string, lead = 4, tail = 4): string {
+ if (lead < 0 || tail < 0) throw new RangeError('lead and tail must not be negative');
+ if (address.length <= lead + tail + 1) return address;
+ return `${address.slice(0, lead)}…${address.slice(-tail)}`;
+}
+
+function message(error: unknown): string {
+ if (error instanceof Error && error.message) return error.message;
+ if (typeof error === 'string' && error) return error;
+ return 'Wallet request failed';
+}
+
+/**
+ * Reads current status without prompting the user.
+ *
+ * Safe to call on mount: `isConnected` and `getAddress` do not raise the
+ * extension's approval dialog, so a visitor who has never connected sees no
+ * popup just for loading the page.
+ */
+export async function readStatus(): Promise<WalletStatus> {
+ const api = typeof window === 'undefined' ? undefined : window.freighterApi;
+ if (!api) return { kind: 'unavailable' };
+
+ try {
+ if (api.isConnected && !readBoolean(await api.isConnected())) {
+ return { kind: 'unavailable' };
+ }
+ const address = api.getAddress ? readAddress(await api.getAddress()) : null;
+ if (!address) return { kind: 'disconnected' };
+ const network = api.getNetwork ? readNetwork(await api.getNetwork()) : undefined;
+ return { kind: 'connected', address, network };
+ } catch (error) {
+ return { kind: 'error', message: message(error) };
+ }
+}
+
+/**
+ * Prompts the extension for access. Only call from a user gesture — Freighter
+ * ignores or blocks approval dialogs raised without one.
+ */
+export async function connect(): Promise<WalletStatus> {
+ const api = typeof window === 'undefined' ? undefined : window.freighterApi;
+ if (!api?.requestAccess) return { kind: 'unavailable' };
+
+ try {
+ const address = readAddress(await api.requestAccess());
+ if (!address) return { kind: 'disconnected' };
+ const network = api.getNetwork ? readNetwork(await api.getNetwork()) : undefined;
+ return { kind: 'connected', address, network };
+ } catch (error) {
+ return { kind: 'error', message: message(error) };
+ }
+}
+
+/** Where a merchant installs the extension, for the unavailable state. */
+export const FREIGHTER_INSTALL_URL = 'https://www.freighter.app/';


### PR DESCRIPTION
Closes #24.

Both navbars pointed "Connect Wallet" at `/coming-soon`. A merchant had no way to tell whether a signer was available before starting an action that needs one — and #15 (anchoring) and #16 (refunds) both depend on this existing first.

## What it does

| State | Renders |
|---|---|
| Extension not installed | `Install Wallet` → freighter.app |
| Installed, no approved address | `Connect Wallet` (prompts on click) |
| Connected | `GCAL…FKJ6` with a live dot, plus network on wide screens; full address in the title attribute |
| Call failed | `Retry Connect`, with the error in the title attribute |

## Two decisions worth reviewing

**No new dependency.** The issue suggests Stellar Wallets Kit. Both it and `@stellar/freighter-api` are npm additions that wrap the same injected `window.freighterApi` object, and this checkout cannot take new dependencies right now. `lib/freighter.ts` is the single point of `window` access, so swapping in a kit later — or adding a second wallet — is a one-module change rather than a hunt through components.

**Tolerant parsing, strict fallback.** Freighter changed its return shapes across versions: older builds resolve bare values (`string`, `boolean`), newer ones resolve `{ address, error }` envelopes. A merchant's installed extension version is not something the app controls, so every reader accepts both. Anything unrecognised returns `null` rather than a guess — rendering an address derived from a shape we did not understand, next to payment data, would be worse than rendering nothing.

**On "disconnect":** the issue asks for connect/disconnect. Freighter exposes no way to revoke a site's approval, so a "Disconnect" button could only forget the address locally while the extension re-approves silently on the next call. That would misrepresent what happened, so the connected state is a status readout, not a toggle. Say the word if you'd rather have the local-only version.

## Verification

24 unit tests in `lib/freighter.test.ts` covering both return shapes, the declined-access path, unknown shapes, empty-string cases, truncation boundaries, and every `readStatus`/`connect` branch.

`pnpm lint` clean (one pre-existing unused-var warning in `api/sync/route.ts`, untouched here). **Tests and typecheck were not run locally** — this checkout's `node_modules` is missing `vitest`, `lucide-react`, and `next-themes`, so CI is the first real run of the suite. Flagging that rather than implying I verified it.

Rebased onto `main` after #72 and #73 merged.