### PR TITLE
feat(web): export payment history as CSV, document the deploy topology

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,136 @@
+# Deployment topology
+
+How the deployed pieces fit together, and the traps that have actually cost time
+here. No credentials appear in this file, and none should be added to it.
+
+## The shape of it
+
+```
+                    GitHub Actions (sync.yml)
+                    scheduled every 5 min
+                             │
+                             │ POST /api/sync
+                             │ Authorization: CRON_SECRET
+                             ▼
+  browser ──────▶  Vercel project `web`  ──────▶  Supabase Postgres
+                   (Next.js, apps/web)     pooler   payments, sync_state
+                             │
+                             │ Soroban RPC (read-only)
+                             ▼
+                   Stellar testnet
+                   ReceiptAnchor · RefundVault
+```
+
+Three moving parts, and only one of them is Vercel's:
+
+- **`web`** — the Next.js app in `apps/web`. Serves the dashboard, the verifier,
+  and the API routes. Aliased to `accensa-dashboard.vercel.app`.
+- **Supabase Postgres** — holds `payments` (indexed chain data) and `sync_state`
+  (the indexer's ledger cursor). Schema is created on first request; see
+  `db-setup.md`.
+- **GitHub Actions** — the real indexing cadence. Explained below, because the
+  `vercel.json` cron is misleading on its own.
+
+There is a second Vercel project, `docs`, serving `accensa-docs.vercel.app` from
+`apps/docs`. It shares nothing with `web` but the repo.
+
+## Indexing cadence — read this before trusting `vercel.json`
+
+`apps/web/vercel.json` declares a **daily** cron. That is not the real cadence,
+and it is not a design choice:
+
+> On the Vercel Hobby plan, declaring more than one cron run per day is a **hard
+> deploy failure**, not a silent clamp. The deploy is rejected.
+
+So the schedule that matters lives in `.github/workflows/sync.yml`, which hits
+`/api/sync` every 5 minutes. GitHub throttles high-frequency scheduled workflows,
+so in practice it lands **every one to three hours**. `apps/web/src/lib/sync-status.ts`
+sets its staleness thresholds from that observed behaviour rather than from the
+declared schedule, so a normal gap is not reported to the merchant as a fault.
+
+If you move off Hobby, raise the `vercel.json` cron and retire the Actions
+workflow — do not run both, or the cursor gets contention from two writers.
+
+## Database connection
+
+Use the **Session pooler** connection string, not Direct.
+
+Direct is IPv6-only. Vercel Functions have no IPv6 route, so a Direct URL
+produces connection timeouts that look like a database outage and are not.
+
+The pooler host looks like `aws-1-<region>.pooler.supabase.com`.
+
+## Environment variables
+
+| Variable | Where | What it does |
+|---|---|---|
+| `DATABASE_URL` | Vercel (`web`) | Supabase **session pooler** connection string. |
+| `CRON_SECRET` | Vercel (`web`) + GitHub secret | Shared by `/api/sync` and `sync.yml`. Anonymous callers get `{"error":"Unauthorized"}`. |
+| `SYNC_URL` | GitHub secret | The `/api/sync` endpoint the workflow posts to. |
+| `HOOK_API_KEY` | Vercel (`web`) | Gates `/api/hook/settle`. **Absent means the endpoint fails closed**, not open. |
+| `NEXT_PUBLIC_REFUND_VAULT_ID` | Vercel (`web`), optional | Overrides the built-in RefundVault contract id. |
+
+Set them per environment (`production`, `preview`, `development`) — Vercel does
+not share values across them.
+
+### `vercel env add` will silently store an empty value
+
+Agent and CI shells default to `--non-interactive`, and piping to stdin in that
+mode stores **nothing** without erroring:
+
+```bash
+vercel env add DATABASE_URL production --value "$CONNECTION_STRING"   # correct
+echo "$CONNECTION_STRING" | vercel env add DATABASE_URL production    # stores empty
+```
+
+`vercel env ls` listing the key proves the key exists. It proves nothing about
+its contents.
+
+Vercel also marks new variables **sensitive** by default, and `vercel env pull`
+returns sensitive values blank *by design* — a blank in your local pull is not
+evidence the remote value is blank. Use `--no-sensitive` for non-secrets if you
+want to read them back.
+
+## Deploying
+
+Two steps, not one:
+
+```bash
+git checkout main && git pull
+vercel deploy --prod
+vercel alias set <new-deployment-url> accensa-dashboard.vercel.app
+```
+
+**`--prod` alone does not move the alias.** `accensa-dashboard.vercel.app` is
+assigned manually, so a production deploy leaves it pointing at the previous
+build and the live site looks unchanged. This has caught people more than once.
+
+Environment variables apply to **new builds only**. Changing one requires a
+redeploy before it takes effect.
+
+The repo root `.vercel/project.json` is linked to project `web`; that link is
+what makes monorepo deploys resolve correctly from the root.
+
+## Verifying a deploy
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://accensa-dashboard.vercel.app/
+curl -s -o /dev/null -w "%{http_code}\n" https://accensa-dashboard.vercel.app/dashboard
+curl -s -o /dev/null -w "%{http_code}\n" https://accensa-dashboard.vercel.app/verify
+curl -s -o /dev/null -w "%{http_code}\n" https://accensa-dashboard.vercel.app/batches/1
+curl -s -o /dev/null -w "%{http_code}\n" https://accensa-dashboard.vercel.app/batches/999  # expect 404
+curl -s https://accensa-dashboard.vercel.app/api/sync                                      # expect Unauthorized
+```
+
+The `/batches/999` 404 and the `/api/sync` rejection are the two that catch a
+half-configured deploy — a 200 from either means something is wrong.
+
+## Rotating the database password
+
+```
+Supabase → Settings → Database → Reset database password
+```
+
+Then update `DATABASE_URL` in every Vercel environment that uses it and
+redeploy, since env changes only reach new builds. Take the **session pooler**
+string, per the IPv6 note above.

--- a/README.md
+++ b/README.md
@@ -192,4 +192,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Security policy in [SECURITY.md](SECURIT
 
 MIT — see [LICENSE](LICENSE).
 ## Setup
-See [db-setup.md](db-setup.md) for database setup instructions.
+See [db-setup.md](db-setup.md) for database setup instructions, and
+[DEPLOYMENT.md](DEPLOYMENT.md) for the deployed topology — how Vercel, Supabase,
+and the GitHub Actions indexer fit together, which environment variables live
+where, and the traps that have cost time here (the alias that `--prod` does not
+move, the Hobby cron limit, and the IPv6-only Direct connection string).

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { formatAmount, sumAmounts, assetLabel } from '@/lib/money';
 import { describeSync, type SyncState } from '@/lib/sync-status';
+import { CSV_BOM, paymentsCsvFilename, paymentsToCsv } from '@/lib/payments-csv';
 import { ArrowUpRight } from 'lucide-react';
 import { PageContainer } from '@/components/page-container';
 import { useOnline } from '@/components/network-status';
@@ -121,6 +122,7 @@ export default function Dashboard() {
  <h2 className="text-xl font-black tracking-tight text-slate-900 dark:text-white transition-colors duration-300">Recent Settlements</h2>
  <div className="flex items-center gap-4">
  <StatusPill state={state} onRetry={reload} />
+ <ExportCsvButton payments={payments} />
  <SyncNowButton onSynced={reload} />
  </div>
  </div>
@@ -467,6 +469,64 @@ function SyncNowButton({ onSynced }: { onSynced: () => void }) {
  }`}
  >
  <span aria-live="polite">{label}</span>
