### PR TITLE
feat(web): route-level revenue breakdown and revenue-over-time chart

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { formatAmount, sumAmounts, assetLabel } from '@/lib/money';
 import { describeSync, type SyncState } from '@/lib/sync-status';
 import { CSV_BOM, paymentsCsvFilename, paymentsToCsv } from '@/lib/payments-csv';
+import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 import { PageContainer } from '@/components/page-container';
 import { useOnline } from '@/components/network-status';
@@ -97,6 +98,12 @@ export default function Dashboard() {
  <div>
  <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-3">Dashboard</p>
  <h1 className="text-4xl sm:text-5xl md:text-6xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">Settled Volume</h1>
+ <Link
+ href="/dashboard/routes"
+ className="inline-block mt-4 text-xs font-bold uppercase tracking-widest text-slate-500 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+ >
+ Revenue by route →
+ </Link>
  </div>
  </div>
  

--- a/apps/web/src/app/dashboard/routes/page.tsx
+++ b/apps/web/src/app/dashboard/routes/page.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { formatAmount, assetLabel } from '@/lib/money';
+import { PageContainer } from '@/components/page-container';
+import { useOnline } from '@/components/network-status';
+import { describeFailure, isAbortError } from '@/lib/network-status';
+import { RevenueChart } from '@/components/revenue-chart';
+import {
+ assetOptions,
+ buildRevenueSeries,
+ buildRouteBreakdown,
+ UNATTRIBUTED_LABEL,
+ type RangeKey,
+ type RevenuePayment,
+ type RouteBucket,
+} from '@/lib/revenue-analytics';
+
+/**
+ * Route-level revenue.
+ *
+ * The honest framing this page has to hold on to: the ledger says how much was
+ * paid, and the merchant's own server says which endpoint was bought. Those are
+ * different provenances with different trust, and a payment can have the first
+ * without the second. Every total below therefore appears twice — once for all
+ * revenue in the asset, once for the part Path B can actually explain — and the
+ * unattributed remainder is shown rather than quietly excluded.
+ */
+
+const RANGES: { key: RangeKey; label: string }[] = [
+ { key: '7d', label: '7 days' },
+ { key: '30d', label: '30 days' },
+ { key: 'all', label: 'All time' },
+];
+
+const EMPTY: RevenuePayment[] = [];
+
+type LoadState =
+ | { status: 'loading' }
+ | { status: 'ready'; payments: RevenuePayment[] }
+ | { status: 'error'; message: string };
+
+export default function RoutesPage() {
+ const [state, setState] = useState<LoadState>({ status: 'loading' });
+ const [asset, setAsset] = useState<string | null>(null);
+ const [range, setRange] = useState<RangeKey>('30d');
+ const online = useOnline();
+
+ useEffect(() => {
+ if (!online) return;
+ const controller = new AbortController();
+ (async () => {
+ try {
+ const res = await fetch('/api/payments', { signal: controller.signal });
+ if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+ const data = await res.json();
+ if (!controller.signal.aborted) {
+ setState({ status: 'ready', payments: data.payments ?? [] });
+ }
+ } catch (error) {
+ if (!controller.signal.aborted && !isAbortError(error)) {
+ setState({ status: 'error', message: describeFailure(error, navigator.onLine) });
+ }
+ }
+ })();
+ return () => controller.abort();
+ }, [online]);
+
+ // Memoised so the identity is stable: the literal `[]` on the loading and
+ // error branches would otherwise be a fresh array on every render, and each
+ // aggregation below would recompute for nothing.
+ const payments = useMemo(
+ () => (state.status === 'ready' ? state.payments : EMPTY),
+ [state],
+ );
+ const assets = useMemo(() => assetOptions(payments), [payments]);
+
+ // Default to whichever asset the merchant actually earns in, once known.
+ const selectedAsset = asset ?? assets[0]?.key ?? null;
+
+ const breakdown = useMemo(
+ () => (selectedAsset ? buildRouteBreakdown(payments, selectedAsset) : null),
+ [payments, selectedAsset],
+ );
+ const series = useMemo(
+ () => (selectedAsset ? buildRevenueSeries(payments, { asset: selectedAsset, range }) : null),
+ [payments, selectedAsset, range],
+ );
+
+ return (
+ <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32">
+ <PageContainer className="space-y-12">
+ <header className="space-y-6">
+ <div className="flex flex-wrap items-end justify-between gap-6">
+ <div>
+ <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs mb-3">
+ Analytics
+ </p>
+ <h1 className="text-4xl sm:text-5xl md:text-6xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
+ Revenue by Route
+ </h1>
+ </div>
+ <Link
+ href="/dashboard"
+ className="text-xs font-bold uppercase tracking-widest text-slate-500 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+ >
+ ← Settlements
+ </Link>
+ </div>
+
+ <p className="text-slate-600 dark:text-slate-400 leading-relaxed max-w-2xl">
+ Amounts come from the ledger. Routes come from your server, reported at settlement
+ through the SDK — the chain records a transfer, not an endpoint. Revenue with no
+ route is shown separately rather than folded in.
+ </p>
+ </header>
+
+ {state.status === 'error' && (
+ <p className="text-sm text-red-600 dark:text-red-400 border border-red-200 dark:border-red-500/20 p-4">
+ {state.message}
+ </p>
+ )}
+
+ {state.status === 'ready' && assets.length === 0 && (
+ <p className="text-sm text-slate-500 dark:text-slate-400 py-12">
+ No settled payments indexed yet.
+ </p>
+ )}
+
+ {selectedAsset && breakdown && series && (
+ <>
+ <div className="flex flex-wrap items-center gap-3">
+ {assets.length > 1 && (
+ <Segmented
+ options={assets.map((a) => ({ key: a.key, label: `${a.label} (${a.calls})` }))}
+ value={selectedAsset}
+ onChange={setAsset}
+ />
+ )}
+ <Segmented
+ options={RANGES.map((r) => ({ key: r.key, label: r.label }))}
+ value={range}
+ onChange={(next) => setRange(next as RangeKey)}
+ />
+ </div>
+
+ <section className="grid sm:grid-cols-3 gap-6">
+ <Stat
+ label="Total settled"
+ value={`${formatAmount(breakdown.total)} ${assetLabel(selectedAsset)}`}
+ note={`${breakdown.calls} payment${breakdown.calls === 1 ? '' : 's'}`}
+ />
+ <Stat
+ label="Attributed to a route"
+ value={`${formatAmount(breakdown.attributedTotal)} ${assetLabel(selectedAsset)}`}
+ note={`${breakdown.attributedCalls} of ${breakdown.calls}`}
+ />
+ <Stat
+ label="No attribution"
+ value={`${formatAmount(breakdown.unattributedTotal)} ${assetLabel(selectedAsset)}`}
+ note={
+ breakdown.unattributedCalls === 0
+ ? 'Every payment is explained'
+ : 'Real transfers, unknown endpoint'
+ }
+ />
+ </section>
+
+ <section className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl p-6 md:p-8 transition-colors duration-300">
+ <h2 className="text-xl font-black tracking-tight text-slate-900 dark:text-white mb-6">
+ Over time
+ </h2>
+ <RevenueChart series={series} />
+ {series.unpricedCalls > 0 && (
+ <p className="text-xs text-slate-500 dark:text-slate-400 mt-4">
+ {series.unpricedCalls} payment{series.unpricedCalls === 1 ? '' : 's'} in range had an
+ unreadable amount and {series.unpricedCalls === 1 ? 'was' : 'were'} counted but not
+ summed.
+ </p>
+ )}
+ </section>
+
+ <section className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl p-6 md:p-8 transition-colors duration-300">
+ <h2 className="text-xl font-black tracking-tight text-slate-900 dark:text-white mb-6">
+ By route
+ </h2>
+ <RouteTable breakdown={breakdown} asset={selectedAsset} />
+ </section>
+ </>
+ )}
+ </PageContainer>
+ </main>
+ );
+}
+
+function RouteTable({
+ breakdown,
+ asset,
+}: {
+ breakdown: NonNullable<ReturnType<typeof buildRouteBreakdown>>;
+ asset: string;
+}) {
+ const rows: RouteBucket[] = [
+ ...breakdown.routes,
+ ...(breakdown.unattributed ? [breakdown.unattributed] : []),
+ ];
+
+ if (rows.length === 0) {
+ return <p className="text-sm text-slate-500 dark:text-slate-400">Nothing to break down yet.</p>;
+ }
+
+ return (
+ <div className="overflow-x-auto">
+ <table className="w-full text-sm">
+ <thead>
+ <tr className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 text-left">
+ <th className="pb-3 pr-4">Route</th>
+ <th className="pb-3 pr-4 text-right">Calls</th>
+ <th className="pb-3 pr-4 text-right">Revenue</th>
+ <th className="pb-3 pr-4 text-right">Average</th>
+ <th className="pb-3 w-1/4">Share</th>
+ </tr>
+ </thead>
+ <tbody>
+ {rows.map((row) => (
+ <tr
+ key={row.key}
+ className="border-t border-slate-100 dark:border-white/5 transition-colors duration-300"
+ >
+ <td className="py-3 pr-4">
+ {row.attributed ? (
+ <span className="font-mono text-slate-900 dark:text-white break-all">
+ <span className="text-emerald-600 dark:text-emerald-400 mr-2">{row.method}</span>
+ {row.route}
+ </span>
+ ) : (
+ <span
+ className="text-slate-500 dark:text-slate-400 italic"
+ title="Chain-indexed transfers your server never reported a route for. Real revenue; unknown endpoint."
+ >
+ {UNATTRIBUTED_LABEL}
+ </span>
+ )}
+ </td>
+ <td className="py-3 pr-4 text-right tabular-nums text-slate-600 dark:text-slate-300">
+ {row.calls}
+ {row.unpriced > 0 && (
+ <span
+ className="text-slate-400 dark:text-slate-500"
+ title={`${row.unpriced} had an unreadable amount and were not summed`}
+ >
+ {' '}
+ ({row.unpriced} unpriced)
+ </span>
+ )}
+ </td>
+ <td className="py-3 pr-4 text-right tabular-nums text-slate-900 dark:text-white font-medium">
+ {formatAmount(row.total)} {assetLabel(asset)}
+ </td>
+ <td className="py-3 pr-4 text-right tabular-nums text-slate-600 dark:text-slate-300">
+ {row.average === null ? '—' : formatAmount(row.average)}
+ </td>
+ <td className="py-3">
+ <span className="sr-only">{Math.round(row.share * 100)}%</span>
+ <span
+ aria-hidden
+ className="block h-2 bg-slate-100 dark:bg-white/5"
+ title={`${Math.round(row.share * 100)}% of settled revenue in this asset`}
+ >
+ <span
+ className={`block h-2 ${
+ row.attributed
+ ? 'bg-emerald-500/80 dark:bg-emerald-400/70'
+ : 'bg-slate-300 dark:bg-white/20'
+ }`}
+ style={{ width: `${Math.max(row.share * 100, row.total === '0' ? 0 : 1)}%` }}
+ />
+ </span>
+ </td>
+ </tr>
+ ))}
+ </tbody>
+ </table>
+ </div>
+ );
+}
+
+function Stat({ label, value, note }: { label: string; value: string; note: string }) {
+ return (
+ <div className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl p-6 transition-colors duration-300">
+ <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-2">
+ {label}
+ </p>
+ <p className="text-2xl font-black tracking-tight text-slate-900 dark:text-white tabular-nums">
+ {value}
+ </p>
+ <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{note}</p>
+ </div>
+ );
+}
+
+function Segmented({
+ options,
+ value,
+ onChange,
+}: {
+ options: { key: string; label: string }[];
+ value: string;
+ onChange: (next: string) => void;
+}) {
+ return (
+ <div className="inline-flex border border-slate-200 dark:border-white/10">
+ {options.map((option) => (
+ <button
+ key={option.key}
+ type="button"
+ onClick={() => onChange(option.key)}
+ aria-pressed={option.key === value}
+ className={`px-3 py-2 text-[10px] font-bold uppercase tracking-widest transition-colors cursor-pointer ${
+ option.key === value
+ ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300'
+ : 'text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-white/5'
+ }`}
+ >
+ {option.label}
+ </button>
+ ))}
+ </div>
+ );
+}

--- a/apps/web/src/components/revenue-chart.tsx
+++ b/apps/web/src/components/revenue-chart.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { formatAmount, assetLabel } from '@/lib/money';
+import type { RevenueSeries } from '@/lib/revenue-analytics';
+
+/**
+ * Revenue over time, as stacked bars.
+ *
+ * Inline SVG rather than a charting library: the repo takes no new runtime
+ * dependency for this, and a stacked bar chart with a fixed bucket count is a
+ * few lines of arithmetic the aggregation layer has already done.
+ *
+ * Every bar is split into two segments, and the split is the point of the
+ * chart. The lower segment is revenue whose route the merchant's own server
+ * reported; the upper segment is revenue the ledger recorded but nothing
+ * explains. Drawing one total bar would imply the whole figure is attributed,
+ * which is the specific claim this product is not allowed to make loosely.
+ */
+
+const VIEW_W = 1000;
+const VIEW_H = 260;
+const PAD_BOTTOM = 28;
+const PAD_TOP = 8;
+const PLOT_H = VIEW_H - PAD_BOTTOM - PAD_TOP;
+
+export function RevenueChart({ series }: { series: RevenueSeries }) {
+ const { buckets } = series;
+ if (buckets.length === 0) {
+ return (
+ <p className="text-sm text-slate-500 dark:text-slate-400 py-12 text-center">
+ No settled payments in this range.
+ </p>
+ );
+ }
+
+ const slot = VIEW_W / buckets.length;
+ // Leave a gap between bars, but never let a dense range collapse them to
+ // slivers thinner than a hairline.
+ const barW = Math.max(1, Math.min(slot * 0.62, 56));
+ const asset = assetLabel(series.asset);
+
+ // Label every bar when there is room, otherwise thin them out so the axis
+ // stays readable instead of turning into a smear.
+ const labelEvery = Math.ceil(buckets.length / 12);
+
+ return (
+ <figure className="w-full">
+ <figcaption className="sr-only">
+ Revenue per {series.granularity === 'week' ? 'week' : 'day'} in {asset}, split into
+ attributed and unattributed.
+ </figcaption>
+
+ <div className="overflow-x-auto">
+ <svg
+ viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+ className="w-full min-w-[520px] h-[260px]"
+ role="img"
+ aria-label={`Revenue per ${series.granularity}. Total ${series.total} ${asset}, of which ${series.attributedTotal} is attributed to a route.`}
+ >
+ {/* Baseline */}
+ <line
+ x1={0}
+ y1={PAD_TOP + PLOT_H}
+ x2={VIEW_W}
+ y2={PAD_TOP + PLOT_H}
+ className="stroke-slate-200 dark:stroke-white/10"
+ strokeWidth={1}
+ />
+
+ {buckets.map((bucket, i) => {
+ const totalH = bucket.totalFraction * PLOT_H;
+ const attributedH = bucket.attributedFraction * PLOT_H;
+ const unattributedH = Math.max(0, totalH - attributedH);
+ const x = i * slot + (slot - barW) / 2;
+ const top = PAD_TOP + PLOT_H - totalH;
+
+ return (
+ <g key={bucket.start}>
+ <title>
+ {`${bucket.label}: ${bucket.total} ${asset} total — ${bucket.attributed} attributed across ${bucket.attributedCalls} call${bucket.attributedCalls === 1 ? '' : 's'}, ${bucket.unattributed} unattributed across ${bucket.unattributedCalls}`}
+ </title>
+
+ {/* Unattributed sits on top, hatched, so it reads as "not explained"
+ rather than as another category of earnings. */}
+ {unattributedH > 0 && (
+ <rect
+ x={x}
+ y={top}
+ width={barW}
+ height={unattributedH}
+ fill="url(#unattributed-hatch)"
+ className="stroke-slate-300 dark:stroke-white/20"
+ strokeWidth={1}
+ />
+ )}
+ {attributedH > 0 && (
+ <rect
+ x={x}
+ y={PAD_TOP + PLOT_H - attributedH}
+ width={barW}
+ height={attributedH}
+ className="fill-emerald-500/80 dark:fill-emerald-400/70"
+ />
+ )}
+
+ {i % labelEvery === 0 && (
+ <text
+ x={i * slot + slot / 2}
+ y={VIEW_H - 8}
+ textAnchor="middle"
+ className="fill-slate-400 dark:fill-slate-500 text-[11px]"
+ >
+ {bucket.label}
+ </text>
+ )}
+ </g>
+ );
+ })}
+
+ <defs>
+ <pattern
+ id="unattributed-hatch"
+ width={6}
+ height={6}
+ patternUnits="userSpaceOnUse"
+ patternTransform="rotate(45)"
+ >
+ <line
+ x1={0}
+ y1={0}
+ x2={0}
+ y2={6}
+ className="stroke-slate-400/60 dark:stroke-slate-500/60"
+ strokeWidth={2}
+ />
+ </pattern>
+ </defs>
+ </svg>
+ </div>
+
+ <div className="flex flex-wrap items-center gap-6 mt-4 text-xs">
+ <Legend swatch="attributed" label={`Attributed — ${formatAmount(series.attributedTotal)} ${asset}`} />
+ <Legend swatch="unattributed" label={`Unattributed — ${formatAmount(series.unattributedTotal)} ${asset}`} />
+ </div>
+ </figure>
+ );
+}
+
+function Legend({ swatch, label }: { swatch: 'attributed' | 'unattributed'; label: string }) {
+ return (
+ <span className="inline-flex items-center gap-2 text-slate-500 dark:text-slate-400">
+ <span
+ aria-hidden
+ className={
+ swatch === 'attributed'
+ ? 'w-3 h-3 bg-emerald-500/80 dark:bg-emerald-400/70'
+ : 'w-3 h-3 border border-slate-300 dark:border-white/20 bg-[repeating-linear-gradient(45deg,transparent,transparent_2px,rgba(100,116,139,0.6)_2px,rgba(100,116,139,0.6)_4px)]'
+ }
+ />
+ {label}
+ </span>
+ );
+}

--- a/apps/web/src/lib/revenue-analytics.test.ts
+++ b/apps/web/src/lib/revenue-analytics.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assetKey,
+  assetOptions,
+  buildRevenueSeries,
+  buildRouteBreakdown,
+  filterByAsset,
+  fraction,
+  RANGE_DAYS,
+  UNATTRIBUTED_LABEL,
+  type RevenuePayment,
+} from './revenue-analytics';
+
+const USDC = 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+const USDC_OTHER = 'USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+function payment(over: Partial<RevenuePayment> = {}): RevenuePayment {
+  return {
+    amount: '1.0000000',
+    asset: null,
+    ts: '2026-03-10T12:00:00.000Z',
+    route: '/api/quote',
+    method: 'GET',
+    ...over,
+  };
+}
+
+describe('assetKey / assetOptions', () => {
+  it('treats a null asset as native', () => {
+    expect(assetKey(null)).toBe('native');
+    expect(assetKey(USDC)).toBe(USDC);
+  });
+
+  it('never merges two issuers that share an asset code', () => {
+    const options = assetOptions([
+      payment({ asset: USDC }),
+      payment({ asset: USDC }),
+      payment({ asset: USDC_OTHER }),
+    ]);
+
+    expect(options).toHaveLength(2);
+    expect(options.map((o) => o.key)).toEqual([USDC, USDC_OTHER]);
+    // Both are"USDC", so the issuer is surfaced to keep them distinguishable.
+    expect(options[0].label).toContain('USDC (');
+    expect(options[1].label).toContain('USDC (');
+    expect(options[0].label).not.toBe(options[1].label);
+  });
+
+  it('leaves an unambiguous label alone and orders by usage', () => {
+    const options = assetOptions([payment({ asset: USDC }), payment(), payment()]);
+    expect(options[0]).toMatchObject({ key: 'native', label: 'XLM', calls: 2 });
+    expect(options[1]).toMatchObject({ key: USDC, label: 'USDC', calls: 1 });
+  });
+
+  it('returns nothing for no payments', () => {
+    expect(assetOptions([])).toEqual([]);
+  });
+
+  it('filters by the raw identifier, not the display code', () => {
+    const rows = [payment({ asset: USDC }), payment({ asset: USDC_OTHER })];
+    expect(filterByAsset(rows, USDC)).toHaveLength(1);
+  });
+});
+
+describe('fraction', () => {
+  it('derives a ratio from bigints without overflowing a float', () => {
+    // 2^70 stroops: far beyond Number.MAX_SAFE_INTEGER, so a naive
+    // Number(value) / Number(max) would already have lost precision.
+    const max = 1n << 70n;
+    expect(fraction(max / 4n, max)).toBeCloseTo(0.25, 6);
+  });
+
+  it('clamps and guards the degenerate cases', () => {
+    expect(fraction(0n, 0n)).toBe(0);
+    expect(fraction(5n, 0n)).toBe(0);
+    expect(fraction(-5n, 10n)).toBe(0);
+    expect(fraction(20n, 10n)).toBe(1);
+  });
+});
+
+describe('buildRouteBreakdown', () => {
+  it('groups by method and route, highest revenue first', () => {
+    const breakdown = buildRouteBreakdown(
+      [
+        payment({ route: '/api/quote', method: 'GET', amount: '1.0000000' }),
+        payment({ route: '/api/quote', method: 'GET', amount: '2.5000000' }),
+        payment({ route: '/api/quote', method: 'POST', amount: '10.0000000' }),
+        payment({ route: '/api/search', method: 'GET', amount: '0.0000003' }),
+      ],
+      'native',
+    );
+
+    expect(breakdown.routes.map((r) => `${r.method} ${r.route}`)).toEqual([
+      'POST /api/quote',
+      'GET /api/quote',
+      'GET /api/search',
+    ]);
+    expect(breakdown.routes[1].total).toBe('3.5000000');
+    expect(breakdown.routes[1].calls).toBe(2);
+    expect(breakdown.routes[1].average).toBe('1.7500000');
+    expect(breakdown.total).toBe('13.5000003');
+    expect(breakdown.unattributed).toBeNull();
+  });
+
+  it('sums exactly where a float would drift', () => {
+    // 0.1 + 0.2 is 0.30000000000000004 in binary floating point.
+    expect(
+      buildRouteBreakdown(
+        [payment({ amount: '0.1000000' }), payment({ amount: '0.2000000' })],
+        'native',
+      ).total,
+    ).toBe('0.3000000');
+
+    // And at the top of the safe-integer range, where stroops exceed 2^53.
+    const big = Array.from({ length: 3 }, () => payment({ amount: '9007199.2540741' }));
+    const breakdown = buildRouteBreakdown(big, 'native');
+    expect(breakdown.total).toBe('27021597.7622223');
+    expect(breakdown.routes[0].average).toBe('9007199.2540741');
+  });
+
+  it('keeps unattributed payments in their own bucket, counted but not merged', () => {
+    const breakdown = buildRouteBreakdown(
+      [
+        payment({ route: '/api/quote', amount: '4.0000000' }),
+        payment({ route: null, method: null, amount: '6.0000000' }),
+        payment({ route: null, method: null, amount: '2.0000000' }),
+      ],
+      'native',
+    );
+
+    expect(breakdown.routes).toHaveLength(1);
+    expect(breakdown.routes[0].total).toBe('4.0000000');
+
+    const unattributed = breakdown.unattributed;
+    expect(unattributed).not.toBeNull();
+    expect(unattributed?.key).toBe(UNATTRIBUTED_LABEL);
+    expect(unattributed?.attributed).toBe(false);
+    expect(unattributed?.route).toBeNull();
+    expect(unattributed?.calls).toBe(2);
+    expect(unattributed?.total).toBe('8.0000000');
+    expect(unattributed?.average).toBe('4.0000000');
+
+    // The overall total is every payment; attribution splits it, never trims it.
+    expect(breakdown.total).toBe('12.0000000');
+    expect(breakdown.attributedTotal).toBe('4.0000000');
+    expect(breakdown.unattributedTotal).toBe('8.0000000');
+    expect(breakdown.calls).toBe(3);
+    expect(breakdown.attributedCalls).toBe(1);
+    expect(breakdown.unattributedCalls).toBe(2);
+    expect(unattributed?.share).toBeCloseTo(2 / 3, 3);
+  });
+
+  it('treats an empty route string as unattributed rather than as a route', () => {
+    const breakdown = buildRouteBreakdown([payment({ route: '', method: 'GET' })], 'native');
+    expect(breakdown.routes).toEqual([]);
+    expect(breakdown.unattributed?.calls).toBe(1);
+  });
+
+  it('does not mix assets', () => {
+    const rows = [
+      payment({ asset: null, amount: '5.0000000' }),
+      payment({ asset: USDC, amount: '100.0000000' }),
+    ];
+    expect(buildRouteBreakdown(rows, 'native').total).toBe('5.0000000');
+    expect(buildRouteBreakdown(rows, USDC).total).toBe('100.0000000');
+  });
+
+  it('counts a payment with an unreadable amount without inventing a value', () => {
+    const breakdown = buildRouteBreakdown(
+      [
+        payment({ amount: '3.0000000' }),
+        payment({ amount: null }),
+        payment({ amount: 'not-a-number' }),
+      ],
+      'native',
+    );
+
+    expect(breakdown.calls).toBe(3);
+    expect(breakdown.unpricedCalls).toBe(2);
+    expect(breakdown.total).toBe('3.0000000');
+    expect(breakdown.routes[0].priced).toBe(1);
+    expect(breakdown.routes[0].unpriced).toBe(2);
+    // Averaged over what was actually priced, not over all three.
+    expect(breakdown.routes[0].average).toBe('3.0000000');
+  });
+
+  it('reports no average when nothing in the bucket could be priced', () => {
+    const breakdown = buildRouteBreakdown([payment({ amount: null })], 'native');
+    expect(breakdown.routes[0].average).toBeNull();
+    expect(breakdown.routes[0].total).toBe('0.0000000');
+  });
+
+  it('handles empty data', () => {
+    const breakdown = buildRouteBreakdown([], 'native');
+    expect(breakdown).toMatchObject({
+      routes: [],
+      unattributed: null,
+      total: '0.0000000',
+      attributedTotal: '0.0000000',
+      unattributedTotal: '0.0000000',
+      calls: 0,
+      attributedCalls: 0,
+      unattributedCalls: 0,
+      unpricedCalls: 0,
+    });
+  });
+});
+
+describe('buildRevenueSeries', () => {
+  const now = Date.parse('2026-03-10T12:00:00.000Z');
+
+  it('emits one bucket per day across the whole range, including empty days', () => {
+    const series = buildRevenueSeries([payment({ ts: '2026-03-10T01:00:00.000Z' })], {
+      asset: 'native',
+      range: '7d',
+      now,
+    });
+
+    expect(series.granularity).toBe('day');
+    expect(series.buckets).toHaveLength(7);
+    expect(series.buckets[0].start).toBe('2026-03-04T00:00:00.000Z');
+    expect(series.buckets[6].start).toBe('2026-03-10T00:00:00.000Z');
+    // Quiet days are shown as zero, not compressed out of the axis.
+    expect(series.buckets[0].total).toBe('0.0000000');
+    expect(series.buckets[0].totalFraction).toBe(0);
+    expect(series.buckets[6].total).toBe('1.0000000');
+    expect(series.buckets[6].totalFraction).toBe(1);
+  });
+
+  it('splits each bucket into attributed and unattributed without dropping either', () => {
+    const series = buildRevenueSeries(
+      [
+        payment({ ts: '2026-03-09T09:00:00.000Z', route: '/api/quote', amount: '3.0000000' }),
+        payment({ ts: '2026-03-09T10:00:00.000Z', route: null, method: null, amount: '1.0000000' }),
+      ],
+      { asset: 'native', range: '7d', now },
+    );
+
+    const day = series.buckets.find((b) => b.start === '2026-03-09T00:00:00.000Z');
+    expect(day?.attributed).toBe('3.0000000');
+    expect(day?.unattributed).toBe('1.0000000');
+    expect(day?.total).toBe('4.0000000');
+    expect(day?.attributedCalls).toBe(1);
+    expect(day?.unattributedCalls).toBe(1);
+    // The stack is drawn attributed-first, so the geometry must agree that the
+    // unattributed segment is the remaining quarter.
+    expect(day?.attributedFraction).toBeCloseTo(0.75, 4);
+    expect(day?.totalFraction).toBe(1);
+
+    expect(series.attributedTotal).toBe('3.0000000');
+    expect(series.unattributedTotal).toBe('1.0000000');
+    expect(series.total).toBe('4.0000000');
+    expect(series.max).toBe('4.0000000');
+  });
+
+  it('excludes payments older than the range', () => {
+    const series = buildRevenueSeries(
+      [
+        payment({ ts: '2026-01-01T00:00:00.000Z', amount: '99.0000000' }),
+        payment({ ts: '2026-03-08T00:00:00.000Z', amount: '2.0000000' }),
+      ],
+      { asset: 'native', range: '7d', now },
+    );
+    expect(series.total).toBe('2.0000000');
+    expect(series.calls).toBe(1);
+  });
+
+  it('switches to weekly buckets once a daily axis stops being readable', () => {
+    const series = buildRevenueSeries(
+      [payment({ ts: '2025-12-01T00:00:00.000Z' }), payment({ ts: '2026-03-09T00:00:00.000Z' })],
+      { asset: 'native', range: 'all', now },
+    );
+
+    expect(series.granularity).toBe('week');
+    // Weeks start on Monday UTC; 2025-12-01 was a Monday.
+    expect(series.buckets[0].start).toBe('2025-12-01T00:00:00.000Z');
+    expect(series.buckets[0].label).toBe('w/c Dec 1');
+    expect(series.calls).toBe(2);
+    expect(series.total).toBe('2.0000000');
+  });
+
+  it('spans from the first payment when the range is all time', () => {
+    const series = buildRevenueSeries([payment({ ts: '2026-03-08T00:00:00.000Z' })], {
+      asset: 'native',
+      range: 'all',
+      now,
+    });
+    expect(series.granularity).toBe('day');
+    expect(series.buckets[0].start).toBe('2026-03-08T00:00:00.000Z');
+    expect(series.buckets.at(-1)?.start).toBe('2026-03-10T00:00:00.000Z');
+  });
+
+  it('does not mix assets', () => {
+    const rows = [
+      payment({ asset: null, amount: '5.0000000' }),
+      payment({ asset: USDC, amount: '100.0000000' }),
+    ];
+    expect(buildRevenueSeries(rows, { asset: USDC, range: '7d', now }).total).toBe('100.0000000');
+  });
+
+  it('counts an unreadable amount without summing it', () => {
+    const series = buildRevenueSeries([payment({ amount: 'oops' })], {
+      asset: 'native',
+      range: '7d',
+      now,
+    });
+    expect(series.unpricedCalls).toBe(1);
+    expect(series.calls).toBe(1);
+    expect(series.total).toBe('0.0000000');
+  });
+
+  it('ignores an unparseable timestamp rather than bucketing it at the epoch', () => {
+    const series = buildRevenueSeries([payment({ ts: 'never' })], {
+      asset: 'native',
+      range: 'all',
+      now,
+    });
+    expect(series.calls).toBe(0);
+  });
+
+  it('handles empty data without producing a degenerate axis', () => {
+    for (const range of Object.keys(RANGE_DAYS) as Array<keyof typeof RANGE_DAYS>) {
+      const series = buildRevenueSeries([], { asset: 'native', range, now });
+      expect(series.buckets.length).toBeGreaterThan(0);
+      expect(series.max).toBe('0.0000000');
+      expect(series.total).toBe('0.0000000');
+      expect(series.calls).toBe(0);
+      expect(series.buckets.every((b) => b.totalFraction === 0)).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/lib/revenue-analytics.ts
+++ b/apps/web/src/lib/revenue-analytics.ts
@@ -1,0 +1,444 @@
+/**
+ * Aggregations behind the merchant analytics view: revenue by route, and
+ * revenue over time.
+ *
+ * Two rules run through all of it.
+ *
+ * 1. Money never touches a float. Every total is folded in integer stroops via
+ *    bigint and converted to a decimal string only at the edge. The one number
+ *    that does become a float is a *fraction* used for chart geometry, and it
+ *    is derived by dividing bigints first - it is a pixel ratio, never a value.
+ *
+ * 2. Attribution is merchant-reported, revenue is chain-indexed. A route on a
+ *    payment arrives from the seller's own process via /api/hook/settle; the
+ *    amount arrives from the ledger. A payment with no route is a real transfer
+ *    that simply has no attribution, so it is kept in its own bucket and
+ *    counted in every total - never folded into a route, never dropped.
+ *
+ * A third rule falls out of the first: amounts are only ever summed within a
+ * single asset. Adding 10 XLM to 10 USDC produces a number that means nothing,
+ * so callers pick an asset and the aggregations work inside it.
+ */
+
+import { assetLabel, fromStroops, toStroops } from './money';
+
+/** The subset of a payment row these aggregations read. */
+export interface RevenuePayment {
+  /** Decimal string from the ledger. May be absent on a malformed row. */
+  amount: string | null;
+  /** SEP-11 asset identifier; null means the native asset. */
+  asset: string | null;
+  /** ISO 8601. Chain-indexed rows always have one. */
+  ts: string;
+  /** Merchant-reported. Null when the transfer carries no attribution. */
+  route: string | null;
+  /** Merchant-reported. */
+  method: string | null;
+}
+
+/** Label for the bucket holding payments with no merchant attribution. */
+export const UNATTRIBUTED_LABEL = '(unattributed)';
+
+/* ------------------------------------------------------------------ assets */
+
+/**
+ * Stable grouping key for an asset.
+ *
+ * Deliberately the raw SEP-11 identifier rather than the display code: two
+ * different issuers can both call their asset USDC, and merging them would sum
+ * money across genuinely different assets.
+ */
+export function assetKey(asset: string | null): string {
+  return asset ?? 'native';
+}
+
+export interface AssetOption {
+  /** Value to pass back into the aggregations. */
+  key: string;
+  /** Display label, disambiguated by issuer if two assets share a code. */
+  label: string;
+  /** How many payments are denominated in it. */
+  calls: number;
+}
+
+function shortIssuer(issuer: string): string {
+  return issuer.length <= 12 ? issuer : `${issuer.slice(0, 4)}…${issuer.slice(-4)}`;
+}
+
+/** The assets present in a set of payments, most-used first. */
+export function assetOptions(payments: RevenuePayment[]): AssetOption[] {
+  const calls = new Map<string, number>();
+  for (const payment of payments) {
+    const key = assetKey(payment.asset);
+    calls.set(key, (calls.get(key) ?? 0) + 1);
+  }
+
+  const labels = new Map<string, number>();
+  for (const key of calls.keys()) {
+    const label = assetLabel(key);
+    labels.set(label, (labels.get(label) ?? 0) + 1);
+  }
+
+  return [...calls.entries()]
+    .map(([key, count]): AssetOption => {
+      const base = assetLabel(key);
+      const issuer = key.includes(':') ? key.split(':')[1] : '';
+      const ambiguous = (labels.get(base) ?? 0) > 1 && issuer !== '';
+      return { key, label: ambiguous ? `${base} (${shortIssuer(issuer)})` : base, calls: count };
+    })
+    .sort((a, b) => b.calls - a.calls || a.label.localeCompare(b.label));
+}
+
+export function filterByAsset(payments: RevenuePayment[], asset: string): RevenuePayment[] {
+  return payments.filter((payment) => assetKey(payment.asset) === asset);
+}
+
+/* ----------------------------------------------------------------- helpers */
+
+/**
+ * Ratio of two stroop amounts as a float in [0, 1], for chart geometry only.
+ *
+ * The division happens in bigint at 1/10000 resolution before anything becomes
+ * a Number, so no amount is ever represented as a float - only the resulting
+ * proportion, which is a pixel measurement rather than money.
+ */
+export function fraction(value: bigint, max: bigint, resolution = 10_000n): number {
+  if (max <= 0n || value <= 0n) return 0;
+  if (value >= max) return 1;
+  return Number((value * resolution) / max) / Number(resolution);
+}
+
+/** Parses an amount, treating an unreadable or missing one as unpriced. */
+function priceOf(amount: string | null): bigint | null {
+  if (typeof amount !== 'string') return null;
+  return toStroops(amount);
+}
+
+/* --------------------------------------------------------- route breakdown */
+
+export interface RouteBucket {
+  /** Stable React key. */
+  key: string;
+  /** Merchant-reported route, or null for the unattributed bucket. */
+  route: string | null;
+  method: string | null;
+  /** False only for the unattributed bucket. */
+  attributed: boolean;
+  /** Payments in the bucket, including any whose amount could not be read. */
+  calls: number;
+  /** Payments that contributed to `total`. */
+  priced: number;
+  /** Payments counted but not priced, because their amount was unreadable. */
+  unpriced: number;
+  /** Exact decimal string. */
+  total: string;
+  /** Exact decimal string, floored to the stroop. Null when nothing is priced. */
+  average: string | null;
+  /** Share of all revenue in this asset, attributed or not. Geometry only. */
+  share: number;
+}
+
+export interface RouteBreakdown {
+  /** The asset every figure below is denominated in. */
+  asset: string;
+  /** Attributed routes, highest revenue first. */
+  routes: RouteBucket[];
+  /** Payments with no merchant attribution. Null when there are none. */
+  unattributed: RouteBucket | null;
+  /** Every payment in the asset, attributed or not. */
+  total: string;
+  attributedTotal: string;
+  unattributedTotal: string;
+  calls: number;
+  attributedCalls: number;
+  unattributedCalls: number;
+  unpricedCalls: number;
+}
+
+interface Accumulator {
+  route: string | null;
+  method: string | null;
+  stroops: bigint;
+  calls: number;
+  priced: number;
+}
+
+/**
+ * Folds payments into one bucket per (method, route) pair.
+ *
+ * Payments with a null route are never merged into a route bucket and never
+ * discarded: they land in `unattributed`, which the caller is expected to show
+ * alongside the routes. That bucket is the honest answer to "how much of this
+ * revenue does Path B actually explain".
+ */
+export function buildRouteBreakdown(
+  payments: RevenuePayment[],
+  asset: string,
+): RouteBreakdown {
+  const buckets = new Map<string, Accumulator>();
+  let unattributed: Accumulator | null = null;
+  let total = 0n;
+  let calls = 0;
+  let unpricedCalls = 0;
+
+  for (const payment of filterByAsset(payments, asset)) {
+    const stroops = priceOf(payment.amount);
+    calls += 1;
+    if (stroops === null) unpricedCalls += 1;
+    else total += stroops;
+
+    // A row is attributed only if it carries a route. The method alone says
+    // nothing about which endpoint earned the money.
+    const attributed = typeof payment.route === 'string' && payment.route !== '';
+
+    let bucket: Accumulator;
+    if (!attributed) {
+      unattributed ??= { route: null, method: null, stroops: 0n, calls: 0, priced: 0 };
+      bucket = unattributed;
+    } else {
+      const key = `${payment.method ?? ''} ${payment.route}`;
+      const existing = buckets.get(key);
+      if (existing) {
+        bucket = existing;
+      } else {
+        bucket = { route: payment.route, method: payment.method, stroops: 0n, calls: 0, priced: 0 };
+        buckets.set(key, bucket);
+      }
+    }
+
+    bucket.calls += 1;
+    if (stroops !== null) {
+      bucket.stroops += stroops;
+      bucket.priced += 1;
+    }
+  }
+
+  const toBucket = (key: string, acc: Accumulator, attributed: boolean): RouteBucket => ({
+    key,
+    route: acc.route,
+    method: acc.method,
+    attributed,
+    calls: acc.calls,
+    priced: acc.priced,
+    unpriced: acc.calls - acc.priced,
+    total: fromStroops(acc.stroops),
+    // Integer division, so the average is floored to the stroop rather than
+    // rounded through a float.
+    average: acc.priced > 0 ? fromStroops(acc.stroops / BigInt(acc.priced)) : null,
+    share: fraction(acc.stroops, total),
+  });
+
+  const routes = [...buckets.entries()]
+    .map(([key, acc]) => toBucket(key, acc, true))
+    .sort((a, b) => {
+      const left = toStroops(a.total) ?? 0n;
+      const right = toStroops(b.total) ?? 0n;
+      if (left !== right) return right > left ? 1 : -1;
+      if (a.calls !== b.calls) return b.calls - a.calls;
+      return `${a.route}`.localeCompare(`${b.route}`);
+    });
+
+  const unattributedBucket = unattributed
+    ? toBucket(UNATTRIBUTED_LABEL, unattributed, false)
+    : null;
+
+  const attributedStroops = routes.reduce((sum, r) => sum + (toStroops(r.total) ?? 0n), 0n);
+
+  return {
+    asset,
+    routes,
+    unattributed: unattributedBucket,
+    total: fromStroops(total),
+    attributedTotal: fromStroops(attributedStroops),
+    unattributedTotal: fromStroops(total - attributedStroops),
+    calls,
+    attributedCalls: routes.reduce((sum, r) => sum + r.calls, 0),
+    unattributedCalls: unattributedBucket?.calls ?? 0,
+    unpricedCalls,
+  };
+}
+
+/* ------------------------------------------------------------- time series */
+
+export type RangeKey = '7d' | '30d' | 'all';
+export type Granularity = 'day' | 'week';
+
+export const RANGE_DAYS: Record<RangeKey, number | null> = { '7d': 7, '30d': 30, all: null };
+
+const DAY_MS = 86_400_000;
+
+/** Midnight UTC of the day containing `ms`. */
+function startOfDay(ms: number): number {
+  return Math.floor(ms / DAY_MS) * DAY_MS;
+}
+
+/** Midnight UTC of the Monday on or before `ms`. 1970-01-01 was a Thursday. */
+function startOfWeek(ms: number): number {
+  const day = startOfDay(ms);
+  const weekday = (Math.floor(day / DAY_MS) + 3) % 7; // 0 = Monday
+  return day - weekday * DAY_MS;
+}
+
+function bucketStart(ms: number, granularity: Granularity): number {
+  return granularity === 'week' ? startOfWeek(ms) : startOfDay(ms);
+}
+
+function advance(ms: number, granularity: Granularity): number {
+  return ms + (granularity === 'week' ? 7 * DAY_MS : DAY_MS);
+}
+
+export interface SeriesBucket {
+  /** Bucket start, midnight UTC, ISO 8601. */
+  start: string;
+  /** Short axis label. */
+  label: string;
+  /** Chain-indexed revenue carrying a merchant-reported route. */
+  attributed: string;
+  /** Chain-indexed revenue with no attribution. Real money, unknown route. */
+  unattributed: string;
+  total: string;
+  calls: number;
+  attributedCalls: number;
+  unattributedCalls: number;
+  /** Height ratios against the tallest bucket. Geometry only. */
+  totalFraction: number;
+  attributedFraction: number;
+}
+
+export interface RevenueSeries {
+  asset: string;
+  range: RangeKey;
+  granularity: Granularity;
+  buckets: SeriesBucket[];
+  /** Tallest bucket total, as a decimal string. Drives the y-axis label. */
+  max: string;
+  total: string;
+  attributedTotal: string;
+  unattributedTotal: string;
+  calls: number;
+  attributedCalls: number;
+  unattributedCalls: number;
+  /** Payments in range whose amount could not be read, so were not summed. */
+  unpricedCalls: number;
+}
+
+/** Above this many days, per-day bars stop being readable, so group by week. */
+const WEEKLY_ABOVE_DAYS = 45;
+
+function formatLabel(startMs: number, granularity: Granularity): string {
+  const date = new Date(startMs);
+  const month = date.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' });
+  const day = date.getUTCDate();
+  return granularity === 'week' ? `w/c ${month} ${day}` : `${month} ${day}`;
+}
+
+/**
+ * Buckets revenue over time, splitting each bucket into attributed and
+ * unattributed.
+ *
+ * Empty buckets are emitted rather than skipped: a day with no revenue is a
+ * fact about the business, and dropping it would compress the x-axis into a
+ * shape that implies steadier income than there was.
+ */
+export function buildRevenueSeries(
+  payments: RevenuePayment[],
+  options: { asset: string; range: RangeKey; now?: number },
+): RevenueSeries {
+  const { asset, range } = options;
+  const now = options.now ?? Date.now();
+
+  const inAsset = filterByAsset(payments, asset).filter((p) => !Number.isNaN(Date.parse(p.ts)));
+  const days = RANGE_DAYS[range];
+
+  // 'all' spans from the first payment to now; a fixed range spans back from
+  // today whether or not anything landed in it, so an empty week reads as an
+  // empty week rather than as no data.
+  const timestamps = inAsset.map((p) => Date.parse(p.ts));
+  const earliest = timestamps.length ? Math.min(...timestamps) : now;
+  const from = days === null ? earliest : now - (days - 1) * DAY_MS;
+  const spanDays = Math.max(1, Math.ceil((now - from) / DAY_MS) + 1);
+  const granularity: Granularity = spanDays > WEEKLY_ABOVE_DAYS ? 'week' : 'day';
+
+  const firstBucket = bucketStart(from, granularity);
+  const lastBucket = bucketStart(now, granularity);
+
+  interface Cell {
+    attributed: bigint;
+    unattributed: bigint;
+    attributedCalls: number;
+    unattributedCalls: number;
+  }
+  const cells = new Map<number, Cell>();
+  for (let ms = firstBucket; ms <= lastBucket; ms = advance(ms, granularity)) {
+    cells.set(ms, { attributed: 0n, unattributed: 0n, attributedCalls: 0, unattributedCalls: 0 });
+  }
+
+  let unpricedCalls = 0;
+  for (const payment of inAsset) {
+    const ms = Date.parse(payment.ts);
+    // Out of range, including anything the ledger stamped in the future.
+    if (ms < firstBucket || ms > advance(lastBucket, granularity) - 1) continue;
+
+    const cell = cells.get(bucketStart(ms, granularity));
+    if (!cell) continue;
+
+    const stroops = priceOf(payment.amount);
+    if (stroops === null) unpricedCalls += 1;
+
+    const attributed = typeof payment.route === 'string' && payment.route !== '';
+    if (attributed) {
+      cell.attributedCalls += 1;
+      if (stroops !== null) cell.attributed += stroops;
+    } else {
+      cell.unattributedCalls += 1;
+      if (stroops !== null) cell.unattributed += stroops;
+    }
+  }
+
+  const ordered = [...cells.entries()].sort((a, b) => a[0] - b[0]);
+  let max = 0n;
+  for (const [, cell] of ordered) {
+    const total = cell.attributed + cell.unattributed;
+    if (total > max) max = total;
+  }
+
+  let attributedTotal = 0n;
+  let unattributedTotal = 0n;
+  let attributedCalls = 0;
+  let unattributedCalls = 0;
+
+  const buckets = ordered.map(([ms, cell]): SeriesBucket => {
+    const total = cell.attributed + cell.unattributed;
+    attributedTotal += cell.attributed;
+    unattributedTotal += cell.unattributed;
+    attributedCalls += cell.attributedCalls;
+    unattributedCalls += cell.unattributedCalls;
+    return {
+      start: new Date(ms).toISOString(),
+      label: formatLabel(ms, granularity),
+      attributed: fromStroops(cell.attributed),
+      unattributed: fromStroops(cell.unattributed),
+      total: fromStroops(total),
+      calls: cell.attributedCalls + cell.unattributedCalls,
+      attributedCalls: cell.attributedCalls,
+      unattributedCalls: cell.unattributedCalls,
+      totalFraction: fraction(total, max),
+      attributedFraction: fraction(cell.attributed, max),
+    };
+  });
+
+  return {
+    asset,
+    range,
+    granularity,
+    buckets,
+    max: fromStroops(max),
+    total: fromStroops(attributedTotal + unattributedTotal),
+    attributedTotal: fromStroops(attributedTotal),
+    unattributedTotal: fromStroops(unattributedTotal),
+    calls: attributedCalls + unattributedCalls,
+    attributedCalls,
+    unattributedCalls,
+    unpricedCalls,
+  };
+}


### PR DESCRIPTION
Closes #17, closes #27.

Adds `/dashboard/routes`: revenue grouped by the endpoint that earned it, plus the same revenue bucketed over time.

## The distinction the page is built around

Amounts are **chain-indexed**. Routes are **merchant-reported**. A payment can have the first without the second, because a SAC transfer records a transfer and not an endpoint — the route arrives separately from the seller's own process via `/api/hook/settle`.

So a payment with no route is never folded into a route bucket and never dropped:

- it lands in its own `(unattributed)` bucket,
- it counts toward every total,
- in the chart it is a **hatched** segment, not a second colour — a colour would read as just another category of earnings,
- and every headline figure appears twice: all revenue in the asset, and the part attribution can actually explain.

Presenting a single total as if it were all attributed is the specific claim this product is not allowed to make loosely, so the UI refuses to make it.

## Money

Totals are folded in integer stroops via `bigint` and converted to a decimal string only at the edge. The one float in the module is a *fraction* for bar geometry, derived by dividing bigints at 1/10000 resolution before anything becomes a `Number` — a pixel ratio, never a value.

Amounts are summed strictly within a single asset. Adding 10 XLM to 10 USDC produces a number that means nothing, so the asset is a selector rather than something to aggregate across. Assets are keyed by raw SEP-11 identifier rather than display code, since two issuers can both call their asset USDC.

## Chart

Inline SVG. **No charting dependency added** — a stacked bar chart over a fixed bucket count is arithmetic the aggregation layer had already done. Empty buckets are emitted rather than skipped: a day with no revenue is a fact, and dropping it would compress the axis into a shape implying steadier income than there was.

## On #10

**This does not depend on it and does not implement it.** Aggregation runs client-side over `/api/payments`, which is already the whole set the dashboard holds. If #10 (the `GET /api/routes` endpoint, assigned to @wagmiiii) lands later, `buildRouteBreakdown` and `buildRevenueSeries` can move behind it unchanged — they take payment rows and know nothing about transport.

## Verification

- `pnpm test` in `apps/web`: **177 passing**, 11 files, including 24 in `revenue-analytics.test.ts` covering the null-route bucket, mixed assets, unreadable amounts, empty ranges, and the day/week granularity switch.
- `pnpm exec tsc --noEmit`: clean. Fixed two real signature mismatches while wiring the UI.
- `pnpm lint`: 0 errors. I also stabilised three `useMemo` dependencies — the loading branch returned a fresh `[]` each render, so the aggregations were recomputing every time and the memos did nothing.

Rebased onto current `main`.