### PR TITLE
fix(web): /api/payments accepts a non-numeric limit and an unvalidated cursor

### DIFF
--- a/apps/web/src/app/api/payments/route.test.ts
+++ b/apps/web/src/app/api/payments/route.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, vi, describe, beforeEach } from 'vitest';
+import { GET } from './route';
+
+vi.mock('@/lib/db', () => ({
+  withClient: vi.fn(),
+  ensureSchema: vi.fn(),
+  getSyncState: vi.fn(),
+}));
+
+describe('/api/payments GET', () => {
+  const mockRequest = (url: string) => {
+    return new Request(url);
+  };
+
+  beforeEach(() => {
+    process.env.DATABASE_URL = 'postgres://dummy';
+  });
+
+  describe('limit validation', () => {
+    test('rejects non-numeric limit (e.g. abc)', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=abc'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects negative limit (-1)', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=-1'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects 0 limit', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=0'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects limit > 1000', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=1001'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects float limit', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=10.5'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+  });
+
+  describe('cursor validation', () => {
+    test('rejects non-base64 cursor', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?cursor=not-base64-!@#$'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+
+    test('rejects cursor without |', async () => {
+      const cursor = Buffer.from('invalidcursor').toString('base64');
+      const res = await GET(mockRequest(`http://localhost/api/payments?cursor=${cursor}`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+
+    test('rejects cursor with invalid timestamp', async () => {
+      const cursor = Buffer.from('not-a-date|a'.repeat(64)).toString('base64');
+      const res = await GET(mockRequest(`http://localhost/api/payments?cursor=${cursor}`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+
+    test('rejects cursor with invalid hash length', async () => {
+      const cursor = Buffer.from(`${new Date().toISOString()}|tooshort`).toString('base64');
+      const res = await GET(mockRequest(`http://localhost/api/payments?cursor=${cursor}`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+  });
+});

--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { withClient, ensureSchema, getSyncState } from '@/lib/db';
+import { isHash32 } from '@/lib/receipt-anchor';
 import type { SyncState } from '@/lib/sync-status';
 
 export const dynamic = 'force-dynamic';
@@ -25,12 +26,41 @@ export interface PaymentsResponse {
 
 export async function GET(request: Request) {
  if (!process.env.DATABASE_URL) {
- return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+ return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
  }
 
  const { searchParams } = new URL(request.url);
- const limit = Math.min(Number(searchParams.get('limit') || '100'), 1000);
- const cursor = searchParams.get('cursor');
+  const limitParam = searchParams.get('limit');
+  let limit = 100;
+  if (limitParam !== null) {
+    const parsed = Number.parseFloat(limitParam);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 1000) {
+      return NextResponse.json(
+        { error: 'limit must be an integer between 1 and 1000' },
+        { status: 400 }
+      );
+    }
+    limit = parsed;
+  }
+
+  const cursor = searchParams.get('cursor');
+  let parsedCursor: { ts: string; txHash: string } | null = null;
+  if (cursor) {
+    try {
+      const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+      const parts = decoded.split('|');
+      if (parts.length !== 2) throw new Error();
+      
+      const [ts, txHash] = parts;
+      const date = new Date(ts);
+      if (Number.isNaN(date.getTime())) throw new Error();
+      if (!isHash32(txHash)) throw new Error();
+      
+      parsedCursor = { ts, txHash };
+    } catch {
+      return NextResponse.json({ error: 'invalid_cursor' }, { status: 400 });
+    }
+  }
 
  try {
  const { rows, sync } = await withClient(async (client) => {
@@ -38,12 +68,10 @@ export async function GET(request: Request) {
  
  let query = `SELECT tx_hash, ledger, payer, amount::text AS amount, asset, ts, route, method FROM payments WHERE ts IS NOT NULL`;
  const params: (string | number)[] = [];
- 
- if (cursor) {
-  const [ts, txHash] = Buffer.from(cursor, 'base64').toString().split('|');
-  query += ` AND (ts < $1 OR (ts = $1 AND tx_hash < $2))`;
-  params.push(ts, txHash);
- }
+  if (parsedCursor) {
+   query += ` AND (ts < $1 OR (ts = $1 AND tx_hash < $2))`;
+   params.push(parsedCursor.ts, parsedCursor.txHash);
+  }
  
  query += ` ORDER BY ts DESC, tx_hash DESC LIMIT $${params.length + 1}`;
  params.push(limit);
@@ -72,7 +100,7 @@ export async function GET(request: Request) {
  };
  return NextResponse.json(body);
  } catch (error: unknown) {
- const message = error instanceof Error ? error.message : 'Unknown error';
- return NextResponse.json({ error: message }, { status: 500 });
+ console.error('Error fetching payments:', error);
+ return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
  }
 }

--- a/apps/web/vitest.config.mjs
+++ b/apps/web/vitest.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+});


### PR DESCRIPTION
# Context
This PR addresses two bugs in `/api/payments` where `limit` was not properly validated as a number, and the cursor was decoded without validation, which resulted in 500 errors and leaked database schema information instead of clean 400 Bad Request responses.

# Changes
- Added rigorous validation for the `limit` query parameter to ensure it is numeric.
- Implemented robust cursor decoding validation to prevent SQL injection or type errors.
- Enhanced error handling to return clear `400` responses for client errors, avoiding raw database errors in the response body.

Fixes #89