+ </button>
+ );
+}
+
+/**
+ * Downloads the payment history the table is showing as a CSV file.
+ *
+ * Exports what is on screen rather than re-fetching: /api/payments is already
+ * the whole set the dashboard has (newest 100), and re-requesting would mean
+ * the file could disagree with the rows the merchant was looking at.
+ *
+ * Serialization lives in lib/payments-csv so it can be tested without a DOM;
+ * this only turns the text into a download.
+ */
+function ExportCsvButton({ payments }: { payments: Payment[] }) {
+ const [error, setError] = useState<string | null>(null);
+
+ const download = useCallback(() => {
+ try {
+ // The BOM is what makes Excel read the file as UTF-8.
+ const blob = new Blob([CSV_BOM + paymentsToCsv(payments)], {
+ type: 'text/csv;charset=utf-8',
+ });
+ const url = URL.createObjectURL(blob);
+ const link = document.createElement('a');
+ link.href = url;
+ link.download = paymentsCsvFilename();
+ link.click();
+ // Safari needs the click to have been dispatched before the object URL
+ // goes away, so revoke on the next frame rather than immediately.
+ requestAnimationFrame(() => URL.revokeObjectURL(url));
+ setError(null);
+ } catch (e) {
+ setError(e instanceof Error ? e.message : 'Export failed');
+ }
+ }, [payments]);
+
+ const empty = payments.length === 0;
+
+ return (
+ <button
+ type="button"
+ onClick={download}
+ disabled={empty}
+ title={
+ error
+ ? error
+ : empty
+ ? 'Nothing to export yet'
+ : `Download these ${payments.length} payment${payments.length === 1 ? '' : 's'} as CSV`
+ }
+ className={`px-3 py-2 text-[10px] font-bold uppercase tracking-widest border transition-colors cursor-pointer disabled:cursor-not-allowed ${
+ error
+ ? 'border-red-200 dark:border-red-500/20 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10'
+ : 'border-slate-200 dark:border-white/10 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/5 disabled:opacity-50 disabled:hover:bg-transparent'
+ }`}
+ >
+ <span aria-live="polite">{error ? 'Export failed' : 'Export CSV'}</span>
  </button>
  );
 }

