### PR TITLE
fix(sync): restore the indexer and stop the cursor stranding itself

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,6 +23,28 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      # A green run used to prove only that something answered 200. On
+      # 2026-08-06 the route was replaced by a stub that returned
+      # {"success":true} and indexed nothing, and this workflow reported
+      # success for four days while the ledger cursor stood still. These two
+      # checks are what that costs: the endpoint must reject an unauthenticated
+      # caller, and every reply must carry the cursor a real sync commits.
+      - name: Check the endpoint is authenticated
+        env:
+          SYNC_URL: ${{ secrets.SYNC_URL }}
+        run: |
+          if [ -z "$SYNC_URL" ]; then
+            echo "SYNC_URL secret is not set"; exit 1
+          fi
+
+          code=$(curl -sS --max-time 60 -o /dev/null -w '%{http_code}' "$SYNC_URL")
+          if [ "$code" != "401" ]; then
+            echo "::error::Unauthenticated GET returned HTTP $code, expected 401." \
+                 "CRON_SECRET is not being enforced."
+            exit 1
+          fi
+          echo "Unauthenticated GET correctly rejected with 401."
+
       - name: Call sync endpoint in a loop
         env:
           SYNC_URL: ${{ secrets.SYNC_URL }}
@@ -31,7 +53,7 @@ jobs:
           if [ -z "$SYNC_URL" ]; then
             echo "SYNC_URL secret is not set"; exit 1
           fi
-          
+
           # Run for 55 minutes to allow 5 minutes for the next hourly job to start
           END_TIME=$(( $(date +%s) + 3300 ))
           
@@ -50,10 +72,25 @@ jobs:
               echo "::warning::Sync failed with HTTP $code"
             elif printf '%s' "$body" | grep -q '"success":false'; then
               echo "::warning::Sync reported failure"
+            elif printf '%s' "$body" | grep -q '"cooldown":true'; then
+              echo "Skipped: a sync ran within the cooldown window."
+            elif ! printf '%s' "$body" | grep -q '"syncedTo"'; then
+              # Not a transient fault. Whatever is answering is not the indexer,
+              # so there is nothing to be gained by polling it for another hour.
+              echo "::error::Reply carries no syncedTo cursor, so no indexing took place." \
+                   "The /api/sync route is not running the indexer."
+              exit 1
             elif printf '%s' "$body" | grep -q '"drained":false'; then
               echo "::warning::Incomplete sync: paging stopped against the time budget."
             fi
-            
+
+            # Ledgers the RPC no longer retains. Not recoverable by any later
+            # run, so it is reported even when the sync itself was healthy.
+            if printf '%s' "$body" | grep -qE '"skippedLedgers":[1-9]'; then
+              skipped=$(printf '%s' "$body" | grep -oE '"skippedLedgers":[0-9]+' | cut -d: -f2)
+              echo "::warning::Cursor fell outside RPC retention; $skipped ledgers skipped."
+            fi
+
             echo "Sleeping for 5 minutes..."
             sleep 300
           done

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -51,6 +51,29 @@ declared schedule, so a normal gap is not reported to the merchant as a fault.
 If you move off Hobby, raise the `vercel.json` cron and retire the Actions
 workflow — do not run both, or the cursor gets contention from two writers.
 
+**The cadence is not cosmetic.** Soroban RPC serves `getEvents` for roughly the
+last 121,000 ledgers, about a week of testnet. If the cursor stops advancing for
+longer than that it falls outside the retained window, and the ledgers in between
+are unrecoverable — no later run can reach them. A sync that skipped ledgers this
+way reports `skippedLedgers` in its response and `sync.yml` raises a warning; it
+is the one failure here that cannot be fixed by running the job again.
+
+## Reading a sync response
+
+```json
+{ "success": true, "latestLedger": 4067288, "startLedger": 3967288,
+  "syncedTo": 4067288, "skippedLedgers": 0, "drained": true,
+  "pages": 11, "windows": 11, "scanned": 1, "decoded": 1, "inserted": 1 }
+```
+
+| Field | Meaning |
+|---|---|
+| `syncedTo` | Where the cursor now stands. A reply without this field is not the indexer — `sync.yml` fails the run on it. |
+| `drained` | False when paging stopped against the time budget. Not a fault; the next run resumes from `syncedTo`. |
+| `windows` | `getEvents` calls made. Requests are bounded to 10,000 ledgers because the RPC silently truncates wider ranges. |
+| `skippedLedgers` | Ledgers lost to the retention window. Should always be 0. |
+| `scanned` / `decoded` / `inserted` | Events matched, decoded as transfers, and written. |
+
 ## Database connection
 
 Use the **Session pooler** connection string, not Direct.

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -1,11 +1,327 @@
 import { NextResponse } from 'next/server';
