### PR TITLE
docs: update org structure and remove outdated indexer references

### DIFF
--- a/apps/docs/docs/contributing.mdx
+++ b/apps/docs/docs/contributing.mdx
@@ -17,7 +17,7 @@ We welcome contributions from the community! Whether it's a bug fix, new feature
 ## Submitting a Pull Request
 
 - Ensure your code follows the existing style conventions.
-- Run all local build and test commands (e.g., `pnpm build`, `cargo test`, `go test`) before submitting.
+- Run all local build and test commands (e.g., `pnpm build`, `cargo test`) before submitting.
 - Provide a clear and descriptive PR title and description.
 - Link to any relevant open issues.
 

--- a/apps/docs/docs/developer.mdx
+++ b/apps/docs/docs/developer.mdx
@@ -29,9 +29,9 @@ app.get('/api/data', (req, res) => {
 });
 ```
 
-## Indexer API Reference
+## Backend API Reference
 
-The Go indexer exposes a JSON REST API consumed by the dashboard. You can also query it directly.
+The Accensa backend exposes a JSON REST API consumed by the dashboard. You can also query it directly.
 
 ### `GET /health`
 Liveness probe. Returns `{"status":"ok"}`.

--- a/apps/docs/docs/introduction.mdx
+++ b/apps/docs/docs/introduction.mdx
@@ -9,6 +9,14 @@ Accensa is a merchant back-office designed specifically for sellers operating on
 
 It reconstructs a seller's payment history directly from on-chain data, anchors verifiable receipts for agent operators, and executes merchant-authorized refunds.
 
+## Organization Structure
+
+The Accensa ecosystem is split across three primary repositories:
+
+1. **`accensa-app`**: The Next.js dashboard for merchants to visualize revenue and manage refunds, along with the Node SDK for receipt verification.
+2. **`accensa-contracts`**: Soroban smart contracts (e.g., `ReceiptAnchor`, `RefundVault`) that provide the on-chain trust layer for verifiable receipts and trustless refunds.
+3. **`x402-facilitator-stellar`**: The standard HTTP 402 facilitator. Sellers run this to automatically handle the x402 payment flow, index resource prices, and handle Stellar payments from AI agents.
+
 ## The Problem
 
 x402 (HTTP 402 over Stellar) facilitates agentic payments seamlessly. However, the seller experience ends the moment funds arrive at the `PAY_TO` address. This creates three critical operational gaps:

--- a/apps/docs/docs/user-guides.mdx
+++ b/apps/docs/docs/user-guides.mdx
@@ -13,17 +13,16 @@ Accensa requires a standard PostgreSQL instance to store parsed ledger data.
 docker run --name pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres
 ```
 
-### 2. Start the Indexer
-The Go Indexer polls the Stellar RPC and populates the database. Provide it with your merchant address and connection strings.
+### 2. Start the Facilitator
+Run the `x402-facilitator-stellar` service to handle the standard x402 protocol flow and process payments from AI agents.
 ```bash
-export DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
-export STELLAR_RPC_URL=https://soroban-testnet.stellar.org
-export MERCHANT_ADDRESS=G...
-go run main.go
+cd x402-facilitator-stellar
+pnpm install
+pnpm start
 ```
 
 ### 3. Start the Dashboard
-The Next.js dashboard connects to the local Go Indexer API to visualize your revenue and receipts.
+The Next.js dashboard connects to your local database to visualize your revenue and receipts.
 ```bash
 cd apps/web
 pnpm install

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -88,6 +88,11 @@ const config: Config = {
           label: 'Documentation',
         },
         {
+          href: 'https://accensa-dashboard.vercel.app',
+          label: 'Dashboard',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/accensa/accensa-app',
           label: 'GitHub',
           position: 'right',
@@ -103,6 +108,15 @@ const config: Config = {
             {
               label: 'Introduction',
               to: '/docs/introduction',
+            },
+          ],
+        },
+        {
+          title: 'App',
+          items: [
+            {
+              label: 'Dashboard',
+              href: 'https://accensa-dashboard.vercel.app',
             },
           ],
         },

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -3,7 +3,6 @@ import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
@@ -36,9 +35,6 @@ export default function Home(): JSX.Element {
       title={`${siteConfig.title} Docs`}
       description="Merchant back-office for x402 sellers on Stellar">
       <HomepageHeader />
-      <main>
-        <HomepageFeatures />
-      </main>
     </Layout>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -83,10 +83,10 @@ export default function Landing() {
  Every request acts as an isolated transaction. The payment settles natively on Stellar as a Stellar Asset Contract transfer, leaving an immutable footprint.
  </p>
  </BentoCard>
- <BentoCard className="md:row-span-2"title="2. Accensa Indexes">
+ <BentoCard className="md:row-span-2"title="2. Facilitator Processes">
  <div className="space-y-4 mt-4">
  <p className="text-slate-600 dark:text-slate-400 leading-relaxed font-medium transition-colors duration-300">
- The indexer decodes transfers to your address in real-time, grouping them into cryptographically secure batches.
+ The facilitator handles x402 payments to your address in real-time, allowing Accensa to group them into cryptographically secure batches.
  </p>
  <div className="p-4 bg-slate-50 dark:bg-black/50 border border-slate-200 dark:border-white/5 font-mono text-xs text-emerald-600 dark:text-emerald-400 break-all transition-colors duration-300">
  root: 7ca64ee60e2b975f59f2a1f1cc1526d5b001a5c29f70291f316ba1c012a01bd1


### PR DESCRIPTION
# Context
This PR updates the organization structure in the documentation and removes outdated references to the indexer that are no longer accurate.

# Changes
- Updated README and other documentation files to reflect the current organizational structure.
- Removed outdated indexer references.

Fixes #105