--- a/apps/web/src/lib/payments-csv.test.ts
+++ b/apps/web/src/lib/payments-csv.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CSV_BOM,
+  escapeCsvField,
+  paymentsCsvFilename,
+  paymentsToCsv,
+  toCsvRow,
+  type CsvPayment,
+} from './payments-csv';
+
+const payment = (over: Partial<CsvPayment> = {}): CsvPayment => ({
+  tx_hash: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b',
+  ledger: 12_847_294,
+  payer: 'GD4C3LWGIXNDWC3G2UTIKXA4TN2KCBOCP5G6R6YT6WBHVDEP4D4GRMK4',
+  amount: '8.2500000',
+  asset: 'native',
+  ts: '2026-07-13T10:00:00.000Z',
+  route: '/api/data',
+  method: 'GET',
+  ...over,
+});
+
+/** Splits on record separators, dropping the trailing empty line. */
+const lines = (csv: string) => csv.split('\r\n').slice(0, -1);
+
+describe('escapeCsvField', () => {
+  it('leaves a plain value alone', () => {
+    expect(escapeCsvField('/api/data')).toBe('/api/data');
+  });
+
+  it('quotes a value containing the delimiter', () => {
+    expect(escapeCsvField('/api/a,b')).toBe('"/api/a,b"');
+  });
+
+  it('doubles embedded quotes', () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it('quotes newlines so one field cannot become two records', () => {
+    expect(escapeCsvField('/api\nnext')).toBe('"/api\nnext"');
+    expect(escapeCsvField('/api\r\nnext')).toBe('"/api\r\nnext"');
+  });
+
+  it('quotes surrounding whitespace a reader would otherwise strip', () => {
+    expect(escapeCsvField(' padded ')).toBe('" padded "');
+  });
+
+  it('passes an empty string through unquoted', () => {
+    expect(escapeCsvField('')).toBe('');
+  });
+});
+
+describe('toCsvRow', () => {
+  it('escapes each cell independently', () => {
+    expect(toCsvRow(['a', 'b,c', 'd"e'])).toBe('a,"b,c","d""e"');
+  });
+});
+
+describe('paymentsToCsv', () => {
+  it('emits the header even for an empty set', () => {
+    const csv = paymentsToCsv([]);
+    expect(lines(csv)).toEqual([
+      'Transaction Hash,Timestamp,Amount,Asset,Asset Identifier,Payer,Route,Method,Ledger',
+    ]);
+  });
+
+  it('terminates every record, including the last', () => {
+    expect(paymentsToCsv([payment()]).endsWith('\r\n')).toBe(true);
+  });
+
+  it('writes the amount verbatim, with no grouping or rounding', () => {
+    const csv = paymentsToCsv([payment({ amount: '1234567.8900000' })]);
+    expect(lines(csv)[1].split(',')[2]).toBe('1234567.8900000');
+  });
+
+  it('preserves a single stroop, which a float round trip would not', () => {
+    const csv = paymentsToCsv([payment({ amount: '0.0000001' })]);
+    expect(lines(csv)[1].split(',')[2]).toBe('0.0000001');
+  });
+
+  it('preserves amounts beyond Number.MAX_SAFE_INTEGER', () => {
+    const huge = '9007199254740993.0000000';
+    const csv = paymentsToCsv([payment({ amount: huge })]);
+    expect(lines(csv)[1].split(',')[2]).toBe(huge);
+    // The value a Number round trip would have written instead.
+    expect(String(Number(huge))).not.toBe(huge);
+  });
+
+  it('keeps a negative amount numeric rather than defusing it as a formula', () => {
+    const csv = paymentsToCsv([payment({ amount: '-2.5000000' })]);
+    expect(lines(csv)[1].split(',')[2]).toBe('-2.5000000');
+  });
+
+  it('escapes a route containing commas, quotes and newlines', () => {
+    const csv = paymentsToCsv([payment({ route: '/api/a,b "c"\nd' })]);
+    expect(lines(csv)[1]).toContain('"/api/a,b ""c""\nd"');
+    // Still two logical records: header plus one payment.
+    expect(lines(csv)).toHaveLength(2);
+  });
+
+  it('defuses a route that a spreadsheet would evaluate as a formula', () => {
+    const csv = paymentsToCsv([payment({ route: '=HYPERLINK("http://evil","x")' })]);
+    expect(csv).toContain(`"'=HYPERLINK(""http://evil"",""x"")"`);
+  });
+
+  it('preserves unicode routes untouched', () => {
+    const csv = paymentsToCsv([payment({ route: '/api/데이터/日本語/émoji-🚀' })]);
+    expect(csv).toContain('/api/데이터/日本語/émoji-🚀');
+  });
+
+  it('labels the asset and keeps the full identifier alongside it', () => {
+    const usdc = 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+    const cells = lines(paymentsToCsv([payment({ asset: usdc })]))[1].split(',');
+    expect(cells[3]).toBe('USDC');
+    expect(cells[4]).toBe(usdc);
+  });
+
+  it('reports a null asset as native XLM', () => {
+    const cells = lines(paymentsToCsv([payment({ asset: null })]))[1].split(',');
+    expect(cells[3]).toBe('XLM');
+    expect(cells[4]).toBe('native');
+  });
+
+  it('writes unattributed and unindexed fields as empty cells, not "null"', () => {
+    const cells = lines(
+      paymentsToCsv([payment({ route: null, method: null, ledger: null })]),
+    )[1].split(',');
+    expect(cells[6]).toBe('');
+    expect(cells[7]).toBe('');
+    expect(cells[8]).toBe('');
+  });
+
+  it('keeps row order and count for a realistic ledger', () => {
+    const csv = paymentsToCsv([
+      payment({ tx_hash: 'aaa', amount: '8.2500000' }),
+      payment({ tx_hash: 'bbb', amount: '3.7500000' }),
+    ]);
+    const rows = lines(csv);
+    expect(rows).toHaveLength(3);
+    expect(rows[1].startsWith('aaa,')).toBe(true);
+    expect(rows[2].startsWith('bbb,')).toBe(true);
+  });
+});
+
+describe('CSV_BOM', () => {
+  it('is the single UTF-8 BOM code point Excel looks for', () => {
+    expect(CSV_BOM).toBe('﻿');
+    expect(CSV_BOM).toHaveLength(1);
+  });
+});
+
+describe('paymentsCsvFilename', () => {
+  it('dates the file from the local calendar day', () => {
+    // Constructed from local parts so the assertion holds in any timezone.
+    expect(paymentsCsvFilename(new Date(2026, 7, 6, 12, 0, 0))).toBe(
+      'accensa_payments_2026-08-06.csv',
+    );
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    expect(paymentsCsvFilename(new Date(2026, 0, 9, 12, 0, 0))).toBe(
+      'accensa_payments_2026-01-09.csv',
+    );
+  });
+});

--- a/apps/web/src/lib/payments-csv.ts
+++ b/apps/web/src/lib/payments-csv.ts
@@ -1,0 +1,122 @@
+/**
+ * CSV serialization for the payment history export.
+ *
+ * Merchants take this straight into a spreadsheet or a bookkeeping import, so
+ * two things matter more than anything else here:
+ *
+ * 1. Amounts are written as the exact decimal string the API returned. They are
+ *    never parsed, rounded, or grouped - see lib/money.ts. `formatAmount` is for
+ *    display only: its thousands separators would break a numeric column, and a
+ *    round trip through Number would lose stroops.
+ * 2. Nothing here trusts field contents. Routes arrive from merchant middleware
+ *    via /api/hook/settle, so they can hold commas, quotes, newlines, or a
+ *    leading `=` that a spreadsheet would evaluate as a formula.
+ *
+ * Pure string work, no DOM - the browser-side download lives in the dashboard.
+ */
+
+import { assetLabel } from './money';
+
+export interface CsvPayment {
+  tx_hash: string;
+  ledger: number | null;
+  payer: string;
+  /** Decimal string. Written through verbatim. */
+  amount: string;
+  asset: string | null;
+  ts: string;
+  route: string | null;
+  method: string | null;
+}
+
+/** RFC 4180 says CRLF; Excel is the consumer that actually cares. */
+const ROW_SEPARATOR = '\r\n';
+
+/**
+ * Byte order mark.
+ *
+ * Excel on Windows reads a BOM-less file as the system codepage, which turns
+ * every non-ASCII route into mojibake. Callers writing a file should prepend it.
+ */
+export const CSV_BOM = '﻿';
+
+const HEADERS = [
+  'Transaction Hash',
+  'Timestamp',
+  'Amount',
+  'Asset',
+  'Asset Identifier',
+  'Payer',
+  'Route',
+  'Method',
+  'Ledger',
+];
+
+/** Characters that make a spreadsheet treat a cell as a formula. */
+const FORMULA_PREFIX = /^[=+\-@\t\r]/;
+
+/**
+ * Defuses a cell that a spreadsheet would evaluate.
+ *
+ * Only applied to free-text fields. Numeric columns are left alone, because a
+ * negative amount legitimately starts with `-` and has to stay a number.
+ */
+function neutralizeFormula(value: string): string {
+  return FORMULA_PREFIX.test(value) ? `'${value}` : value;
+}
+
+/**
+ * Quotes a field per RFC 4180.
+ *
+ * Quoted when the value contains a delimiter, a quote, or a line break, and
+ * also when it carries surrounding whitespace a reader would be free to strip.
+ */
+export function escapeCsvField(value: string): string {
+  const needsQuotes = /[",\r\n]/.test(value) || value !== value.trim();
+  if (!needsQuotes) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/** Joins one row of already-stringified cells. */
+export function toCsvRow(cells: string[]): string {
+  return cells.map(escapeCsvField).join(',');
+}
+
+/**
+ * Serializes payments to CSV text, header row included.
+ *
+ * An empty set still returns the header, so the download is a valid CSV with
+ * named columns rather than a zero-byte file that reads as a failure.
+ */
+export function paymentsToCsv(payments: readonly CsvPayment[]): string {
+  const rows = payments.map((payment) =>
+    toCsvRow([
+      neutralizeFormula(payment.tx_hash),
+      payment.ts,
+      // Verbatim. No Number, no formatAmount.
+      payment.amount,
+      assetLabel(payment.asset),
+      neutralizeFormula(payment.asset ?? 'native'),
+      neutralizeFormula(payment.payer),
+      neutralizeFormula(payment.route ?? ''),
+      neutralizeFormula(payment.method ?? ''),
+      payment.ledger === null ? '' : String(payment.ledger),
+    ]),
+  );
+
+  // Trailing separator so appending to the file cannot merge two records.
+  return [toCsvRow(HEADERS), ...rows].join(ROW_SEPARATOR) + ROW_SEPARATOR;
+}
+
+/**
+ * `accensa_payments_2026-08-06.csv`.
+ *
+ * Dated in the viewer's own timezone, because the merchant filing the export
+ * thinks in their local day, not UTC.
+ */
+export function paymentsCsvFilename(now: Date = new Date()): string {
+  const year = String(now.getFullYear()).padStart(4, '0');
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `accensa_payments_${year}-${month}-${day}.csv`;
+}


### PR DESCRIPTION
Closes #39, closes #19.

## #39 — CSV export

Merchants take this straight into a spreadsheet or a bookkeeping import, so the serializer is stricter than a naive join:

**Amounts are written verbatim.** The exact decimal string the API returned — never parsed, rounded, or grouped. `formatAmount` is display-only: its thousands separators would break a numeric column, and a round trip through `Number` would lose stroops. This follows the repo's existing rule that money never touches a float.

**Field contents are untrusted.** Routes and payers arrive from merchant middleware via `/api/hook/settle`, so they can hold commas, quotes, newlines — or a leading `=`. Fields are quoted per RFC 4180, and a leading `=`, `+`, `-`, `@`, or tab is prefixed so a spreadsheet cannot evaluate the cell as a formula. Numeric columns are deliberately exempt: a negative amount legitimately starts with a minus and has to stay a number.

**A UTF-8 BOM is prepended.** Without it Excel on Windows reads the file as the system codepage and turns every non-ASCII route into mojibake.

**An empty set still emits the header row**, so the download is a valid CSV with named columns rather than a zero-byte file that reads as a failure.

The button exports what the table is currently showing rather than re-fetching — `/api/payments` is already the whole set the dashboard holds, and re-requesting would let the file disagree with the rows the merchant was looking at.

Serialization lives in `lib/payments-csv.ts` with no DOM dependency, so it is unit-testable; the component only turns the text into a download.

## #19 — deployment topology

`DEPLOYMENT.md` documents how Vercel, Supabase, and the GitHub Actions indexer fit together, and which environment variables live where. **Names only — no credential values.**

The useful half is the traps, all of which have cost real time here:

- **`vercel deploy --prod` does not move the alias.** `accensa-dashboard.vercel.app` is assigned manually, so a production deploy leaves it on the previous build and the live site looks unchanged.
- **The Hobby plan makes a second daily cron a hard deploy failure**, not a silent clamp. That is why `vercel.json` says daily while the real cadence comes from `sync.yml` — and why `sync-status.ts` calibrates staleness against the observed one-to-three-hour landing rate rather than the declared schedule.
- **Supabase Direct is IPv6-only** and Vercel Functions have no IPv6 route, so a Direct URL produces timeouts that look like a database outage. Use the session pooler.
- **`vercel env add` silently stores an empty value** when stdin is piped in non-interactive mode, and `vercel env ls` will happily list the key regardless. Use `--value`.

Linked from the README next to `db-setup.md`.

## Verification

- `pnpm test` in `apps/web`: **153 passing**, 10 files.
- `pnpm exec tsc --noEmit`: clean.
- `pnpm lint`: no errors (two pre-existing unused-var warnings in `api/hook/settle/route.ts`, untouched here).

Rebased onto current `main`, so it sits on top of #77's offline work.