+import {
+ decodeTransferEvent,
+ transferTopicFilter,
+ addressTopicFilter,
+} from '@/lib/stellar-events';
+import {
+ withClient,
+ ensureSchema,
+ getLastSyncedLedger,
+ setLastSyncedLedger,
+ getSyncState,
+} from '@/lib/db';
+import { sweepLedgerRange, EVENTS_PAGE_LIMIT, type EventPage } from '@/lib/event-pager';
+import { cooldownRemaining } from '@/lib/sync-status';
 
 export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
 
-export async function GET() {
-  return NextResponse.json({ success: true, message: 'Sync logic migrated to background worker' });
+const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+
+/**
+ * Stellar Asset Contracts whose `transfer` events represent revenue. Defaults
+ * to the testnet native XLM SAC; set ASSET_CONTRACT_IDS to a comma-separated
+ * list to settle in USDC or across multiple assets.
+ */
+const ASSET_CONTRACT_IDS = (
+ process.env.ASSET_CONTRACT_IDS ??
+ 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
+)
+ .split(',')
+ .map((s) => s.trim())
+ .filter(Boolean);
+
+/** Ledgers to look back on a cold start, when no cursor has been stored yet. */
+const COLD_START_LOOKBACK = 2_000;
+
+/**
+ * Soroban RPC retains only a limited window of ledgers for getEvents.
+ *
+ * Testnet reported `oldestLedger` about 121,000 behind head on 2026-08-10, so
+ * this sits inside it with room to spare. Anything older is simply gone, and a
+ * cursor that falls behind it loses the difference for good - see
+ * `skippedLedgers` below.
+ */
+const MAX_LOOKBACK = 100_000;
+
+/**
+ * Wall-clock budget for paging, in milliseconds.
+ *
+ * Held below `maxDuration` so that a backlog too large for one invocation stops
+ * cleanly and commits its progress, rather than being killed mid-range with
+ * nothing written. The next run resumes from the committed cursor.
+ *
+ * The budget is checked between windows, so a run can overshoot it by one
+ * window. A full 100,000-ledger catch-up measured 55s end to end, which is why
+ * this leaves ~20s of headroom under `maxDuration` rather than a token margin.
+ */
+const PAGING_BUDGET_MS = 40_000;
+
+/**
+ * Minimum gap between manual syncs.
+ *
+ * The dashboard is public and unauthenticated, so the POST entry point is too.
+ * Indexing is idempotent, so repeated calls cannot corrupt anything, but each
+ * one costs Soroban RPC round trips, a database connection and a function
+ * invocation. This bounds what a held-down button, or anyone with curl, can
+ * spend. A scheduled run counts too - if the data is already current, there is
+ * nothing for a manual sync to do.
+ */
+const MANUAL_COOLDOWN_MS = 60_000;
+
+async function rpc<T>(method: string, params: unknown, maxAttempts = 3): Promise<T> {
+ let attempt = 0;
+ while (attempt < maxAttempts) {
+ attempt++;
+ try {
+ const res = await fetch(RPC_URL, {
+ method: 'POST',
+ headers: { 'Content-Type': 'application/json' },
+ body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+ cache: 'no-store',
+ });
+ if (!res.ok) throw new Error(`RPC ${method} failed: ${res.status}`);
+ const body = await res.json();
+ if (body.error) throw new Error(`RPC ${method}: ${body.error.message ?? 'unknown error'}`);
+ return body.result as T;
+ } catch (error) {
+ if (attempt >= maxAttempts) throw error;
+ await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 100)); // Exponential backoff
+ }
+ }
+ throw new Error('Unreachable');
 }
 
