### PR TITLE
feat(web): refund a payment against RefundVault from its detail view

### DIFF
--- a/apps/web/src/app/api/refund/preflight/route.ts
+++ b/apps/web/src/app/api/refund/preflight/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import {
+ REFUND_VAULT_ID,
+ getRefund,
+ preflightRefund,
+ type RefundPreflight,
+ type RefundRecord,
+} from '@/lib/refund-vault';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Answers "would this refund go through, and has it already?" without signing.
+ *
+ * Runs server-side because the RPC endpoint is configured here and the reads
+ * are simulations that need no wallet. The merchant's browser only signs once
+ * this has already said yes, so a doomed refund never reaches a signing prompt.
+ *
+ * Read-only: nothing here submits a transaction or moves funds.
+ */
+
+export interface RefundPreflightRequest {
+ txHash: string;
+ recipient: string;
+ /** Stroops, decimal string. */
+ amount: string;
+ paidAtLedger: number;
+ merchant: string;
+}
+
+export interface RefundPreflightResponse {
+ contract: string;
+ /** Set when this payment has already been refunded. */
+ existing: RefundRecord | null;
+ preflight: RefundPreflight;
+}
+
+export async function POST(request: Request) {
+ let body: RefundPreflightRequest;
+ try {
+ body = await request.json();
+ } catch {
+ return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+ }
+
+ const { txHash, recipient, amount, paidAtLedger, merchant } = body ?? {};
+
+ if (typeof txHash !== 'string' || typeof recipient !== 'string' || typeof merchant !== 'string') {
+ return NextResponse.json(
+ { error: 'txHash, recipient, and merchant are required' },
+ { status: 400 },
+ );
+ }
+ // Amount stays a string end to end. Accepting a number here would put the
+ // refund through a float on its way to an i128.
+ if (typeof amount !== 'string' || !/^\d+$/.test(amount) || amount === '0') {
+ return NextResponse.json(
+ { error: 'amount must be a positive integer string in stroops' },
+ { status: 400 },
+ );
+ }
+ if (!Number.isInteger(paidAtLedger) || paidAtLedger < 0) {
+ return NextResponse.json({ error: 'paidAtLedger must be a ledger number' }, { status: 400 });
+ }
+
+ let existing: RefundRecord | null = null;
+ try {
+ existing = await getRefund(txHash, merchant);
+ } catch {
+ // A failed lookup is not evidence the payment was never refunded, so it is
+ // left null and the preflight below still runs — the contract itself will
+ // report AlreadyRefunded if that is the case.
+ }
+
+ const preflight = await preflightRefund({ txHash, recipient, amount, paidAtLedger, merchant });
+
+ return NextResponse.json<RefundPreflightResponse>({
+ contract: REFUND_VAULT_ID,
+ existing,
+ preflight,
+ });
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { describeSync, type SyncState } from '@/lib/sync-status';
 import { CSV_BOM, paymentsCsvFilename, paymentsToCsv } from '@/lib/payments-csv';
 import { ArrowUpRight } from 'lucide-react';
 import { PageContainer } from '@/components/page-container';
+import { RefundPanel } from '@/components/refund-panel';
 import { useOnline } from '@/components/network-status';
 import { describeFailure, isAbortError } from '@/lib/network-status';
 
@@ -37,6 +38,14 @@ export default function Dashboard() {
  const [selected, setSelected] = useState<Payment | null>(null);
  const closeButtonRef = useRef<HTMLButtonElement>(null);
  const [reloadToken, setReloadToken] = useState(0);
+ // Refunds issued in this session. The indexer does not watch RefundVault
+ // events yet, so a refund is otherwise invisible until someone opens the
+ // payment again and the contract is re-read.
+ const [refunded, setRefunded] = useState<ReadonlySet<string>>(() => new Set());
+ const markRefunded = useCallback(
+ (txHash: string) => setRefunded((prev) => new Set(prev).add(txHash)),
+ [],
+ );
  const online = useOnline();
 
  const reload = useCallback(() => setReloadToken((n) => n + 1), []);
@@ -215,6 +224,14 @@ export default function Dashboard() {
  >
  <td className="px-8 py-5 font-mono text-emerald-600 dark:text-emerald-400 text-sm group-hover:text-emerald-600 dark:group-hover:text-emerald-300 transition-colors">
  {truncate(payment.tx_hash)}
+ {refunded.has(payment.tx_hash) && (
+ <span
+ className="ml-2 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-widest border border-amber-300 dark:border-amber-500/30 text-amber-700 dark:text-amber-300 align-middle"
+ title="Refunded from the vault in this session"
+ >
+ Refunded
+ </span>
+ )}
  </td>
  <td className="px-8 py-5">
  <span className="font-black text-lg tracking-tight text-slate-900 dark:text-white transition-colors duration-300">{formatAmount(payment.amount)}</span>
@@ -293,6 +310,13 @@ export default function Dashboard() {
  >
  View on Explorer <ArrowUpRight className="w-4 h-4 opacity-70"/>
  </a>
+ </div>
+
+ <div className="pt-6 mt-6 border-t border-slate-100 dark:border-white/10 transition-colors duration-300">
+ <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-3">
+ Refund
+ </p>
+ <RefundPanel payment={selected} onRefunded={markRefunded} />
  </div>
  </div>
  </div>

--- a/apps/web/src/components/refund-panel.tsx
+++ b/apps/web/src/components/refund-panel.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { formatAmount, assetLabel } from '@/lib/money';
+import { readStatus, truncateAddress } from '@/lib/freighter';
+import { submitRefund, type RefundOutcome } from '@/lib/refund-submit';
+import type { RefundPreflightResponse } from '@/app/api/refund/preflight/route';
+
+/**
+ * Refunds one payment from the vault, from the payment's own detail view.
+ *
+ * The flow is deliberately preflight-first: the contract is asked whether the
+ * refund would succeed *before* a signing prompt appears, so the merchant is
+ * told "this window has closed" instead of approving a transaction that then
+ * fails. Nothing here is signed by the server — Accensa holds no key that can
+ * move a merchant's float, and a refund it could issue alone would make it a
+ * custodian.
+ */
+
+interface RefundablePayment {
+ tx_hash: string;
+ payer: string;
+ amount: string;
+ asset: string | null;
+ ledger: number | null;
+}
+
+type Phase =
+ | { kind: 'idle' }
+ | { kind: 'checking' }
+ | { kind: 'ready'; check: RefundPreflightResponse }
+ | { kind: 'submitting' }
+ | { kind: 'done'; outcome: RefundOutcome };
+
+export function RefundPanel({
+ payment,
+ onRefunded,
+}: {
+ payment: RefundablePayment;
+ onRefunded: (txHash: string) => void;
+}) {
+ const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+ const [merchant, setMerchant] = useState<string | null>(null);
+ const [error, setError] = useState<string | null>(null);
+
+ useEffect(() => {
+ let live = true;
+ void readStatus().then((status) => {
+ if (live) setMerchant(status.kind === 'connected' ? status.address : null);
+ });
+ return () => {
+ live = false;
+ };
+ }, []);
+
+ const check = useCallback(async () => {
+ if (!merchant || payment.ledger === null) return;
+ setError(null);
+ setPhase({ kind: 'checking' });
+ try {
+ const res = await fetch('/api/refund/preflight', {
+ method: 'POST',
+ headers: { 'Content-Type': 'application/json' },
+ body: JSON.stringify({
+ txHash: payment.tx_hash,
+ recipient: payment.payer,
+ amount: payment.amount,
+ paidAtLedger: payment.ledger,
+ merchant,
+ }),
+ });
+ if (!res.ok) throw new Error(`Preflight failed: ${res.status}`);
+ setPhase({ kind: 'ready', check: await res.json() });
+ } catch (e) {
+ setPhase({ kind: 'idle' });
+ setError(e instanceof Error ? e.message : 'Could not check this refund');
+ }
+ }, [merchant, payment]);
+
+ const confirm = useCallback(async () => {
+ if (!merchant || payment.ledger === null) return;
+ setPhase({ kind: 'submitting' });
+ const outcome = await submitRefund({
+ txHash: payment.tx_hash,
+ recipient: payment.payer,
+ amount: payment.amount,
+ paidAtLedger: payment.ledger,
+ merchant,
+ });
+ setPhase({ kind: 'done', outcome });
+ if (outcome.status === 'confirmed') onRefunded(payment.tx_hash);
+ }, [merchant, payment, onRefunded]);
+
+ const asset = assetLabel(payment.asset);
+
+ if (!merchant) {
+ return (
+ <Note>
+ Connect a Stellar wallet to issue refunds. The refund is signed by your own account —
+ Accensa never holds a key that can move your float.
+ </Note>
+ );
+ }
+
+ if (payment.ledger === null) {
+ return (
+ <Note>
+ This payment has no ledger recorded, so the vault cannot check it against the refund
+ window. Refunds need an indexed ledger number.
+ </Note>
+ );
+ }
+
+ if (phase.kind === 'done') {
+ return <Outcome outcome={phase.outcome} />;
+ }
+
+ if (phase.kind === 'ready') {
+ const { existing, preflight } = phase.check;
+
+ if (existing) {
+ return (
+ <Note tone="warn">
+ Already refunded: {formatAmount(existing.amount)} {asset} to{' '}
+ <span className="font-mono">{truncateAddress(existing.recipient)}</span> at ledger{' '}
+ {existing.ledger}. A payment can only be refunded once.
+ </Note>
+ );
+ }
+
+ if (preflight.status === 'rejected') {
+ return (
+ <div className="space-y-3">
+ <Note tone="warn">{preflight.message}</Note>
+ <SmallButton onClick={check}>Re-check</SmallButton>
+ </div>
+ );
+ }
+
+ if (preflight.status === 'unknown') {
+ return (
+ <div className="space-y-3">
+ <Note tone="warn">
+ Could not confirm whether this refund would succeed: {preflight.message}
+ </Note>
+ <SmallButton onClick={check}>Retry check</SmallButton>
+ </div>
+ );
+ }
+
+ return (
+ <div className="space-y-4">
+ <Note tone="ok">
+ The vault will accept this refund: {formatAmount(payment.amount)} {asset} back to{' '}
+ <span className="font-mono">{truncateAddress(payment.payer)}</span>. Checked against the
+ live contract just now — float, refund window, and pause state all pass.
+ </Note>
+ <div className="flex flex-wrap gap-3">
+ <SmallButton onClick={confirm} tone="primary">
+ Sign and refund
+ </SmallButton>
+ <SmallButton onClick={() => setPhase({ kind: 'idle' })}>Cancel</SmallButton>
+ </div>
+ </div>
+ );
+ }
+
+ return (
+ <div className="space-y-3">
+ {error && <Note tone="warn">{error}</Note>}
+ <SmallButton onClick={check} disabled={phase.kind === 'checking'}>
+ {phase.kind === 'checking' ? 'Checking…' : 'Refund this payment'}
+ </SmallButton>
+ <p className="text-[11px] text-slate-400 dark:text-slate-500">
+ Signing as <span className="font-mono">{truncateAddress(merchant)}</span>. Nothing is
+ submitted until you approve it in your wallet.
+ </p>
+ </div>
+ );
+}
+
+function Outcome({ outcome }: { outcome: RefundOutcome }) {
+ if (outcome.status === 'confirmed') {
+ return (
+ <Note tone="ok">
+ Refund confirmed on-chain.{' '}
+ <a
+ href={`https://stellar.expert/explorer/testnet/tx/${outcome.hash}`}
+ target="_blank"
+ rel="noreferrer"
+ className="underline"
+ >
+ View transaction
+ </a>
+ </Note>
+ );
+ }
+ if (outcome.status === 'pending') {
+ return (
+ <Note>
+ Submitted, but not yet confirmed. It may still succeed — check the transaction before
+ retrying, or you risk attempting a second refund the vault will reject.{' '}
+ <a
+ href={`https://stellar.expert/explorer/testnet/tx/${outcome.hash}`}
+ target="_blank"
+ rel="noreferrer"
+ className="underline"
+ >
+ View transaction
+ </a>
+ </Note>
+ );
+ }
+ return <Note tone="warn">{outcome.message}</Note>;
+}
+
+function Note({ children, tone = 'neutral' }: { children: React.ReactNode; tone?: 'neutral' | 'ok' | 'warn' }) {
+ const tones = {
+ neutral: 'border-slate-200 dark:border-white/10 text-slate-600 dark:text-slate-300',
+ ok: 'border-emerald-200 dark:border-emerald-500/20 text-emerald-700 dark:text-emerald-300',
+ warn: 'border-amber-200 dark:border-amber-500/20 text-amber-700 dark:text-amber-300',
+ };
+ return <p className={`text-xs leading-relaxed border p-3 ${tones[tone]}`}>{children}</p>;
+}
+
+function SmallButton({
+ children,
+ onClick,
+ disabled,
+ tone = 'default',
+}: {
+ children: React.ReactNode;
+ onClick: () => void;
+ disabled?: boolean;
+ tone?: 'default' | 'primary';
+}) {
+ return (
+ <button
+ type="button"
+ onClick={onClick}
+ disabled={disabled}
+ className={`px-3 py-2 text-[10px] font-bold uppercase tracking-widest border transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+ tone === 'primary'
+ ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/25'
+ : 'border-slate-200 dark:border-white/10 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/5'
+ }`}
+ >
+ {children}
+ </button>
+ );
+}

--- a/apps/web/src/lib/freighter.ts
+++ b/apps/web/src/lib/freighter.ts
@@ -19,6 +19,10 @@ interface InjectedFreighter {
  getAddress?: () => Promise<unknown>;
  requestAccess?: () => Promise<unknown>;
  getNetwork?: () => Promise<unknown>;
+ signTransaction?: (
+ xdr: string,
+ opts?: { networkPassphrase?: string; address?: string },
+ ) => Promise<unknown>;
 }
 
 declare global {
@@ -138,6 +142,44 @@ export async function connect(): Promise<WalletStatus> {
  } catch (error) {
  return { kind: 'error', message: message(error) };
  }
+}
+
+/**
+ * Reads a signed envelope out of whatever shape the extension returned.
+ *
+ * Same tolerance as {@link readAddress}, and the same refusal to guess: a
+ * malformed envelope here would be submitted to the network as a transaction,
+ * so an unrecognised shape must be an error, never a best effort.
+ */
+export function readSignedXdr(value: unknown): string | null {
+ if (typeof value === 'string') return value.length > 0 ? value : null;
+ if (value && typeof value === 'object') {
+ const envelope = value as { signedTxXdr?: unknown; error?: unknown };
+ if (typeof envelope.error === 'string' && envelope.error.length > 0) return null;
+ if (typeof envelope.signedTxXdr === 'string' && envelope.signedTxXdr.length > 0) {
+ return envelope.signedTxXdr;
+ }
+ }
+ return null;
+}
+
+/**
+ * Asks the extension to sign a transaction envelope.
+ *
+ * Throws rather than resolving null on refusal, because every caller is in the
+ * middle of a money-moving flow where "no signature" must stop the flow rather
+ * than fall through to a submit.
+ */
+export async function signTransaction(
+ xdr: string,
+ opts: { networkPassphrase: string; address?: string },
+): Promise<string> {
+ const api = typeof window === 'undefined' ? undefined : window.freighterApi;
+ if (!api?.signTransaction) throw new Error('No Stellar wallet available to sign with');
+
+ const signed = readSignedXdr(await api.signTransaction(xdr, opts));
+ if (!signed) throw new Error('The wallet did not return a signed transaction');
+ return signed;
 }
 
 /** Where a merchant installs the extension, for the unavailable state. */

--- a/apps/web/src/lib/refund-submit.ts
+++ b/apps/web/src/lib/refund-submit.ts
@@ -1,0 +1,118 @@
+import {
+ Address,
+ Contract,
+ Networks,
+ TransactionBuilder,
+ nativeToScVal,
+ rpc,
+ xdr,
+} from '@stellar/stellar-sdk';
+import { signTransaction } from './freighter';
+import { REFUND_VAULT_ID, paymentRef } from './refund-vault';
+
+/**
+ * Builds, signs, and submits a refund from the browser.
+ *
+ * The merchant's key never leaves their wallet: this assembles the envelope,
+ * hands the XDR to Freighter, and submits whatever comes back. The server is
+ * not in the signing path at all, which is the point — Accensa is not a
+ * custodian, and a refund it could sign on its own would make it one.
+ *
+ * Callers are expected to have run the preflight first, so the common contract
+ * rejections are already reported before a signing prompt appears.
+ */
+
+const RPC_URL =
+ process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE =
+ process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+
+/** How long to wait for the network to make up its mind. */
+const CONFIRM_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 1_000;
+
+export interface RefundInput {
+ txHash: string;
+ recipient: string;
+ /** Stroops, decimal string. Never a float. */
+ amount: string;
+ paidAtLedger: number;
+ merchant: string;
+}
+
+export type RefundOutcome =
+ | { status: 'confirmed'; hash: string }
+ /** Accepted by the network but still pending when we stopped waiting. */
+ | { status: 'pending'; hash: string }
+ | { status: 'failed'; message: string; hash?: string };
+
+export async function submitRefund(input: RefundInput): Promise<RefundOutcome> {
+ const server = new rpc.Server(RPC_URL, { allowHttp: RPC_URL.startsWith('http://') });
+
+ try {
+ // The real sequence number matters here, unlike in the read-only
+ // simulations elsewhere: this transaction is actually submitted.
+ const account = await server.getAccount(input.merchant);
+
+ const operation = new Contract(REFUND_VAULT_ID).call(
+ 'refund',
+ xdr.ScVal.scvBytes(Buffer.from(paymentRef(input.txHash), 'hex')),
+ new Address(input.recipient).toScVal(),
+ nativeToScVal(BigInt(input.amount), { type: 'i128' }),
+ nativeToScVal(input.paidAtLedger, { type: 'u32' }),
+ );
+
+ const built = new TransactionBuilder(account, {
+ fee: '1000000',
+ networkPassphrase: NETWORK_PASSPHRASE,
+ })
+ .addOperation(operation)
+ .setTimeout(180)
+ .build();
+
+ // prepareTransaction re-simulates and attaches the resource footprint and
+ // fees the contract call needs. Submitting without it is rejected.
+ const prepared = await server.prepareTransaction(built);
+
+ const signedXdr = await signTransaction(prepared.toXDR(), {
+ networkPassphrase: NETWORK_PASSPHRASE,
+ address: input.merchant,
+ });
+
+ const signed = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+ const sent = await server.sendTransaction(signed);
+
+ if (sent.status === 'ERROR') {
+ return { status: 'failed', message: 'The network rejected the transaction.', hash: sent.hash };
+ }
+
+ return await waitForConfirmation(server, sent.hash);
+ } catch (error) {
+ return { status: 'failed', message: describe(error) };
+ }
+}
+
+async function waitForConfirmation(server: rpc.Server, hash: string): Promise<RefundOutcome> {
+ const deadline = Date.now() + CONFIRM_TIMEOUT_MS;
+
+ while (Date.now() < deadline) {
+ const result = await server.getTransaction(hash);
+
+ if (result.status === 'SUCCESS') return { status: 'confirmed', hash };
+ if (result.status === 'FAILED') {
+ return { status: 'failed', message: 'The refund failed on-chain.', hash };
+ }
+ await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+ }
+
+ // Not a failure: the transaction is in the network's hands and may still
+ // succeed. Saying "failed" here could prompt a second refund of the same
+ // payment, which the contract would reject but the merchant would not
+ // understand.
+ return { status: 'pending', hash };
+}
+
+function describe(error: unknown): string {
+ if (error instanceof Error && error.message) return error.message;
+ return 'The refund could not be submitted.';
+}

--- a/apps/web/src/lib/refund-vault.test.ts
+++ b/apps/web/src/lib/refund-vault.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+ REFUND_ERRORS,
+ describeRefundError,
+ parseContractErrorCode,
+ paymentRef,
+} from './refund-vault';
+
+const HASH = 'a'.repeat(64);
+
+describe('paymentRef', () => {
+ it('accepts a 32-byte hex hash and normalises case', () => {
+ expect(paymentRef('AB'.repeat(32))).toBe('ab'.repeat(32));
+ });
+
+ it('tolerates surrounding whitespace from a paste', () => {
+ expect(paymentRef(`  ${HASH}\n`)).toBe(HASH);
+ });
+
+ it('rejects anything that is not exactly 32 bytes', () => {
+ expect(() => paymentRef('abc')).toThrow();
+ expect(() => paymentRef('a'.repeat(63))).toThrow();
+ expect(() => paymentRef('a'.repeat(65))).toThrow();
+ expect(() => paymentRef('')).toThrow();
+ });
+
+ it('rejects non-hex characters rather than truncating them', () => {
+ // A silently truncated reference would refund against the wrong record.
+ expect(() => paymentRef('z'.repeat(64))).toThrow();
+ expect(() => paymentRef(`0x${'a'.repeat(62)}`)).toThrow();
+ });
+});
+
+describe('parseContractErrorCode', () => {
+ it('reads the discriminant out of a Soroban contract error', () => {
+ expect(parseContractErrorCode('HostError: Error(Contract, #4)')).toBe(4);
+ expect(parseContractErrorCode('Error(Contract, #6)')).toBe(6);
+ });
+
+ it('tolerates spacing differences', () => {
+ expect(parseContractErrorCode('Error(Contract,#5)')).toBe(5);
+ });
+
+ it('reads the alternate ContractError shape', () => {
+ expect(parseContractErrorCode('ContractError(8)')).toBe(8);
+ });
+
+ it('returns null for failures that are not contract errors', () => {
+ // An RPC outage is not a verdict on the refund, and reporting it as one
+ // would tell the merchant something false about their payment.
+ expect(parseContractErrorCode('fetch failed')).toBeNull();
+ expect(parseContractErrorCode('Error(WasmVm, InvalidAction)')).toBeNull();
+ expect(parseContractErrorCode('')).toBeNull();
+ });
+});
+
+describe('describeRefundError', () => {
+ it('has a message for every code the contract can return', () => {
+ for (const code of Object.keys(REFUND_ERRORS).map(Number)) {
+ const message = describeRefundError(code);
+ expect(message.length).toBeGreaterThan(0);
+ expect(message).not.toContain('error code');
+ }
+ });
+
+ it('names the three states a merchant actually hits', () => {
+ expect(describeRefundError(4)).toMatch(/already been refunded/i);
+ expect(describeRefundError(5)).toMatch(/window/i);
+ expect(describeRefundError(6)).toMatch(/float/i);
+ });
+
+ it('falls back without pretending to know an unmapped code', () => {
+ expect(describeRefundError(99)).toContain('99');
+ });
+});

--- a/apps/web/src/lib/refund-vault.ts
+++ b/apps/web/src/lib/refund-vault.ts
@@ -1,0 +1,210 @@
+import {
+ Account,
+ Address,
+ Contract,
+ Networks,
+ TransactionBuilder,
+ nativeToScVal,
+ rpc,
+ scValToNative,
+ xdr,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Reads the RefundVault contract, and dry-runs refunds before they are signed.
+ *
+ * The contract exposes no getter for its refund window or its paused flag —
+ * both live in instance storage with no public accessor — so there is no way to
+ * render "you have N ledgers left" from chain state alone. Simulating the
+ * actual `refund` call is strictly better anyway: it runs the contract's own
+ * guards in order and returns the exact error the real submission would hit,
+ * rather than a guess reassembled from separate reads that could disagree with
+ * it. Nothing is signed and no fee is paid to find out.
+ */
+
+export const REFUND_VAULT_ID =
+ process.env.NEXT_PUBLIC_REFUND_VAULT_ID ??
+ 'CCMBM44EJUGD52G4LSMGHSXMAH2KSAQZX7VOYY4TTBF5BK4D7M4IHRQA';
+
+const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE = process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+
+/**
+ * Error discriminants from `contracts/refund-vault/src/lib.rs`.
+ *
+ * Kept in sync by hand; the contract is a separate repo with no generated
+ * bindings here. A code this file does not know is reported as unknown rather
+ * than mapped to the wrong message.
+ */
+export const REFUND_ERRORS = {
+ 1: 'AlreadyInitialized',
+ 2: 'NotInitialized',
+ 3: 'Unauthorized',
+ 4: 'AlreadyRefunded',
+ 5: 'WindowExpired',
+ 6: 'InsufficientFloat',
+ 7: 'InvalidAmount',
+ 8: 'Paused',
+ 9: 'RefundNotFound',
+} as const;
+
+export type RefundErrorName = (typeof REFUND_ERRORS)[keyof typeof REFUND_ERRORS];
+
+/**
+ * Merchant-facing wording.
+ *
+ * Each says what happened and what the merchant can do, because every one of
+ * these is reachable through the UI and "Error(Contract, #6)" is not something
+ * to put in front of someone trying to refund a customer.
+ */
+const MESSAGES: Record<RefundErrorName, string> = {
+ AlreadyInitialized: 'This vault is already initialised.',
+ NotInitialized: 'The refund vault has not been initialised yet.',
+ Unauthorized: 'Only the merchant account that owns this vault can issue refunds.',
+ AlreadyRefunded: 'This payment has already been refunded. A payment can only be refunded once.',
+ WindowExpired:
+ 'The refund window for this payment has closed. The window is set on the vault and counted in ledgers from the payment.',
+ InsufficientFloat:
+ 'The vault does not hold enough float to cover this refund. Deposit more before retrying.',
+ InvalidAmount: 'The refund amount must be greater than zero.',
+ Paused: 'Refunds are paused on this vault. Unpause it before issuing refunds.',
+ RefundNotFound: 'No refund record exists for this payment.',
+};
+
+/** Turns a contract error code into something worth showing a merchant. */
+export function describeRefundError(code: number): string {
+ const name = REFUND_ERRORS[code as keyof typeof REFUND_ERRORS];
+ return name ? MESSAGES[name] : `The contract rejected this refund with error code ${code}.`;
+}
+
+/**
+ * Pulls the contract error discriminant out of a simulation failure.
+ *
+ * Soroban reports these as `Error(Contract, #6)`. Returns null for anything
+ * else — an RPC outage or a malformed transaction is not a contract error, and
+ * reporting it as one would tell the merchant something false about their
+ * payment.
+ */
+export function parseContractErrorCode(message: string): number | null {
+ const match = /Error\(Contract,\s*#(\d+)\)/.exec(message);
+ if (match) return Number(match[1]);
+ // Some RPC versions surface the raw enum instead.
+ const alt = /ContractError\((\d+)\)/.exec(message);
+ return alt ? Number(alt[1]) : null;
+}
+
+/**
+ * A payment's reference in the vault.
+ *
+ * The transaction hash is used directly: it is exactly 32 bytes, globally
+ * unique, and already the thing both the merchant and the payer can point at.
+ * Deriving something else would mean the merchant could not check on an
+ * explorer what a refund record refers to.
+ */
+export function paymentRef(txHash: string): string {
+ const trimmed = txHash.trim().toLowerCase();
+ if (!/^[0-9a-f]{64}$/.test(trimmed)) {
+ throw new Error('Payment reference must be a 32-byte transaction hash in hex');
+ }
+ return trimmed;
+}
+
+export interface RefundRecord {
+ amount: string;
+ recipient: string;
+ ledger: number;
+}
+
+export type RefundPreflight =
+ /** The contract would accept this refund. */
+ | { status: 'ok' }
+ /** The contract would reject it, for a reason worth showing. */
+ | { status: 'rejected'; code: number; name: RefundErrorName | null; message: string }
+ /** We could not find out — RPC trouble, not a verdict on the refund. */
+ | { status: 'unknown'; message: string };
+
+function hexToBytes32(hex: string) {
+ return xdr.ScVal.scvBytes(Buffer.from(paymentRef(hex), 'hex'));
+}
+
+function server() {
+ return new rpc.Server(RPC_URL, { allowHttp: RPC_URL.startsWith('http://') });
+}
+
+function build(source: string, method: string, args: xdr.ScVal[]) {
+ return new TransactionBuilder(new Account(source, '0'), {
+ fee: '100',
+ networkPassphrase: NETWORK_PASSPHRASE,
+ })
+ .addOperation(new Contract(REFUND_VAULT_ID).call(method, ...args))
+ .setTimeout(30)
+ .build();
+}
+
+/** Reads an existing refund record, or null when the payment was never refunded. */
+export async function getRefund(txHash: string, source: string): Promise<RefundRecord | null> {
+ const sim = await server().simulateTransaction(build(source, 'get_refund', [hexToBytes32(txHash)]));
+
+ if (rpc.Api.isSimulationError(sim)) throw new Error(sim.error);
+ if (!('result' in sim) || !sim.result?.retval) return null;
+
+ const raw = scValToNative(sim.result.retval) as Record<string, unknown> | null;
+ if (!raw) return null;
+
+ return {
+ amount: String(raw.amount ?? '0'),
+ recipient: String(raw.recipient ?? ''),
+ ledger: Number(raw.ledger ?? 0),
+ };
+}
+
+/**
+ * Dry-runs a refund against the live contract.
+ *
+ * `merchant` is the address that would sign. It matters: the contract's
+ * `require_auth` runs during simulation, so passing the wrong account reports
+ * Unauthorized here rather than after the merchant has signed.
+ */
+export async function preflightRefund(input: {
+ txHash: string;
+ recipient: string;
+ /** Stroops, as a decimal string. Never a float. */
+ amount: string;
+ paidAtLedger: number;
+ merchant: string;
+}): Promise<RefundPreflight> {
+ let tx;
+ try {
+ tx = build(input.merchant, 'refund', [
+ hexToBytes32(input.txHash),
+ new Address(input.recipient).toScVal(),
+ nativeToScVal(BigInt(input.amount), { type: 'i128' }),
+ nativeToScVal(input.paidAtLedger, { type: 'u32' }),
+ ]);
+ } catch (error) {
+ return { status: 'unknown', message: error instanceof Error ? error.message : 'Invalid input' };
+ }
+
+ let sim;
+ try {
+ sim = await server().simulateTransaction(tx);
+ } catch (error) {
+ return {
+ status: 'unknown',
+ message: error instanceof Error ? error.message : 'Could not reach the network',
+ };
+ }
+
+ if (rpc.Api.isSimulationError(sim)) {
+ const code = parseContractErrorCode(sim.error);
+ if (code === null) return { status: 'unknown', message: sim.error };
+ return {
+ status: 'rejected',
+ code,
+ name: REFUND_ERRORS[code as keyof typeof REFUND_ERRORS] ?? null,
+ message: describeRefundError(code),
+ };
+ }
+
+ return { status: 'ok' };
+}


### PR DESCRIPTION
Closes #16.

Refunds are the core merchant action and had no UI at all.

## Preflight-first, by necessity and by preference

Before any signing prompt appears, the server simulates the **real** `refund` call against the live contract and reports what it would do.

This started as a workaround: the contract exposes no getter for its refund window or its paused flag — both live in instance storage with no public accessor — so acceptance criterion 2 ("vault float balance and refund-window state shown before confirming") cannot be satisfied by reading chain state directly.

It turned out to be the better design anyway. Simulating the actual call runs the contract's own guards **in their real order** and returns the exact error the real submission would hit, rather than an answer reassembled from separate reads that could disagree with it. Nothing is signed and no fee is paid to find out.

## Error mapping

| Contract error | What the merchant sees |
|---|---|
| `AlreadyRefunded` | Already refunded; a payment can only be refunded once |
| `WindowExpired` | The window has closed, and what the window is counted in |
| `InsufficientFloat` | Not enough float; deposit more before retrying |
| `Paused` | Refunds are paused on this vault |

Those first three are the ones reachable through normal use. `Error(Contract, #6)` is not something to put in front of someone trying to refund a customer. A code the mapping does not recognise is reported as unknown rather than mapped to the nearest message — and an RPC failure is reported as `unknown`, never as a contract verdict, because saying "this payment was already refunded" when the network merely timed out would be a lie about someone's money.

## The server is not in the signing path

Signing happens in the merchant's wallet. Accensa holds no key that can move a merchant's float — a refund it could issue on its own would make it a custodian, which is the specific thing the product claims not to be.

## Pending is not failed

A submitted-but-unconfirmed refund reports as **pending**, with a link to the transaction. Calling it failed would invite a second attempt at a refund that may already be in flight; the vault would reject the duplicate, but the merchant would have no idea why.

## Scope limit, stated plainly

**Refunded rows are marked, but only for refunds issued in the current session.** `RefundVault` emits a `RefundEvent`, but the indexer does not watch the vault yet, so there is no durable per-payment refund state to read on page load. Opening a payment *does* re-read `get_refund` and reports an existing refund accurately — so nothing is ever wrongly shown as refundable — but the table badge does not survive a reload. Durable marking needs vault events indexed, which is indexer work outside this issue.

Money stays a decimal string end to end; the preflight API rejects a numeric `amount` outright rather than letting a refund pass through a float on its way to an `i128`.

## Verification

- `pnpm test` in `apps/web`: **164 passing**, 11 files, including 11 new tests covering payment-ref validation (non-hex and wrong-length inputs are rejected rather than truncated — a truncated ref would refund against the wrong record), contract-error parsing across both Soroban shapes, and complete message coverage for every error the contract can return.
- `pnpm exec tsc --noEmit`: clean.
- `pnpm lint`: 0 errors.

**Not verified:** the submit path itself. There is no Freighter extension and no funded merchant key in this environment, so build → sign → submit → confirm has been typechecked and reasoned through but never executed against testnet. That wants a manual pass with a real wallet before it is trusted, and I would rather say so than imply otherwise.