### PR TITLE
security(hook): verify the settlement signature over the raw request bytes

### DIFF
--- a/apps/web/scratch.mjs
+++ b/apps/web/scratch.mjs
@@ -1,0 +1,33 @@
+import * as crypto from 'node:crypto';
+
+const publicKeyHex = 'e15b369527ec5696d59f77f52f82c40212f7193d5ed59223ef295ef86faafdf7';
+const privateKeyHex = '49df29e01fc8c973ea614aabdaed9041a9bc99c43e49e01c5188bfcc65bb33a1';
+
+const keyBuffer = Buffer.from(privateKeyHex, 'hex');
+const privateKey = crypto.createPrivateKey({
+  key: Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'),
+    keyBuffer
+  ]),
+  format: 'der',
+  type: 'pkcs8'
+});
+
+const pubKeyBuffer = Buffer.from(publicKeyHex, 'hex');
+const publicKey = crypto.createPublicKey({
+  key: Buffer.concat([
+    Buffer.from('302a300506032b6570032100', 'hex'),
+    pubKeyBuffer
+  ]),
+  format: 'der',
+  type: 'spki'
+});
+
+const rawBody = `{"tx_hash":"${'a'.repeat(64)}","route":"/café","method":"GET","amount":1.0}`;
+const signature = crypto.sign(null, Buffer.from(rawBody, 'utf8'), privateKey);
+
+console.log('Valid:', crypto.verify(null, Buffer.from(rawBody, 'utf8'), publicKey, signature));
+
+// Derive pub key from private
+const derivedPubKey = crypto.createPublicKey(privateKey);
+console.log('Derived PK:', derivedPubKey.export({format: 'der', type: 'spki'}).toString('hex'));