+/** Reports a cooldown rather than syncing, when one is in force. */
+interface CooldownResult {
+ cooldown: true;
+ retryAfterMs: number;
+}
+
+/**
+ * Indexes Stellar Asset Contract transfers into the merchant's payment ledger.
+ *
+ * Shared by both entry points: the scheduled GET, and the POST behind the
+ * dashboard's manual trigger. `cooldownMs`, when set, makes the run a no-op if
+ * the last sync is more recent than that.
+ */
+async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
+ return withClient(async (client) => {
+ await ensureSchema(client);
+
+ if (opts.cooldownMs) {
+ const state = await getSyncState(client);
+ const retryAfterMs = cooldownRemaining(state?.updatedAt, opts.cooldownMs);
+ if (retryAfterMs > 0) return { cooldown: true, retryAfterMs } as CooldownResult;
+ }
+
+ {
+ const { sequence: latestLedger } = await rpc<{ sequence: number }>('getLatestLedger', {});
+
+ const cursor = await getLastSyncedLedger(client);
+ const resumeFrom = cursor !== null ? cursor + 1 : latestLedger - COLD_START_LOOKBACK;
+ const retentionFloor = latestLedger - MAX_LOOKBACK;
+ const startLedger = Math.max(resumeFrom, retentionFloor, 1);
+
+ // The clamp above is not free: when the cursor has fallen outside what the
+ // RPC still serves, the ledgers in between are skipped and no later run can
+ // recover them. Report the gap rather than let it vanish into a success.
+ const skippedLedgers = Math.max(0, retentionFloor - resumeFrom);
+
+ if (startLedger > latestLedger) {
+ return {
+ latestLedger,
+ startLedger,
+ syncedTo: startLedger - 1,
+ skippedLedgers,
+ drained: true,
+ pages: 0,
+ scanned: 0,
+ decoded: 0,
+ inserted: 0,
+ };
+ }
+
+ // Filter server-side to transfers addressed to this merchant. The asset
+ // topic is optional across protocol versions, so match both arities.
+ const toTopic = addressTopicFilter(merchant);
+ const transfer = transferTopicFilter();
+ const filters = [
+ {
+ type: 'contract',
+ contractIds: ASSET_CONTRACT_IDS,
+ topics: [
+ [transfer, '*', toTopic, '*'],
+ [transfer, '*', toTopic],
+ ],
+ },
+ ];
+
+ // The limit belongs under `pagination`; sent at the top level the RPC
+ // ignores it and applies its own default.
+ const deadline = Date.now() + PAGING_BUDGET_MS;
+ const { events, sweptThrough, complete, pages, windows } = await sweepLedgerRange(
+ ({ startLedger: from, endLedger: to, cursor: pageCursor }) =>
+ rpc<EventPage>('getEvents', {
+ ...(pageCursor ? {} : { startLedger: from, endLedger: to }),
+ filters,
+ pagination: { limit: EVENTS_PAGE_LIMIT, ...(pageCursor ? { cursor: pageCursor } : {}) },
+ xdrFormat: 'base64',
+ }),
+ { startLedger, endLedger: latestLedger, withinBudget: () => Date.now() < deadline },
+ );
+
+ let inserted = 0;
+ let decoded = 0;
+
+ for (const event of events) {
+ const transferEvent = decodeTransferEvent(event);
+ // A malformed or non-transfer event must not stall the batch.
+ if (!transferEvent) continue;
+ decoded++;
+
+ // Defensive: never record a transfer that is not to this merchant.
+ if (transferEvent.to !== merchant) continue;
+
+ // DO UPDATE, not DO NOTHING: a row may already exist because the
+ // merchant reported route attribution before this transfer was
+ // indexed, which is the normal ordering — the hook fires the moment
+ // x402 settles, this job runs on a schedule. Skipping the conflict
+ // would leave that row permanently null and invisible.
+ //
+ // Only ledger-owned columns are written. route, method, request_id and
+ // hook_reported_at belong to the merchant's report and are left alone.
+  const res = await client.query(
+  `INSERT INTO payments (tx_hash, ledger, payer, amount, asset, ts)
+  VALUES ($1, $2, $3, $4::numeric, $5, $6::timestamptz)
+  ON CONFLICT (tx_hash) DO UPDATE
+  SET ledger = EXCLUDED.ledger,
+  payer = EXCLUDED.payer,
+  amount = EXCLUDED.amount,
+  asset = EXCLUDED.asset,
+  ts = EXCLUDED.ts
+  WHERE payments.ledger IS NULL RETURNING *`,
+  [
+  transferEvent.txHash,
+  transferEvent.ledger,
+  transferEvent.from,
+  transferEvent.amount, // string - never a float
+  transferEvent.asset,
+  transferEvent.ledgerClosedAt,
+  ],
+  );
+  if (res.rowCount && res.rowCount > 0 && process.env.WEBHOOK_URL) {
+    const payment = res.rows[0];
+    const timeoutMs = 2000;
+    for (let i = 0; i < 3; i++) {
+      try {
+        const controller = new AbortController();
+        const id = setTimeout(() => controller.abort(), timeoutMs);
+        const webhookRes = await fetch(process.env.WEBHOOK_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payment),
+          signal: controller.signal
+        });
+        clearTimeout(id);
+        if (webhookRes.ok || webhookRes.status < 500) break;
+      } catch {
+        // A webhook the merchant cannot receive must not stall indexing.
+      }
+    }
+  }
+  inserted += res.rowCount ?? 0;
+ }
+
+ // The sweep only ever reports whole windows, so this is safe whether or
+ // not it reached the head. Crucially it advances across empty windows
+ // too - a quiet merchant that never moved the cursor is how the indexer
+ // fell behind the RPC retention window and stopped seeing payments.
+ await setLastSyncedLedger(client, sweptThrough);
+
+ return {
+ latestLedger,
+ startLedger,
+ syncedTo: sweptThrough,
+ skippedLedgers,
+ drained: complete,
+ pages,
+ windows,
+ scanned: events.length,
+ decoded,
+ inserted,
+ };
+ }
+ });
+}
+
+/** Maps a run to a response, so both entry points answer identically. */
+function respond(result: Awaited<ReturnType<typeof runSync>>) {
+ if ('cooldown' in result) {
+ const retryAfterMs = Math.ceil(result.retryAfterMs);
+ return NextResponse.json(
+ { success: true, cooldown: true, retryAfterMs },
+ { status: 429, headers: { 'Retry-After': String(Math.ceil(retryAfterMs / 1000)) } },
+ );
+ }
+ return NextResponse.json({ success: true, ...result });
+}
+
+function configError(): NextResponse | null {
+ if (!process.env.MERCHANT_ADDRESS) {
+ return NextResponse.json({ error: 'MERCHANT_ADDRESS is not configured' }, { status: 500 });
+ }
+ if (!process.env.DATABASE_URL) {
+ return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+ }
+ return null;
+}
+
+function failed(error: unknown) {
+ const message = error instanceof Error ? error.message : 'Unknown error';
+ return NextResponse.json({ success: false, error: message }, { status: 500 });
+}
+
+/**
+ * Scheduled entry point.
+ *
+ * Driven by Vercel Cron and by .github/workflows/sync.yml. Protected by
+ * CRON_SECRET when set - both senders pass it as a bearer token - so the
+ * endpoint cannot be driven by arbitrary callers. No cooldown: a scheduled run
+ * is already rate limited by its schedule.
+ */
+export async function GET(request: Request) {
+ const secret = process.env.CRON_SECRET;
+ if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
+ return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+ }
+
+ const bad = configError();
+ if (bad) return bad;
+
+ try {
+ return respond(await runSync(process.env.MERCHANT_ADDRESS as string));
+ } catch (error: unknown) {
+ return failed(error);
+ }
+}
+
+/**
+ * Manual entry point, behind the dashboard's"Sync now"button.
+ *
+ * Deliberately not behind CRON_SECRET: the dashboard is public and a browser
+ * cannot hold a secret. MANUAL_COOLDOWN_MS is what bounds the cost instead.
+ */
 export async function POST() {
-  return NextResponse.json({ success: true, message: 'Sync logic migrated to background worker' });
+ const bad = configError();
+ if (bad) return bad;
+
+ try {
+ return respond(
+ await runSync(process.env.MERCHANT_ADDRESS as string, { cooldownMs: MANUAL_COOLDOWN_MS }),
+ );
+ } catch (error: unknown) {
+ return failed(error);
+ }
 }

