### PR TITLE
fix(docs): point every documentation link at the site we actually publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <p>
     <a href="https://accensa-dashboard.vercel.app/verify"><strong>Verify a Receipt</strong></a> ·
     <a href="https://accensa-dashboard.vercel.app/dashboard"><strong>Live Dashboard</strong></a> ·
-    <a href="https://accensa-docs.vercel.app"><strong>Documentation</strong></a> ·
+    <a href="https://accensa.github.io/accensa-app/"><strong>Documentation</strong></a> ·
     <a href="https://github.com/accensa/accensa-contracts"><strong>accensa-contracts</strong></a>
   </p>
 </div>

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -41,10 +41,8 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/accensa/accensa-app/tree/main/apps/docs/',
         },
         blog: {
           showReadingTime: true,
@@ -52,10 +50,8 @@ const config: Config = {
             type: ['rss', 'atom'],
             xslt: true,
           },
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/accensa/accensa-app/tree/main/apps/docs/',
           // Useful options to enforce blogging best practices
           onInlineTags: 'warn',
           onInlineAuthors: 'warn',

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -133,7 +133,7 @@ export function Nav() {
  <div className="h-px w-12 bg-slate-200 dark:bg-white/10 my-1"/>
 
  <a
- href="https://accensa-docs.vercel.app"
+ href="https://accensa.github.io/accensa-app"
  target="_blank"
  rel="noreferrer"
  onClick={() => setIsOpen(false)}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,6 +5,15 @@
   "main": "index.ts",
   "types": "index.ts",
   "license": "MIT",
+  "homepage": "https://accensa.github.io/accensa-app/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/accensa/accensa-app.git",
+    "directory": "packages/sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/accensa/accensa-app/issues"
+  },
   "exports": {
     ".": "./index.ts",
     "./merkle": "./merkle.ts"


### PR DESCRIPTION
## Context

Three links still pointed at `accensa-docs.vercel.app` — a separate Vercel project, last deployed 31 days ago, still serving unmodified Docusaurus scaffold copy ("Easy to Use", "Focus on What Matters", "Docusaurus was designed from the ground up"). That is exactly the boilerplate #105 removed from the real site.

The docs site published on 08-13 lives at <https://accensa.github.io/accensa-app/>. The desktop nav and the footer were updated to it in #112; the mobile menu, the README, and the docs sidebar links were not — so a phone visitor and anyone arriving from GitHub still landed on the scaffold.

## Changes

- `nav.tsx` mobile menu → the published site (desktop was already correct)
- `README.md` "Documentation" → the published site
- `docusaurus.config.ts`: `editUrl` still carried the `create-docusaurus` default, so every "Edit this page" link on every docs page pointed into `facebook/docusaurus`. It now points at `apps/docs/` in this repo.
- `@accensa/sdk` gains `homepage`, `repository`, and `bugs`. npm renders none of these today because the package is unpublished (#102), but they are what the registry page links back with.

## Verification

- `docusaurus build` completes clean
- 198 `apps/web` + 81 `packages/sdk` tests still pass

Note: production is currently serving a build that predates #112, so the desktop Docs link is still wrong on the live site. Merging this triggers the production deploy that fixes both.