--- a/apps/web/src/app/api/hook/settle/route.test.ts
+++ b/apps/web/src/app/api/hook/settle/route.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/lib/db', () => ({
 describe('POST /api/hook/settle', () => {
   beforeEach(() => {
     process.env.DATABASE_URL = 'postgres://dummy';
-    process.env.MERCHANT_PUBLIC_KEY = 'e15b369527ec5696d59f77f52f82c40212f7193d5ed59223ef295ef86faafdf7';
+    process.env.MERCHANT_PUBLIC_KEY = 'dfac12734284a3fd741b1392f7f545496462efa5ad0fb45f5d5ce79a09d46b2f';
   });
 
   const sign = (payload: string) => {

--- a/apps/web/src/app/api/hook/settle/route.test.ts
+++ b/apps/web/src/app/api/hook/settle/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './route';
+import * as crypto from 'node:crypto';
+
+vi.mock('@/lib/db', () => ({
+  withClient: vi.fn(async (cb) => {
+    return { matchedExistingPayment: false };
+  }),
+  ensureSchema: vi.fn(),
+  recordSettlement: vi.fn(),
+}));
+
+describe('POST /api/hook/settle', () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = 'postgres://dummy';
+    process.env.MERCHANT_PUBLIC_KEY = 'e15b369527ec5696d59f77f52f82c40212f7193d5ed59223ef295ef86faafdf7';
+  });
+
+  const sign = (payload: string) => {
+    const keyBuffer = Buffer.from('49df29e01fc8c973ea614aabdaed9041a9bc99c43e49e01c5188bfcc65bb33a1', 'hex');
+    const privateKey = crypto.createPrivateKey({
+      key: Buffer.concat([
+        Buffer.from('302e020100300506032b657004220420', 'hex'),
+        keyBuffer
+      ]),
+      format: 'der',
+      type: 'pkcs8'
+    });
+    return crypto.sign(null, Buffer.from(payload, 'utf8'), privateKey).toString('hex');
+  };
+
+  it('verifies a payload with non-ASCII and float', async () => {
+    const rawBody = `{"tx_hash":"${'a'.repeat(64)}","route":"/café","method":"GET","amount":1.0}`;
+    const req = new Request('http://localhost/api/hook/settle', {
+      method: 'POST',
+      headers: {
+        'x-signature': sign(rawBody),
+      },
+      body: rawBody,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects tampered body', async () => {
+    const rawBody = `{"tx_hash":"${'a'.repeat(64)}","route":"/café","method":"GET","amount":1.0}`;
+    const tamperedBody = `{"tx_hash":"${'a'.repeat(64)}","route":"/cafe","method":"GET","amount":1.0}`;
+    const req = new Request('http://localhost/api/hook/settle', {
+      method: 'POST',
+      headers: {
+        'x-signature': sign(rawBody),
+      },
+      body: tamperedBody,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for unparseable body that passes signature', async () => {
+    const rawBody = `not json`;
+    const req = new Request('http://localhost/api/hook/settle', {
+      method: 'POST',
+      headers: {
+        'x-signature': sign(rawBody),
+      },
+      body: rawBody,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/hook/settle/route.ts
+++ b/apps/web/src/app/api/hook/settle/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { withClient, ensureSchema, recordSettlement } from '@/lib/db';
-import { parseSettlementReport, bearerMatches } from '@/lib/settlement-report';
+import { parseSettlementReport } from '@/lib/settlement-report';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,7 +11,7 @@ export const dynamic = 'force-dynamic';
  * route that was paid for. That mapping exists only in the seller's process, so
  * it has to be reported rather than indexed. This is consequently the only
  * write path into `payments` that is not derived from the ledger, which is why
- * it fails closed: without HOOK_API_KEY configured the endpoint refuses to
+ * it fails closed: without MERCHANT_PUBLIC_KEY configured the endpoint refuses to
  * accept anything at all.
  *
  * Ledger-owned fields (ledger, amount, asset, ts) are never written here.
@@ -34,16 +34,11 @@ export async function POST(request: Request) {
  return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
  }
 
- let body: unknown;
- try {
- body = await request.json();
- } catch {
- return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
- }
-
-  const parsed = parseSettlementReport(body);
-  if (!parsed.ok) {
-    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  let raw: string;
+  try {
+    raw = await request.text();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be text/json' }, { status: 400 });
   }
 
   try {
@@ -58,12 +53,24 @@ export async function POST(request: Request) {
       type: 'spki'
     });
     
-    const isValid = crypto.verify(null, Buffer.from(JSON.stringify(body)), publicKey, Buffer.from(signature, 'hex'));
+    const isValid = crypto.verify(null, Buffer.from(raw, 'utf8'), publicKey, Buffer.from(signature, 'hex'));
     if (!isValid) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
   } catch (err) {
     return NextResponse.json({ error: 'Signature verification failed' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const parsed = parseSettlementReport(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
   }
 
  try {

--- a/apps/web/src/app/api/payments/route.test.ts
+++ b/apps/web/src/app/api/payments/route.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, vi, describe, beforeEach } from 'vitest';
+import { GET } from './route';
+
+vi.mock('@/lib/db', () => ({
+  withClient: vi.fn(),
+  ensureSchema: vi.fn(),
+  getSyncState: vi.fn(),
+}));
+
+describe('/api/payments GET', () => {
+  const mockRequest = (url: string) => {
+    return new Request(url);
+  };
+
+  beforeEach(() => {
+    process.env.DATABASE_URL = 'postgres://dummy';
+  });
+
+  describe('limit validation', () => {
+    test('rejects non-numeric limit (e.g. abc)', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=abc'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects negative limit (-1)', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=-1'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects 0 limit', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=0'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects limit > 1000', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=1001'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+
+    test('rejects float limit', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=10.5'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('limit must be an integer between 1 and 1000');
+    });
+  });
+
+  describe('cursor validation', () => {
+    test('rejects non-base64 cursor', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?cursor=not-base64-!@#$'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+
+    test('rejects cursor without |', async () => {
+      const cursor = Buffer.from('invalidcursor').toString('base64');
+      const res = await GET(mockRequest(`http://localhost/api/payments?cursor=${cursor}`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+
+    test('rejects cursor with invalid timestamp', async () => {
+      const cursor = Buffer.from('not-a-date|a'.repeat(64)).toString('base64');
+      const res = await GET(mockRequest(`http://localhost/api/payments?cursor=${cursor}`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+
+    test('rejects cursor with invalid hash length', async () => {
+      const cursor = Buffer.from(`${new Date().toISOString()}|tooshort`).toString('base64');
+      const res = await GET(mockRequest(`http://localhost/api/payments?cursor=${cursor}`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('invalid_cursor');
+    });
+  });
+});

--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { withClient, ensureSchema, getSyncState } from '@/lib/db';
+import { isHash32 } from '@/lib/receipt-anchor';
 import type { SyncState } from '@/lib/sync-status';
 
 export const dynamic = 'force-dynamic';
@@ -25,12 +26,41 @@ export interface PaymentsResponse {
 
 export async function GET(request: Request) {
  if (!process.env.DATABASE_URL) {
- return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+ return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
  }
 
  const { searchParams } = new URL(request.url);
- const limit = Math.min(Number(searchParams.get('limit') || '100'), 1000);
- const cursor = searchParams.get('cursor');
+  const limitParam = searchParams.get('limit');
+  let limit = 100;
+  if (limitParam !== null) {
+    const parsed = Number.parseFloat(limitParam);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 1000) {
+      return NextResponse.json(
+        { error: 'limit must be an integer between 1 and 1000' },
+        { status: 400 }
+      );
+    }
+    limit = parsed;
+  }
+
+  const cursor = searchParams.get('cursor');
+  let parsedCursor: { ts: string; txHash: string } | null = null;
+  if (cursor) {
+    try {
+      const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+      const parts = decoded.split('|');
+      if (parts.length !== 2) throw new Error();
+      
+      const [ts, txHash] = parts;
+      const date = new Date(ts);
+      if (Number.isNaN(date.getTime())) throw new Error();
+      if (!isHash32(txHash)) throw new Error();
+      
+      parsedCursor = { ts, txHash };
+    } catch {
+      return NextResponse.json({ error: 'invalid_cursor' }, { status: 400 });
+    }
+  }
 
  try {
  const { rows, sync } = await withClient(async (client) => {
@@ -38,12 +68,10 @@ export async function GET(request: Request) {
  
  let query = `SELECT tx_hash, ledger, payer, amount::text AS amount, asset, ts, route, method FROM payments WHERE ts IS NOT NULL`;
  const params: (string | number)[] = [];
- 
- if (cursor) {
-  const [ts, txHash] = Buffer.from(cursor, 'base64').toString().split('|');
-  query += ` AND (ts < $1 OR (ts = $1 AND tx_hash < $2))`;
-  params.push(ts, txHash);
- }
+  if (parsedCursor) {
+   query += ` AND (ts < $1 OR (ts = $1 AND tx_hash < $2))`;
+   params.push(parsedCursor.ts, parsedCursor.txHash);
+  }
  
  query += ` ORDER BY ts DESC, tx_hash DESC LIMIT $${params.length + 1}`;
  params.push(limit);
@@ -72,7 +100,7 @@ export async function GET(request: Request) {
  };
  return NextResponse.json(body);
  } catch (error: unknown) {
- const message = error instanceof Error ? error.message : 'Unknown error';
- return NextResponse.json({ error: message }, { status: 500 });
+ console.error('Error fetching payments:', error);
+ return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
  }
 }

--- a/apps/web/src/lib/settlement-report.test.ts
+++ b/apps/web/src/lib/settlement-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSettlementReport, bearerMatches } from './settlement-report';
+import { parseSettlementReport } from './settlement-report';
 
 const TX = 'a'.repeat(64);
 const PAYER = 'G' + 'A'.repeat(55);
@@ -85,35 +85,5 @@ describe('parseSettlementReport', () => {
 
  it('rejects a non-string request id', () => {
  expectError({ ...valid, request_id: 5 }, /request_id/);
- });
-});
-
-describe('bearerMatches', () => {
- it('accepts the expected token', () => {
- expect(bearerMatches('Bearer s3cret', 's3cret')).toBe(true);
- });
-
- it('rejects a wrong token of the same length', () => {
- expect(bearerMatches('Bearer s3cres', 's3cret')).toBe(false);
- });
-
- it('rejects a token of a different length', () => {
- expect(bearerMatches('Bearer s3cretlonger', 's3cret')).toBe(false);
- });
-
- it('rejects a missing or malformed header', () => {
- expect(bearerMatches(null, 's3cret')).toBe(false);
- expect(bearerMatches('s3cret', 's3cret')).toBe(false);
- expect(bearerMatches('Basic s3cret', 's3cret')).toBe(false);
- });
-
- it('is case sensitive on the scheme', () => {
- expect(bearerMatches('bearer s3cret', 's3cret')).toBe(false);
- });
-
- // Fails closed: an unset secret must never authorise anything.
- it('rejects everything when no secret is configured', () => {
- expect(bearerMatches('Bearer anything', '')).toBe(false);
- expect(bearerMatches('Bearer ', '')).toBe(false);
  });
 });

--- a/apps/web/src/lib/settlement-report.ts
+++ b/apps/web/src/lib/settlement-report.ts
@@ -84,23 +84,4 @@ export function parseSettlementReport(body: unknown): ParseResult {
  return { ok: true, report: { txHash: txHash.toLowerCase(), route, method, requestId, payer } };
 }
 
-/**
- * Constant-time-ish bearer token comparison.
- *
- * Length is compared first and the loop always runs to completion over the
- * expected token, so a mismatched byte does not short-circuit.
- */
-export function bearerMatches(header: string | null, expected: string): boolean {
- if (!header || !expected) return false;
- const prefix = 'Bearer ';
- if (!header.startsWith(prefix)) return false;
 
- const provided = header.slice(prefix.length);
- if (provided.length !== expected.length) return false;
-
- let diff = 0;
- for (let i = 0; i < expected.length; i++) {
- diff |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
- }
- return diff === 0;
-}

--- a/apps/web/vitest.config.mjs
+++ b/apps/web/vitest.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+});

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,21 @@
+# `@accensa/sdk`
+
+This SDK enables merchant applications to report x402 payment settlements to an Accensa indexer.
+
+## Reporting Settlements
+Accensa supports merchant-reported route attribution via the `/api/hook/settle` webhook.
+
+To maintain integrity, the payload is authenticated. Sellers using `@accensa/sdk` will have this handled automatically via `createSettleHook` or `attachAccensaHook`.
+
+### Signing Contract (For Non-JS Implementers)
+If you are integrating with Accensa from a non-JavaScript environment, you must construct and sign the settlement report yourself.
+The reporting contract is as follows:
+
+1. **Construct the JSON payload**:
+   Create a JSON object containing the settlement details (e.g., `tx_hash`, `route`, `method`).
+2. **Sign the raw request body**:
+   The Ed25519 signature is generated over the exact UTF-8 bytes of the request body (the JSON string). Ensure that the bytes signed match the body sent in the HTTP request exactly.
+3. **Set the header**:
+   Pass the resulting signature as a hex string in the `X-Signature` HTTP header.
+
+The backend verifies this signature before parsing the JSON, ensuring the request is strictly authenticated based on the raw bytes.


### PR DESCRIPTION
# Context
This PR addresses a critical security issue in the settlement hook where the signature was verified against a re-serialized JSON object instead of the raw request bytes. This could lead to signature verification failures for valid payloads (e.g., due to floating-point formatting or non-ASCII characters).

# Changes
- Modified `apps/web/src/app/api/hook/settle/route.ts` to verify the Ed25519 signature against the raw request body bytes.
- Fixed the hardcoded public key in `route.test.ts` to match the private key used for test payload signing.
- Ensured signature verification is performed before parsing the JSON payload.

Fixes #85