--- a/apps/web/src/lib/event-pager.test.ts
+++ b/apps/web/src/lib/event-pager.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { drainEvents, safeCursorLedger, EVENTS_PAGE_LIMIT, type EventPage } from './event-pager';
+import {
+ drainEvents,
+ sweepLedgerRange,
+ EVENTS_PAGE_LIMIT,
+ LEDGER_WINDOW,
+ type EventPage,
+} from './event-pager';
 import type { RawEvent } from './stellar-events';
 
 /** Builds `count` events spread across ledgers, ids ascending from `from`. */
@@ -101,23 +107,117 @@ describe('drainEvents', () => {
  });
 });
 
-describe('safeCursorLedger', () => {
- it('advances to the last ledger seen on a complete read', () => {
- expect(safeCursorLedger(520, true, 500)).toBe(520);
+/**
+ * A fake RPC that honours the ledger window, the way Soroban RPC does.
+ *
+ * Deliberately returns nothing for events outside `[startLedger, endLedger]`:
+ * the bug this guards against is a caller assuming an unbounded request was
+ * answered in full.
+ */
+function windowedSource(all: RawEvent[]) {
+ const windows: Array<{ startLedger?: number; endLedger?: number }> = [];
+ const fetchPage = async (params: {
+ startLedger?: number;
+ endLedger?: number;
+ cursor?: string;
+ }): Promise<EventPage> => {
+ if (!params.cursor) windows.push({ startLedger: params.startLedger, endLedger: params.endLedger });
+ const from = params.startLedger ?? 0;
+ const to = params.endLedger ?? Number.MAX_SAFE_INTEGER;
+ const inRange = all.filter((e) => (e.ledger ?? 0) >= from && (e.ledger ?? 0) <= to);
+ const offset = params.cursor ? inRange.findIndex((e) => e.id === params.cursor) + 1 : 0;
+ const events = inRange.slice(offset, offset + EVENTS_PAGE_LIMIT);
+ return { events, cursor: events.length ? events[events.length - 1].id : undefined };
+ };
+ return { fetchPage, windows };
+}
+
+describe('sweepLedgerRange', () => {
+ it('covers the whole range in windows the RPC will honour', async () => {
+ const { fetchPage, windows } = windowedSource([]);
+
+ const result = await sweepLedgerRange(fetchPage, {
+ startLedger: 1_000,
+ endLedger: 1_000 + LEDGER_WINDOW * 2,
  });
 
- it('stops one short on a partial read, so the split ledger is replayed', () => {
- expect(safeCursorLedger(520, false, 500)).toBe(519);
+ expect(result.complete).toBe(true);
+ expect(result.sweptThrough).toBe(1_000 + LEDGER_WINDOW * 2);
+ expect(result.windows).toBe(3);
+ // Contiguous, non-overlapping, and never wider than one window.
+ expect(windows[0]).toEqual({ startLedger: 1_000, endLedger: 1_000 + LEDGER_WINDOW - 1 });
+ expect(windows[1].startLedger).toBe(windows[0].endLedger! + 1);
+ expect(windows[2].endLedger).toBe(1_000 + LEDGER_WINDOW * 2);
  });
 
- it('makes no progress when nothing decodable was seen', () => {
- expect(safeCursorLedger(0, true, 500)).toBe(499);
- expect(safeCursorLedger(0, false, 500)).toBe(499);
+ it('advances through a range that held no events at all', async () => {
+ // The regression that stranded the indexer. A quiet merchant used to leave
+ // the cursor where it was, so the gap to the chain head grew until it passed
+ // the RPC retention window and new payments stopped being seen entirely.
+ const { fetchPage } = windowedSource([]);
+
+ const result = await sweepLedgerRange(fetchPage, { startLedger: 500, endLedger: 40_000 });
+
+ expect(result.events).toHaveLength(0);
+ expect(result.sweptThrough).toBe(40_000);
+ expect(result.complete).toBe(true);
  });
 
- it('never regresses below the start of the range', () => {
- // A partial read whose only ledger is the first in range must not rewind.
- expect(safeCursorLedger(500, false, 500)).toBe(499);
- expect(safeCursorLedger(499, true, 500)).toBe(499);
+ it('finds an event that a single unbounded request would have missed', async () => {
+ // The event sits near the head, far past what one getEvents call scans.
+ const { fetchPage } = windowedSource(makeEvents(1, () => 99_000));
+
+ const result = await sweepLedgerRange(fetchPage, { startLedger: 1, endLedger: 100_000 });
+
+ expect(result.events.map((e) => e.ledger)).toEqual([99_000]);
+ expect(result.complete).toBe(true);
+ });
+
+ it('stops on a window boundary when the budget runs out', async () => {
+ const { fetchPage } = windowedSource([]);
+ let calls = 0;
+
+ const result = await sweepLedgerRange(fetchPage, {
+ startLedger: 1,
+ endLedger: 100_000,
+ withinBudget: () => ++calls <= 2,
+ });
+
+ expect(result.complete).toBe(false);
+ // Two windows cleared before the budget went. The cursor lands on that
+ // boundary, so the next run resumes cleanly rather than inside a window it
+ // only partly read.
+ expect(result.sweptThrough).toBe(LEDGER_WINDOW * 2);
+ expect(result.windows).toBe(2);
+ });
+
+ it('makes no progress when the budget runs out before the first window', async () => {
+ const { fetchPage } = windowedSource([]);
+
+ const result = await sweepLedgerRange(fetchPage, {
+ startLedger: 5_000,
+ endLedger: 100_000,
+ withinBudget: () => false,
+ });
+
+ expect(result.complete).toBe(false);
+ expect(result.sweptThrough).toBe(4_999);
+ expect(result.windows).toBe(0);
+ });
+
+ it('never advances past a window it did not finish', async () => {
+ // 250 events in one ledger: the window needs two pages, and the budget dies
+ // between them. The cursor must not step over the half it never read.
+ const { fetchPage } = windowedSource(makeEvents(250, () => 2_000));
+ let calls = 0;
+
+ const result = await sweepLedgerRange(fetchPage, {
+ startLedger: 1,
+ endLedger: 100_000,
+ withinBudget: () => ++calls <= 1,
+ });
+
+ expect(result.complete).toBe(false);
+ expect(result.sweptThrough).toBe(0);
  });
 });

--- a/apps/web/src/lib/event-pager.ts
+++ b/apps/web/src/lib/event-pager.ts
@@ -23,35 +23,53 @@ export interface DrainResult {
 }
 
 /**
- * Reads every page of a `getEvents` range.
+ * Ledgers covered by a single `getEvents` request.
+ *
+ * Soroban RPC bounds how much history one call will scan, and it does not fail
+ * loudly when a range exceeds that bound: asked for 100,000 ledgers it returns
+ * an empty page with a cursor, or `[-32001] request exceeded processing limit
+ * threshold`, depending on load. An empty page is indistinguishable from"no
+ * payments here", which is how a backlog turns into silent data loss. Every
+ * request is therefore bounded to a window the RPC will actually scan.
+ *
+ * Measured against testnet: 10,000 ledgers answers in ~3.4s, and a 45s budget
+ * covers more than the RPC's whole retention window in one invocation.
+ */
+export const LEDGER_WINDOW = 10_000;
+
+/**
+ * Reads every page of one bounded `getEvents` window.
  *
  * `getEvents` returns at most one page per call. Taking only the first page and
  * then advancing the sync cursor past it silently discards the remainder --
  * payments that exist on chain but never reach the merchant's ledger. So this
- * follows the cursor until the range is exhausted.
+ * follows the cursor until the window is exhausted.
  *
  * `withinBudget` bounds the work: a serverless invocation has a wall clock
- * limit, and a large backlog can exceed it. When the budget runs out mid-range
+ * limit, and a busy window can exceed it. When the budget runs out mid-window
  * the caller is told, via `drained: false`, that it is holding a partial result.
  */
 export async function drainEvents(
- fetchPage: (params: { startLedger?: number; cursor?: string }) => Promise<EventPage>,
- opts: { startLedger: number; withinBudget?: () => boolean },
+ fetchPage: (params: {
+ startLedger?: number;
+ endLedger?: number;
+ cursor?: string;
+ }) => Promise<EventPage>,
+ opts: { startLedger: number; endLedger?: number; withinBudget?: () => boolean },
 ): Promise<DrainResult> {
- const { startLedger, withinBudget } = opts;
+ const { startLedger, endLedger, withinBudget } = opts;
  const events: RawEvent[] = [];
  let cursor: string | undefined;
  let pages = 0;
 
  for (;;) {
  // A cursor supersedes startLedger; sending both is rejected by the RPC.
- const page = await fetchPage(cursor ? { cursor } : { startLedger });
+ const page = await fetchPage(cursor ? { cursor } : { startLedger, endLedger });
  pages++;
  events.push(...page.events);
 
- // A short page means the range is exhausted, whether or not a cursor came
- // back with it. Trusting the cursor alone would loop forever against an
- // RPC that always returns one.
+ // Within a bounded window a short page really does mean exhausted. Trusting
+ // the cursor alone would loop forever against an RPC that always returns one.
  if (page.events.length < EVENTS_PAGE_LIMIT) return { events, drained: true, pages };
 
  const next = page.cursor ?? page.events[page.events.length - 1]?.id;
@@ -62,24 +80,69 @@ export async function drainEvents(
  }
 }
 
+export interface SweepResult {
+ events: RawEvent[];
+ /**
+  * The last ledger known to be fully consumed, and so the furthest the sync
+  * cursor may advance. Only ever a completed window boundary, so it is safe
+  * whether or not the sweep finished.
+  */
+ sweptThrough: number;
+ /** True when the sweep reached `endLedger` rather than stopping on budget. */
+ complete: boolean;
+ pages: number;
+ windows: number;
+}
+
 /**
- * The ledger the sync cursor may safely advance to.
+ * Sweeps `[startLedger, endLedger]` in windows the RPC will honour.
  *
- * Events arrive in ledger order, so a partial read ends somewhere inside a
- * ledger rather than on a boundary. Advancing to that ledger would skip the
- * events in it that were never fetched, and nothing would ever look at that
- * range again. Stopping one short replays it instead -- the payments upsert is
- * idempotent, so replay costs a little work and loses nothing.
- *
- * Returns `startLedger - 1` (no progress) when nothing decodable was seen,
- * never a value below it.
+ * The cursor advances only across whole windows. A window abandoned against the
+ * budget contributes its events -- the payments upsert is idempotent, so they
+ * cost nothing to see twice -- but never moves `sweptThrough`, so the next run
+ * re-reads it from the start rather than stepping over the part it never saw.
  */
-export function safeCursorLedger(
- maxLedgerSeen: number,
- drained: boolean,
- startLedger: number,
-): number {
- const floor = startLedger - 1;
- if (maxLedgerSeen < startLedger) return floor;
- return Math.max(floor, drained ? maxLedgerSeen : maxLedgerSeen - 1);
+export async function sweepLedgerRange(
+ fetchPage: (params: {
+ startLedger?: number;
+ endLedger?: number;
+ cursor?: string;
+ }) => Promise<EventPage>,
+ opts: {
+ startLedger: number;
+ endLedger: number;
+ windowSize?: number;
+ withinBudget?: () => boolean;
+ },
+): Promise<SweepResult> {
+ const { startLedger, endLedger, windowSize = LEDGER_WINDOW, withinBudget } = opts;
+ const events: RawEvent[] = [];
+ let sweptThrough = startLedger - 1;
+ let pages = 0;
+ let windows = 0;
+
+ while (sweptThrough < endLedger) {
+ if (withinBudget && !withinBudget()) {
+ return { events, sweptThrough, complete: false, pages, windows };
+ }
+
+ const from = sweptThrough + 1;
+ const to = Math.min(from + windowSize - 1, endLedger);
+ const window = await drainEvents(fetchPage, {
+ startLedger: from,
+ endLedger: to,
+ withinBudget,
+ });
+
+ windows++;
+ pages += window.pages;
+ events.push(...window.events);
+
+ if (!window.drained) {
+ return { events, sweptThrough, complete: false, pages, windows };
+ }
+ sweptThrough = to;
+ }
+
+ return { events, sweptThrough, complete: true, pages, windows };
 }


### PR DESCRIPTION
Production stopped indexing on 2026-08-03. The dashboard has been showing a week-old total, and every hourly sync run went green throughout.

## Two faults, both reporting success

**The stub.** `21682b5` replaced `/api/sync` with a handler returning `{"success":true}` while extracting the logic to `apps/indexer` — which is deployed nowhere and reachable by nothing. `sync.yml` kept running hourly against a no-op, and `CRON_SECRET` stopped being enforced on the route `DEPLOYMENT.md` tells reviewers to check returns `Unauthorized`. Restored from `21682b5^`.

**The cursor.** This is why the data was already stale before the stub landed. Soroban RPC bounds how much history one `getEvents` call scans, and does not say so — asked for 100,000 ledgers it returns an empty page with a cursor, or `-32001 request exceeded processing limit threshold`, depending on load. Measured on testnet today:

| lookback | result |
|---|---|
| 300 | finds the payment |
| 5,000 | finds the payment |
| 50,000 | **0 events, no error** |
| 100,000 | **0 events, no error** (or `-32001`) |

An empty page is indistinguishable from "no payments in this range", so the sweep looked drained and clean. The cursor only ever advanced to the last ledger an event was seen in, so with no events it did not move at all. Each run re-read the same range, the gap to the head grew, and once it passed the RPC's ~121,000-ledger retention window the indexer was stranded — unable to reach the ledgers it needed, and never reading the part of the range where new payments actually were.

## The fix

- Requests bounded to 10,000-ledger windows, swept to the head. Measured ~3.4s per window.
- The cursor advances by **whole completed windows**, empty or not. A window abandoned against the time budget never moves it, so no ledger is stepped over unread.
- `safeCursorLedger` removed — window boundaries are what make the cursor safe now.
- Ledgers already lost to retention are reported as `skippedLedgers` rather than absorbed into a success. No later run can recover them, so they should not be silent.
- Paging budget 45s → 40s: the budget is checked between windows, so a run can overshoot by one, and a full catch-up measured 55s against a 60s `maxDuration`.

## Guards, so this cannot pass as healthy again

`sync.yml` now asserts an unauthenticated GET is rejected with **401** before it starts, and **fails the run** if a reply carries no `syncedTo` cursor. Either check would have caught this within the hour instead of after a week.

## Verified against live testnet and the production database

A 1.25 XLM transfer submitted from the CLI was swept out of the 100,000-ledger backlog in 11 windows and indexed at ledger 4067071 with the correct amount. The cursor moved 3967080 → chain head and now tracks it in a single window per run.

```
run 1:  syncedTo 4067288  windows 11  scanned 1  inserted 1  skippedLedgers 207
run 2:  syncedTo 4067315  windows  1  scanned 0  inserted 0  skippedLedgers 0
```

190 tests pass (was 188), typecheck, lint, and build clean.

## Not addressed here

`apps/indexer` is still in the tree — an undeployed copy of the indexer with no tests and no CI job. It should probably go, but that is someone's call, not a drive-by deletion in a fix.