### PR TITLE
feat(web): handle offline and RPC failure, follow the OS theme by default

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -5,6 +5,8 @@ import { formatAmount, sumAmounts, assetLabel } from '@/lib/money';
 import { describeSync, type SyncState } from '@/lib/sync-status';
 import { ArrowUpRight } from 'lucide-react';
 import { PageContainer } from '@/components/page-container';
+import { useOnline } from '@/components/network-status';
+import { describeFailure, isAbortError } from '@/lib/network-status';
 
 interface Payment {
  tx_hash: string;
@@ -34,10 +36,16 @@ export default function Dashboard() {
  const [selected, setSelected] = useState<Payment | null>(null);
  const closeButtonRef = useRef<HTMLButtonElement>(null);
  const [reloadToken, setReloadToken] = useState(0);
+ const online = useOnline();
 
  const reload = useCallback(() => setReloadToken((n) => n + 1), []);
 
+ // `online` is a dependency, not just a guard: polling stops while the browser
+ // has no connection - every request would fail and overwrite a good table with
+ // an error - and reconnecting re-runs the effect, which refetches immediately
+ // rather than waiting out the remainder of a 15s tick.
  useEffect(() => {
+ if (!online) return;
  const controller = new AbortController();
  async function fetchPayments() {
  try {
@@ -52,13 +60,18 @@ export default function Dashboard() {
  setState({ status: 'ready', payments, fetchedAt: Date.now(), sync });
  }
  } catch (error) {
- if (!controller.signal.aborted) setState({ status: 'error', message: error instanceof Error ? error.message : 'Failed' });
+ // Re-read navigator.onLine here rather than closing over `online`: the
+ // connection can drop between the request going out and it failing,
+ // and that is exactly the case worth naming correctly.
+ if (!controller.signal.aborted && !isAbortError(error)) {
+ setState({ status: 'error', message: describeFailure(error, navigator.onLine) });
+ }
  }
  }
  void fetchPayments();
  const timer = setInterval(fetchPayments, POLL_INTERVAL_MS);
  return () => { controller.abort(); clearInterval(timer); };
- }, [reloadToken]);
+ }, [reloadToken, online]);
 
  useEffect(() => {
  if (!selected) return;
@@ -365,6 +378,7 @@ type SyncPhase =
 function SyncNowButton({ onSynced }: { onSynced: () => void }) {
  const [state, setState] = useState<SyncPhase>({ phase: 'idle' });
  const [now, setNow] = useState(() => Date.now());
+ const online = useOnline();
 
  // Expiry is derived, not stored: a timer that writes state back on every tick
  // would re-render the whole header once a second for no benefit.
@@ -414,10 +428,15 @@ function SyncNowButton({ onSynced }: { onSynced: () => void }) {
  }, [onSynced]);
 
  const secondsLeft = state.phase === 'cooldown' ? Math.max(0, Math.ceil((state.until - now) / 1000)) : 0;
- const disabled = state.phase === 'running' || cooling;
+ // Offline is a hard disable: the POST cannot reach the indexer, and letting
+ // it fail would burn the server-side cooldown on a request that never left
+ // the browser - the merchant would then be told to wait before retrying
+ // something that never ran.
+ const disabled = state.phase === 'running' || cooling || !online;
 
- const label =
- state.phase === 'running'
+ const label = !online
+ ? 'Offline'
+ : state.phase === 'running'
  ? 'Syncing…'
  : state.phase === 'done'
  ? state.message
@@ -433,7 +452,9 @@ function SyncNowButton({ onSynced }: { onSynced: () => void }) {
  onClick={trigger}
  disabled={disabled}
  title={
- state.phase === 'error'
+ !online
+ ? 'No connection. Reconnect to trigger a sync.'
+ : state.phase === 'error'
  ? state.message
  : state.phase === 'cooldown'
  ? 'A sync ran moments ago. The indexer is rate limited to avoid hammering the network.'

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,78 @@
+'use client'; // Error boundaries must be Client Components.
+
+import React, { useEffect } from 'react';
+import Link from 'next/link';
+import { RotateCw, TriangleAlert } from 'lucide-react';
+import { useOnline } from '@/components/network-status';
+import { PageContainer } from '@/components/page-container';
+
+/**
+ * Catches render-time exceptions anywhere under the root layout.
+ *
+ * Sits at the app segment rather than in each route so a crash on any page -
+ * a malformed API payload, a bad date, an RPC shape we did not expect - lands
+ * on something readable instead of a blank screen. The root layout (and so the
+ * nav) survives, because `error.tsx` wraps its siblings but not the layout
+ * above it; a failure in the layout itself falls through to `global-error.tsx`.
+ */
+export default function AppError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  const online = useOnline();
+
+  useEffect(() => {
+    // No error reporting service is wired up yet, so the console is the only
+    // place a digest can be matched against the server logs.
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32">
+      <PageContainer width="narrow" className="text-center space-y-6">
+        <div className="w-12 h-12 mx-auto bg-red-100 dark:bg-red-500/10 flex items-center justify-center text-red-600 dark:text-red-400">
+          <TriangleAlert className="w-5 h-5" />
+        </div>
+
+        <h1 className="text-3xl sm:text-4xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
+          Something went wrong
+        </h1>
+
+        <p className="text-slate-600 dark:text-slate-400 leading-relaxed transition-colors duration-300">
+          {online
+            ? 'This page hit an error it could not recover from on its own. Nothing you did caused it, and no payment data was changed.'
+            : 'This page hit an error while your browser was offline. Reconnect and try again - the data it needs could not be fetched.'}
+        </p>
+
+        {/* Production strips the message from server-thrown errors and leaves
+            only the digest, which is what support would ask for. */}
+        {error.digest && (
+          <p className="font-mono text-xs text-slate-400 dark:text-slate-500 break-all">
+            Reference: {error.digest}
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-4 justify-center pt-2">
+          <button
+            type="button"
+            onClick={() => unstable_retry()}
+            disabled={!online}
+            title={online ? undefined : 'Retrying needs a connection.'}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-600 dark:bg-emerald-500 text-white dark:text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-700 dark:hover:bg-emerald-400 transition-all shadow-md dark:shadow-none cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-emerald-600 dark:disabled:hover:bg-emerald-500"
+          >
+            <RotateCw className="w-4 h-4" /> Try again
+          </button>
+          <Link
+            href="/"
+            className="px-6 py-3 border border-slate-200 dark:border-white/15 bg-white dark:bg-transparent text-slate-700 dark:text-slate-200 font-bold text-sm hover:bg-slate-50 dark:hover:bg-white/5 transition-colors shadow-sm dark:shadow-none"
+          >
+            Back to Accensa
+          </Link>
+        </div>
+      </PageContainer>
+    </main>
+  );
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,57 @@
+'use client'; // Error boundaries must be Client Components.
+
+import './globals.css';
+
+/**
+ * Last-resort boundary for errors thrown by the root layout itself, which
+ * `error.tsx` cannot catch because it is rendered inside that layout.
+ *
+ * It replaces the layout, so it has to supply its own <html> and <body>, and it
+ * gets neither the fonts nor the ThemeProvider. That also means the `.dark`
+ * class is never on <html> here, so `dark:` variants would never fire - this
+ * screen is deliberately written in one palette that reads on any display
+ * rather than a dark variant that silently does nothing.
+ *
+ * It stays dependency-free (no icon package, no hooks) because whatever took
+ * out the root layout may well have taken out a shared chunk with it.
+ */
+export default function GlobalError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  return (
+    <html lang="en" className="h-full antialiased">
+      <body className="min-h-full flex items-center justify-center bg-slate-50 text-slate-600 font-sans p-6">
+        <div className="max-w-md text-center space-y-6">
+          <div className="w-12 h-12 mx-auto bg-red-100 flex items-center justify-center text-red-600 text-xl">
+            !
+          </div>
+
+          <h1 className="text-3xl font-black tracking-tighter text-slate-900">
+            Accensa could not load
+          </h1>
+
+          <p className="leading-relaxed">
+            The application failed to start. If you are offline, reconnect and try again; otherwise
+            this is a fault on our side and no payment data was changed.
+          </p>
+
+          {error.digest && (
+            <p className="font-mono text-xs text-slate-400 break-all">Reference: {error.digest}</p>
+          )}
+
+          <button
+            type="button"
+            onClick={() => unstable_retry()}
+            className="px-6 py-3 bg-emerald-600 text-white font-black text-sm uppercase tracking-wider hover:bg-emerald-700 transition-colors shadow-md cursor-pointer"
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import"./globals.css";
 import { ThemeProvider } from"@/components/theme-provider";
 import { Nav } from"@/components/nav";
 import { Footer } from"@/components/footer";
+import { OfflineBanner } from"@/components/network-status";
 
 const geistSans = Geist({
  variable:"--font-geist-sans",
@@ -67,10 +68,17 @@ export default function RootLayout({
  />
  </head>
  <body className="min-h-full flex flex-col bg-slate-50 dark:bg-[#04090f] transition-colors duration-300 relative">
- <ThemeProvider attribute="class"defaultTheme="dark"disableTransitionOnChange>
+ {/* defaultTheme is the fallback used only when localStorage holds no
+ choice, so"system"gives a first-time visitor whatever their OS is set
+ to while an explicit pick from the toggle still wins on every visit.
+ It was"dark", which ignored prefers-color-scheme entirely. */}
+ <ThemeProvider attribute="class"defaultTheme="system"enableSystem disableTransitionOnChange>
  <Nav />
  {children}
  <Footer />
+ {/* Outside the page tree so it survives navigation and stays visible
+ when a page-level error boundary takes over the content area. */}
+ <OfflineBanner />
  </ThemeProvider>
  </body>
  </html>

--- a/apps/web/src/components/network-status.tsx
+++ b/apps/web/src/components/network-status.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+import { WifiOff } from 'lucide-react';
+import { OFFLINE_MESSAGE } from '@/lib/network-status';
+
+function subscribe(onChange: () => void) {
+  window.addEventListener('online', onChange);
+  window.addEventListener('offline', onChange);
+  return () => {
+    window.removeEventListener('online', onChange);
+    window.removeEventListener('offline', onChange);
+  };
+}
+
+const getSnapshot = () => navigator.onLine;
+
+// The server has no idea whether the client has a connection, and rendering
+// "offline" into the HTML would flash on every cold load. Assume online and let
+// the first client snapshot correct it.
+const getServerSnapshot = () => true;
+
+/**
+ * Whether the browser currently has a network connection.
+ *
+ * `useSyncExternalStore` rather than useState + useEffect so the value is read
+ * during render instead of one paint late: a page loaded from bfcache while
+ * offline would otherwise enable its buttons for a frame.
+ *
+ * Only trustworthy when false. A browser reports online for any working link,
+ * including a captive portal that reaches nothing, so this gates the UI but is
+ * never taken as proof a request will succeed.
+ */
+export function useOnline(): boolean {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/**
+ * Persistent notice while the browser has no connection.
+ *
+ * Deliberately not a toast: the condition lasts until it is fixed, and a notice
+ * that dismisses itself after a few seconds would leave a merchant reading
+ * stale totals with no indication they are stale.
+ *
+ * Sits bottom-left so it clears the fixed nav, and stops short of the right
+ * edge on mobile so it does not sit under the floating menu button.
+ */
+export function OfflineBanner() {
+  const online = useOnline();
+  if (online) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-6 left-6 right-24 md:right-auto md:max-w-sm z-[70] flex items-start gap-3 px-4 py-3 bg-amber-50/90 dark:bg-amber-500/10 backdrop-blur-2xl border border-amber-300 dark:border-amber-400/20 text-amber-900 dark:text-amber-200 shadow-[0_8px_30px_rgba(0,0,0,0.15)] dark:shadow-[0_8px_30px_rgba(0,0,0,0.6)] transition-colors duration-300"
+    >
+      <WifiOff className="w-4 h-4 mt-0.5 shrink-0 opacity-80" />
+      <div className="space-y-1">
+        <p className="text-[10px] font-bold uppercase tracking-widest">Network disconnected</p>
+        <p className="text-sm leading-snug">{OFFLINE_MESSAGE}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/network-status.test.ts
+++ b/apps/web/src/lib/network-status.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyFailure,
+  describeFailure,
+  isAbortError,
+  isTransportError,
+  OFFLINE_MESSAGE,
+} from './network-status';
+
+/** What `fetch` rejects with when no response is received. */
+const transportError = (message: string) => new TypeError(message);
+
+/** What `AbortController.abort()` produces in a browser. */
+const abortError = () => {
+  const error = new Error('The operation was aborted.');
+  error.name = 'AbortError';
+  return error;
+};
+
+describe('isAbortError', () => {
+  it('recognises an aborted request by name, not message', () => {
+    expect(isAbortError(abortError())).toBe(true);
+    expect(isAbortError(new Error('The operation was aborted.'))).toBe(false);
+  });
+
+  it('ignores non-errors', () => {
+    expect(isAbortError('aborted')).toBe(false);
+    expect(isAbortError(null)).toBe(false);
+  });
+});
+
+describe('isTransportError', () => {
+  it('matches the per-engine wording of a failed fetch', () => {
+    expect(isTransportError(transportError('Failed to fetch'))).toBe(true);
+    expect(
+      isTransportError(transportError('NetworkError when attempting to fetch resource.')),
+    ).toBe(true);
+    expect(isTransportError(transportError('Load failed'))).toBe(true);
+  });
+
+  it('does not match an error we built from a response we did receive', () => {
+    expect(isTransportError(new Error('Error 500'))).toBe(false);
+  });
+
+  it('does not treat an abort as a transport failure', () => {
+    const aborted = new TypeError('The operation was aborted.');
+    aborted.name = 'AbortError';
+    expect(isTransportError(aborted)).toBe(false);
+  });
+});
+
+describe('classifyFailure', () => {
+  it('trusts navigator.onLine when it says offline, whatever the error was', () => {
+    expect(classifyFailure(transportError('Failed to fetch'), false)).toBe('offline');
+    expect(classifyFailure(new Error('Error 502'), false)).toBe('offline');
+  });
+
+  it('blames the service, not the connection, when a fetch dies while online', () => {
+    expect(classifyFailure(transportError('Failed to fetch'), true)).toBe('unreachable');
+  });
+
+  it('treats an error carrying a server response as a server failure', () => {
+    expect(classifyFailure(new Error('Error 500'), true)).toBe('server');
+  });
+});
+
+describe('describeFailure', () => {
+  it('gives the offline message the banner uses, so the two agree', () => {
+    expect(describeFailure(transportError('Failed to fetch'), false)).toBe(OFFLINE_MESSAGE);
+  });
+
+  it('names the RPC as a possible cause when the API cannot be reached', () => {
+    expect(describeFailure(transportError('Load failed'), true)).toMatch(/Stellar RPC/);
+  });
+
+  it('passes a server message straight through - it is the useful part', () => {
+    expect(describeFailure(new Error('merchant address not configured'), true)).toBe(
+      'merchant address not configured',
+    );
+  });
+
+  it('never surfaces the raw engine wording of a transport failure', () => {
+    expect(describeFailure(transportError('Load failed'), true)).not.toMatch(/Load failed/);
+  });
+
+  it('falls back when a server failure carries no message', () => {
+    expect(describeFailure(new Error('   '), true)).toBe('The request failed for an unknown reason.');
+    expect(describeFailure({ nope: true }, true)).toBe('The request failed for an unknown reason.');
+  });
+});

--- a/apps/web/src/lib/network-status.ts
+++ b/apps/web/src/lib/network-status.ts
@@ -1,0 +1,70 @@
+/**
+ * Why a request failed, from the browser's point of view.
+ *
+ * `offline` - the browser has no network at all. Retrying is pointless until
+ * connectivity returns, so the UI says so instead of offering a retry.
+ * `unreachable` - the request never got a response even though the browser
+ * believes it is online: the API or the Stellar RPC behind it is down, DNS is
+ * failing, or a captive portal is swallowing the request.
+ * `server` - a response came back and it was an error. The network is fine;
+ * the message from the server is the useful thing to show.
+ */
+export type FailureKind = 'offline' | 'unreachable' | 'server';
+
+/**
+ * An aborted request is not a failure - the component unmounted or the poll
+ * was superseded. Callers generally drop these before classifying, but the
+ * check lives here so no caller has to remember the DOMException name.
+ */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+/**
+ * True when `fetch` rejected instead of resolving, i.e. no response was ever
+ * received.
+ *
+ * `fetch` signals this with a plain `TypeError`, but the message differs per
+ * engine ("Failed to fetch" on Chrome, "NetworkError when attempting to fetch
+ * resource" on Firefox, "Load failed" on Safari), so the type is what we match
+ * on rather than the text. Errors we construct ourselves from a non-ok
+ * response are ordinary `Error`s and fall through as server failures.
+ */
+export function isTransportError(error: unknown): boolean {
+  return !isAbortError(error) && error instanceof TypeError;
+}
+
+/**
+ * `online` is `navigator.onLine`, which is only trustworthy when false: a
+ * browser reports online for any working link, including one that cannot reach
+ * the internet. So being offline is taken at its word, and being "online" with
+ * a transport error is reported as the service being unreachable rather than
+ * as a connection the user can fix.
+ */
+export function classifyFailure(error: unknown, online: boolean): FailureKind {
+  if (!online) return 'offline';
+  return isTransportError(error) ? 'unreachable' : 'server';
+}
+
+/** What we say when the browser has no connection. Shared with the banner. */
+export const OFFLINE_MESSAGE = 'No internet connection. Data shown may be out of date.';
+
+/**
+ * A sentence for the user, given a rejected request.
+ *
+ * The raw error text is only surfaced for server failures, where it came from
+ * our own API and describes something real. Transport rejections carry engine
+ * specific strings ("Load failed") that tell a merchant nothing.
+ */
+export function describeFailure(error: unknown, online: boolean): string {
+  switch (classifyFailure(error, online)) {
+    case 'offline':
+      return OFFLINE_MESSAGE;
+    case 'unreachable':
+      return 'Could not reach the Accensa API. It may be down, or the Stellar RPC behind it is not responding.';
+    case 'server': {
+      const message = error instanceof Error ? error.message.trim() : '';
+      return message || 'The request failed for an unknown reason.';
+    }
+  }
+}


### PR DESCRIPTION
Closes #30, closes #33.

## #33 was mostly already delivered

The toggle (`components/theme-toggle.tsx`), `next-themes` wiring, localStorage persistence, and the Tailwind dark variants all exist and predate this PR. Three of the issue's four acceptance criteria were already met.

The missing one was the system half: `layout.tsx` set `defaultTheme="dark"`, so `prefers-color-scheme` was ignored entirely. It is now `"system"`. That value applies **only** when localStorage holds no choice, so a first-time visitor gets their OS setting while an explicit pick from the toggle still wins on every later visit.

## #30 is the substance

The dashboard polls `/api/payments` every 15s and had no notion of connectivity. Losing the connection replaced a good table with an error message, and every subsequent tick re-failed against a network that was not there.

| Change | Why |
|---|---|
| `error.tsx` + `global-error.tsx` | A render throw showed a blank page; now it shows a recoverable screen. |
| `OfflineBanner` in `layout.tsx` | Mounted outside the page tree so it survives navigation and stays visible when a page-level boundary has taken over the content area. |
| `online` as a polling **dependency** | Polling stops while disconnected instead of failing on a loop, and reconnecting re-runs the effect immediately rather than waiting out the rest of a 15s tick. |
| Re-read `navigator.onLine` at failure time | The connection can drop between a request going out and it failing. Closing over a stale `online` would misreport exactly the case worth naming correctly. |
| `Sync now` disabled while offline | Letting the POST fail would burn the **server-side** cooldown on a request that never left the browser — the merchant would then be told to wait before retrying something that never ran. |

## Verification

- `pnpm test` in `apps/web`: **110 passing**, 8 files, including 13 new tests in `lib/network-status.test.ts`.
- `pnpm exec tsc --noEmit`: clean.
- `pnpm lint`: clean apart from one pre-existing unused-var warning in `api/sync/route.ts`, untouched here.

Rebased on `main` after #72 and #73, so this sits on top of the extracted `Footer` and `PageContainer`.