### PR TITLE
feat(web): merchant batch anchoring flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ of a cent, which is the only way verifiability survives micropayment economics.
      PostgreSQL                        │
           │                            │
           ▼                            ▼
-   Next.js dashboard  ◀──verify_receipt(leaf, proof)
+   Next.js dashboard  ──anchor_batch──▶  ReceiptAnchor
+          │                            │
+          ▼                            ▼
+   GET /api/receipts/:txHash    verify_receipt(leaf, proof)
 ```
 
 | Component         | Path                                                     | What it does                                                                                                                                                                                 |

--- a/apps/docs/docs/app/receipt-leaves.mdx
+++ b/apps/docs/docs/app/receipt-leaves.mdx
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+title: Receipt leaves
+---
+
+# Receipt leaf definition
+
+A receipt leaf is the 32-byte value that `ReceiptAnchor::verify_receipt` (and
+`verifyReceipt` in `@accensa/sdk`) hashes up a Merkle tree. The **tree
+algorithm** is pinned by the shared conformance vectors in
+[`packages/sdk/merkle-vectors.json`](https://github.com/accensa/accensa-app/blob/main/packages/sdk/merkle-vectors.json):
+sorted-pair SHA-256, odd nodes promoted unchanged, proofs in leaf-to-root
+order. That algorithm is identical in the SDK, the Soroban contract, and the
+merchant anchoring flow.
+
+The **leaf preimage** for a live payment is defined here, once.
+
+## Production leaf
+
+```
+leaf = SHA-256( tx_hash as 32 raw bytes )
+```
+
+- `tx_hash` is the hex-encoded SHA-256 of the Stellar transaction that paid
+  the merchant — the same 64 hex characters stored on `payments.tx_hash`.
+- Decode the hex to 32 bytes, then SHA-256 those bytes. Do not hash the hex
+  string. Do not include amount, payer, asset, or ledger: those can be read
+  from the transaction itself once inclusion is proven.
+- `receiptLeaf()` in `@accensa/sdk` is the canonical implementation. The
+  dashboard preview, the recorded `payments.receipt_leaf` column, and any
+  third-party verifier must call it (or byte-identical code).
+
+A third party who knows only the payment's transaction hash can recompute the
+leaf, `GET /api/receipts/:txHash` for the proof, and check it against the
+anchored root — locally via `verifyReceipt` or on-chain via `verify_receipt`.
+
+## Why not the vector labels?
+
+The fixtures in `merkle-vectors.json` hash UTF-8 labels (`"receipt-001:150.00"`)
+so the SDK tests and the contract tests can agree without a live ledger. They
+pin the tree, not the preimage. Production batches always use `receiptLeaf(tx_hash)`.
+
+## Selection and period
+
+Unanchored payments are selected by **ledger sequence**, not wall-clock time.
+Ledger numbers are monotonic; a merchant's clock is not. The tree is built in
+`(ledger ASC, tx_hash ASC)` order so the same set always produces the same
+root. `period_start` / `period_end` written to `anchor_batch` are Unix seconds
+taken from the first and last payment in that order.
+
+The same selection hashed (`sha256` of the `tx_hash` list, one per line) is
+the idempotency key. Submitting it twice does not create a second batch.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
       label: 'accensa-app',
       items: [
         'app/overview',
+        'app/receipt-leaves',
         'onboarding',
         'user-guides',
         {

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -22,8 +22,8 @@ To secure the dashboard and private API routes, we use a Stellar Wallet Auth mod
 
 ### Scope
 
-- **Public**: `/verify`, `POST /api/verify`, landing pages, docs.
-- **Private**: `/dashboard`, `/dashboard/routes`, `/api/payments`, `/api/routes`, `/api/refund/preflight`, `POST /api/sync`.
+- **Public**: `/verify`, `POST /api/verify`, `GET /api/receipts/:txHash`, landing pages, docs.
+- **Private**: `/dashboard`, `/dashboard/routes`, `/api/payments`, `/api/routes`, `/api/refund/preflight`, `POST /api/sync`, `/api/anchor/*`.
 - **Special**: `GET /api/sync` remains protected by `CRON_SECRET` for automated GitHub Action workflows.
 
 ### Session Handling

--- a/apps/web/src/app/api/anchor/preview/route.ts
+++ b/apps/web/src/app/api/anchor/preview/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { withClient, ensureSchema } from '@/lib/db';
+import { buildPreview, loadUnanchored, persistPreview, MAX_BATCH_SIZE } from '@/lib/anchor';
+import { RECEIPT_ANCHOR_ID } from '@/lib/receipt-anchor';
+import { Networks } from '@stellar/stellar-sdk';
+
+export const dynamic = 'force-dynamic';
+
+function parseLedger(value: string | null, label: string): number | undefined {
+  if (value === null || value === '') return undefined;
+  if (!/^\d+$/.test(value)) throw new Error(`${label} must be a whole number`);
+  const n = Number(value);
+  if (!Number.isSafeInteger(n) || n < 1) throw new Error(`${label} must be a positive integer`);
+  return n;
+}
+
+/**
+ * Builds the tree a merchant is about to commit to, without touching the
+ * wallet. The root, count, and period shown here are the arguments
+ * `anchor_batch` will be signed over, so a preview that disagrees with the
+ * signing prompt is a bug.
+ */
+export async function GET(request: Request) {
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+  if (!process.env.MERCHANT_ADDRESS) {
+    return NextResponse.json({ error: 'MERCHANT_ADDRESS is not configured' }, { status: 500 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  let fromLedger: number | undefined;
+  let toLedger: number | undefined;
+  try {
+    fromLedger = parseLedger(searchParams.get('fromLedger'), 'fromLedger');
+    toLedger = parseLedger(searchParams.get('toLedger'), 'toLedger');
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'invalid range' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const body = await withClient(async (client) => {
+      await ensureSchema(client);
+      const payments = await loadUnanchored(client, { fromLedger, toLedger });
+      if (payments.length === 0) {
+        return {
+          count: 0,
+          merchant: process.env.MERCHANT_ADDRESS,
+          contractId: RECEIPT_ANCHOR_ID,
+          networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET,
+          maxBatchSize: MAX_BATCH_SIZE,
+        };
+      }
+      const preview = await persistPreview(client, buildPreview(payments));
+      return {
+        ...preview,
+        merchant: process.env.MERCHANT_ADDRESS,
+        contractId: RECEIPT_ANCHOR_ID,
+        networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET,
+        maxBatchSize: MAX_BATCH_SIZE,
+      };
+    });
+    return NextResponse.json(body);
+  } catch (error: unknown) {
+    console.error('anchor preview failed:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/anchor/record/route.ts
+++ b/apps/web/src/app/api/anchor/record/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server';
+import { withClient, ensureSchema } from '@/lib/db';
+import { recordAnchoredBatch } from '@/lib/anchor';
+import { getBatch, isHash32 } from '@/lib/receipt-anchor';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Persists the payment-to-batch mapping after `anchor_batch` confirms on
+ * chain. The on-chain root is re-read and compared to the previewed tree so
+ * a client cannot record proofs against a batch they did not actually
+ * submit. Replaying the same selection is a no-op and returns the existing
+ * batch_id — that is the double-submit path.
+ *
+ * If this handler fails after the transaction is in the ledger, the row
+ * stays `submitted` (or `previewed` if we never got that far). Calling again
+ * with the same body completes the write. That gap is where real money and
+ * real confusion live; it is recoverable, and it is tested.
+ */
+export async function POST(request: Request) {
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return NextResponse.json({ error: 'Request body must be a JSON object' }, { status: 400 });
+  }
+
+  const rec = body as Record<string, unknown>;
+  const selectionHash = typeof rec.selectionHash === 'string' ? rec.selectionHash.trim() : '';
+  const root = typeof rec.root === 'string' ? rec.root.trim() : '';
+  const anchorTx = typeof rec.anchorTx === 'string' ? rec.anchorTx.trim() : '';
+  const batchId = typeof rec.batchId === 'number' ? rec.batchId : Number(rec.batchId);
+
+  if (!isHash32(selectionHash)) {
+    return NextResponse.json(
+      { error: 'selectionHash must be a 32-byte hex hash' },
+      { status: 400 },
+    );
+  }
+  if (!isHash32(root)) {
+    return NextResponse.json({ error: 'root must be a 32-byte hex hash' }, { status: 400 });
+  }
+  if (!isHash32(anchorTx)) {
+    return NextResponse.json({ error: 'anchorTx must be a 32-byte hex hash' }, { status: 400 });
+  }
+  if (!Number.isSafeInteger(batchId) || batchId < 1) {
+    return NextResponse.json({ error: 'batchId must be a positive integer' }, { status: 400 });
+  }
+
+  let onchain;
+  try {
+    onchain = await getBatch(batchId);
+  } catch (error) {
+    console.error('get_batch failed while recording an anchor:', error);
+    return NextResponse.json(
+      {
+        error:
+          'Could not read the batch from the ledger. The transaction may still be confirming — retry recording without submitting again.',
+      },
+      { status: 502 },
+    );
+  }
+
+  if (onchain.root.toLowerCase() !== root.toLowerCase()) {
+    return NextResponse.json(
+      { error: 'On-chain root does not match the previewed tree; refusing to record' },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const result = await withClient(async (client) => {
+      await ensureSchema(client);
+      return recordAnchoredBatch(client, {
+        selectionHash: selectionHash.toLowerCase(),
+        batchId,
+        anchorTx: anchorTx.toLowerCase(),
+        root: root.toLowerCase(),
+      });
+    });
+    return NextResponse.json({ success: true, ...result });
+  } catch (error: unknown) {
+    const code = (error as { code?: string }).code;
+    if (
+      code === 'UNKNOWN_SELECTION' ||
+      code === 'ROOT_MISMATCH' ||
+      code === 'ALREADY_ANCHORED' ||
+      code === 'PAYMENT_ALREADY_ANCHORED'
+    ) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Conflict' },
+        { status: 409 },
+      );
+    }
+    console.error('anchor record failed:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/receipts/[txHash]/route.test.ts
+++ b/apps/web/src/app/api/receipts/[txHash]/route.test.ts
@@ -1,0 +1,54 @@
+import { expect, test, vi, describe, beforeEach } from 'vitest';
+import { GET } from './route';
+
+vi.mock('@/lib/db', () => ({
+  withClient: vi.fn(async (fn: (c: unknown) => unknown) => fn({})),
+  ensureSchema: vi.fn(),
+}));
+
+vi.mock('@/lib/anchor', () => ({
+  getProof: vi.fn(),
+}));
+
+import { getProof } from '@/lib/anchor';
+
+describe('GET /api/receipts/:txHash', () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = 'postgres://dummy';
+    vi.mocked(getProof).mockReset();
+  });
+
+  test('rejects a malformed hash', async () => {
+    const res = await GET(new Request('http://localhost/api/receipts/abcd'), {
+      params: Promise.resolve({ txHash: 'abcd' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 404 when no proof has been recorded', async () => {
+    vi.mocked(getProof).mockResolvedValueOnce(null);
+    const tx = 'a'.repeat(64);
+    const res = await GET(new Request(`http://localhost/api/receipts/${tx}`), {
+      params: Promise.resolve({ txHash: tx }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test('returns the stored proof for a recorded payment', async () => {
+    const tx = 'a'.repeat(64);
+    vi.mocked(getProof).mockResolvedValueOnce({
+      txHash: tx,
+      batchId: 1,
+      leaf: 'b'.repeat(64),
+      proof: ['c'.repeat(64)],
+      root: 'd'.repeat(64),
+    });
+    const res = await GET(new Request(`http://localhost/api/receipts/${tx}`), {
+      params: Promise.resolve({ txHash: tx }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.batchId).toBe(1);
+    expect(body.proof).toHaveLength(1);
+  });
+});

--- a/apps/web/src/app/api/receipts/[txHash]/route.ts
+++ b/apps/web/src/app/api/receipts/[txHash]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { withClient, ensureSchema } from '@/lib/db';
+import { getProof } from '@/lib/anchor';
+import { isHash32 } from '@/lib/receipt-anchor';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Serves the membership proof for one payment, so `/verify` can be filled
+ * from real data rather than the hand-pasted sample.
+ *
+ * Public on purpose: a proof is not a secret. Anyone holding a `tx_hash`
+ * should be able to fetch the leaf and siblings that place it in an
+ * anchored batch.
+ */
+export async function GET(_request: Request, context: { params: Promise<{ txHash: string }> }) {
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+
+  const { txHash } = await context.params;
+  if (!isHash32(txHash)) {
+    return NextResponse.json({ error: 'txHash must be a 32-byte hex hash' }, { status: 400 });
+  }
+
+  try {
+    const proof = await withClient(async (client) => {
+      await ensureSchema(client);
+      return getProof(client, txHash.trim().toLowerCase());
+    });
+    if (!proof) {
+      return NextResponse.json({ error: 'No recorded proof for this payment' }, { status: 404 });
+    }
+    return NextResponse.json(proof);
+  } catch (error: unknown) {
+    console.error('receipt proof lookup failed:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 import { PageContainer } from '@/components/page-container';
 import { RefundPanel } from '@/components/refund-panel';
+import { AnchorPanel } from '@/components/anchor-panel';
 import { useOnline } from '@/components/network-status';
 import { describeFailure, isAbortError } from '@/lib/network-status';
 
@@ -167,6 +168,8 @@ export default function Dashboard() {
             </span>
           </div>
         </header>
+
+        <AnchorPanel />
 
         {/* Data Table Section */}
         <section className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl overflow-hidden shadow-[0_8px_30px_rgba(0,0,0,0.12),inset_0_1px_1px_rgba(255,255,255,0.8)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.15)] transition-colors duration-300">
@@ -415,6 +418,14 @@ export default function Dashboard() {
                   className="flex items-center justify-center gap-1.5 w-full py-4 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 shadow-sm dark:shadow-none transition-all font-bold text-sm tracking-wide uppercase"
                 >
                   View on Explorer <ArrowUpRight className="w-4 h-4 opacity-70" />
+                </a>
+                <a
+                  href={`/api/receipts/${selected.tx_hash}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-3 flex items-center justify-center gap-1.5 w-full py-4 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 shadow-sm dark:shadow-none transition-all font-bold text-sm tracking-wide uppercase"
+                >
+                  Fetch receipt proof
                 </a>
               </div>
 

--- a/apps/web/src/components/anchor-panel.tsx
+++ b/apps/web/src/components/anchor-panel.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import Link from 'next/link';
+import { readStatus, connect, FREIGHTER_INSTALL_URL } from '@/lib/freighter';
+import { submitAnchor, type AnchorOutcome } from '@/lib/anchor-submit';
+import type { AnchorPreview, AnchorStatus } from '@/lib/anchor';
+
+type PreviewResponse =
+  | (AnchorPreview & {
+      merchant: string;
+      contractId: string;
+      networkPassphrase: string;
+      maxBatchSize: number;
+    })
+  | { count: 0; merchant: string };
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'empty' }
+  | { kind: 'preview'; preview: Exclude<PreviewResponse, { count: 0 }> }
+  | { kind: 'signing'; preview: Exclude<PreviewResponse, { count: 0 }> }
+  | {
+      kind: 'recording';
+      preview: Exclude<PreviewResponse, { count: 0 }>;
+      batchId: number;
+      hash: string;
+    }
+  | { kind: 'done'; batchId: number; hash: string }
+  | { kind: 'pending'; hash: string };
+
+/**
+ * The producer side of the receipt loop: select unanchored payments, preview
+ * the root, sign `anchor_batch`, persist proofs.
+ *
+ * Preview is a separate step from the wallet prompt on purpose. Anchoring is
+ * irreversible and costs a fee; the merchant should see the count, period and
+ * root before Freighter appears.
+ */
+export function AnchorPanel() {
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPreview = useCallback(async () => {
+    setError(null);
+    setPhase({ kind: 'loading' });
+    try {
+      const res = await fetch('/api/anchor/preview', { cache: 'no-store' });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? `Preview failed (${res.status})`);
+      if (!body.count) {
+        setPhase({ kind: 'empty' });
+        return;
+      }
+      setPhase({ kind: 'preview', preview: body });
+    } catch (e) {
+      setPhase({ kind: 'idle' });
+      setError(e instanceof Error ? e.message : 'Could not build a preview');
+    }
+  }, []);
+
+  const confirm = useCallback(async (preview: Exclude<PreviewResponse, { count: 0 }>) => {
+    setError(null);
+
+    if (
+      preview.existing &&
+      preview.existing.status === 'recorded' &&
+      preview.existing.batchId > 0
+    ) {
+      setPhase({
+        kind: 'done',
+        batchId: preview.existing.batchId,
+        hash: preview.existing.anchorTx ?? '',
+      });
+      return;
+    }
+
+    if (
+      preview.existing &&
+      preview.existing.status === 'submitted' &&
+      preview.existing.batchId > 0
+    ) {
+      setPhase({
+        kind: 'recording',
+        preview,
+        batchId: preview.existing.batchId,
+        hash: preview.existing.anchorTx ?? '',
+      });
+      await record(preview, preview.existing.batchId, preview.existing.anchorTx ?? '');
+      return;
+    }
+
+    const wallet = await readStatus();
+    if (wallet.kind === 'unavailable') {
+      setError('Freighter is not installed. Install it, then come back to sign.');
+      return;
+    }
+    if (wallet.kind !== 'connected') {
+      const connected = await connect();
+      if (connected.kind !== 'connected') {
+        setError('Freighter did not approve this site. Nothing was submitted.');
+        return;
+      }
+    }
+
+    setPhase({ kind: 'signing', preview });
+    const outcome: AnchorOutcome = await submitAnchor({
+      root: preview.root,
+      count: preview.count,
+      periodStart: preview.periodStart,
+      periodEnd: preview.periodEnd,
+      merchant: preview.merchant,
+    });
+
+    if (outcome.status === 'failed') {
+      setPhase({ kind: 'preview', preview });
+      setError(outcome.message);
+      return;
+    }
+    if (outcome.status === 'pending') {
+      setPhase({ kind: 'pending', hash: outcome.hash });
+      return;
+    }
+
+    setPhase({ kind: 'recording', preview, batchId: outcome.batchId, hash: outcome.hash });
+    await record(preview, outcome.batchId, outcome.hash);
+  }, []);
+
+  const record = async (
+    preview: Exclude<PreviewResponse, { count: 0 }>,
+    batchId: number,
+    hash: string,
+  ) => {
+    try {
+      const res = await fetch('/api/anchor/record', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          selectionHash: preview.selectionHash,
+          root: preview.root,
+          batchId,
+          anchorTx: hash,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? `Recording failed (${res.status})`);
+      setPhase({ kind: 'done', batchId, hash });
+    } catch (e) {
+      setError(
+        `${e instanceof Error ? e.message : 'Recording failed'}. The batch is on-chain as #${batchId}; retry recording without submitting again.`,
+      );
+      setPhase({ kind: 'preview', preview });
+    }
+  };
+
+  return (
+    <section className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl p-6 md:p-8 shadow-[0_8px_30px_rgba(0,0,0,0.12),inset_0_1px_1px_rgba(255,255,255,0.8)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.15)] transition-colors duration-300 space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-1">
+            Receipts
+          </p>
+          <h2 className="text-xl font-black tracking-tight text-slate-900 dark:text-white">
+            Anchor a batch
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 max-w-xl">
+            Select unanchored payments, preview the Merkle root, then sign
+            <code className="mx-1 text-xs">anchor_batch</code>
+            with Freighter. Anchoring is irreversible and costs a network fee.
+          </p>
+        </div>
+        {phase.kind === 'idle' || phase.kind === 'empty' ? (
+          <button
+            type="button"
+            onClick={loadPreview}
+            className="px-4 py-2 text-[10px] font-bold uppercase tracking-widest border border-slate-200 dark:border-white/10 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-white/5 transition-colors"
+          >
+            {phase.kind === 'empty' ? 'Check again' : 'Preview unanchored'}
+          </button>
+        ) : null}
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}{' '}
+          {/not installed/i.test(error) && (
+            <a href={FREIGHTER_INSTALL_URL} className="underline" target="_blank" rel="noreferrer">
+              Install Freighter
+            </a>
+          )}
+        </p>
+      )}
+
+      {phase.kind === 'loading' && (
+        <p className="text-sm text-slate-500 animate-pulse">Building the tree…</p>
+      )}
+
+      {phase.kind === 'empty' && (
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Nothing unanchored. Indexed payments that are not already in a recorded batch will appear
+          here.
+        </p>
+      )}
+
+      {phase.kind === 'pending' && (
+        <p className="text-sm text-amber-700 dark:text-amber-300">
+          Transaction submitted ({phase.hash.slice(0, 8)}…) but not yet confirmed. Wait for the
+          ledger, then preview again — a submitted selection is recorded without a second signature.
+        </p>
+      )}
+
+      {(phase.kind === 'preview' || phase.kind === 'signing' || phase.kind === 'recording') && (
+        <PreviewCard
+          preview={phase.preview}
+          busy={phase.kind !== 'preview'}
+          onConfirm={() => void confirm(phase.preview)}
+          onCancel={() => {
+            setError(null);
+            setPhase({ kind: 'idle' });
+          }}
+        />
+      )}
+
+      {phase.kind === 'done' && (
+        <div className="space-y-2">
+          <p className="text-sm text-emerald-700 dark:text-emerald-400">
+            Batch #{phase.batchId} recorded. Proofs are now serveable.
+          </p>
+          <Link
+            href={`/batches/${phase.batchId}`}
+            className="inline-block text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-400 hover:underline"
+          >
+            View batch #{phase.batchId} →
+          </Link>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PreviewCard({
+  preview,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  preview: Exclude<PreviewResponse, { count: 0 }>;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const already: AnchorStatus | undefined = preview.existing?.status;
+  const label =
+    already === 'recorded'
+      ? 'Already anchored'
+      : already === 'submitted'
+        ? 'Finish recording'
+        : busy
+          ? 'Working…'
+          : 'Sign and submit';
+
+  return (
+    <div className="space-y-4">
+      <dl className="grid sm:grid-cols-3 gap-4">
+        <Stat label="Receipts" value={String(preview.count)} />
+        <Stat label="Ledgers" value={`${preview.startLedger} – ${preview.endLedger}`} />
+        <Stat
+          label="Period"
+          value={`${new Date(preview.periodStart * 1000).toLocaleString()} → ${new Date(preview.periodEnd * 1000).toLocaleString()}`}
+        />
+      </dl>
+      <div>
+        <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-1">
+          Merkle root
+        </p>
+        <p className="font-mono text-xs break-all bg-slate-50 dark:bg-white/5 border border-slate-200 dark:border-white/10 px-3 py-2 text-slate-800 dark:text-slate-200">
+          {preview.root}
+        </p>
+      </div>
+      {already === 'recorded' && (
+        <p className="text-sm text-slate-500">
+          This exact selection is already batch #{preview.existing?.batchId}. Submitting again will
+          not create a second batch.
+        </p>
+      )}
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={busy}
+          className="px-5 py-2.5 bg-emerald-600 dark:bg-emerald-500 text-white dark:text-black font-black text-xs uppercase tracking-wider hover:bg-emerald-700 dark:hover:bg-emerald-400 disabled:opacity-50"
+        >
+          {label}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={busy}
+          className="px-5 py-2.5 border border-slate-200 dark:border-white/10 text-xs font-bold uppercase tracking-wider text-slate-600 dark:text-slate-300"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[10px] font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">
+        {label}
+      </dt>
+      <dd className="text-sm font-medium text-slate-900 dark:text-white mt-1 break-all">{value}</dd>
+    </div>
+  );
+}

--- a/apps/web/src/lib/anchor-record.test.ts
+++ b/apps/web/src/lib/anchor-record.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const query = vi.fn();
+const client = { query };
+
+vi.mock('pg', () => ({ Client: vi.fn() }));
+
+import { recordAnchoredBatch, buildPreview, type AnchorablePayment } from './anchor';
+import { createHash } from 'node:crypto';
+
+function tx(n: number): string {
+  return createHash('sha256').update(String(n)).digest('hex');
+}
+
+function payment(n: number): AnchorablePayment {
+  return {
+    tx_hash: tx(n),
+    ledger: 100 + n,
+    payer: 'GABC',
+    amount: '1',
+    asset: 'native',
+    ts: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+describe('recordAnchoredBatch', () => {
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  it('is a no-op when the same selection is already recorded under this batch_id', async () => {
+    const preview = buildPreview([payment(1)]);
+    query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            selection_hash: preview.selectionHash,
+            batch_id: '7',
+            root: preview.root,
+            status: 'recorded',
+            proofs: preview.proofs,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({}); // COMMIT
+
+    const result = await recordAnchoredBatch(client as never, {
+      selectionHash: preview.selectionHash,
+      batchId: 7,
+      anchorTx: tx(99),
+      root: preview.root,
+    });
+
+    expect(result).toEqual({ batchId: 7, alreadyRecorded: true, status: 'recorded' });
+    const sql = query.mock.calls.map((c) => String(c[0]));
+    expect(sql.some((s) => /UPDATE payments/.test(s))).toBe(false);
+  });
+
+  it('marks submitted then recorded, writing proofs onto each payment', async () => {
+    const preview = buildPreview([payment(1), payment(2)]);
+    query.mockImplementation(async (sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return {};
+      if (sql.includes('FROM receipt_batches WHERE selection_hash')) {
+        return {
+          rows: [
+            {
+              selection_hash: preview.selectionHash,
+              batch_id: null,
+              root: preview.root,
+              status: 'previewed',
+              proofs: preview.proofs,
+            },
+          ],
+        };
+      }
+      if (sql.includes('UPDATE receipt_batches')) return { rowCount: 1 };
+      if (sql.includes('UPDATE payments')) return { rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+
+    const result = await recordAnchoredBatch(client as never, {
+      selectionHash: preview.selectionHash,
+      batchId: 3,
+      anchorTx: tx(99),
+      root: preview.root,
+    });
+
+    expect(result).toEqual({ batchId: 3, alreadyRecorded: false, status: 'recorded' });
+    const updates = query.mock.calls.filter((c) => String(c[0]).includes('UPDATE payments'));
+    expect(updates).toHaveLength(2);
+  });
+
+  it('rolls back when the supplied root does not match the preview', async () => {
+    const preview = buildPreview([payment(1)]);
+    query.mockImplementation(async (sql: string) => {
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return {};
+      return {
+        rows: [
+          {
+            selection_hash: preview.selectionHash,
+            batch_id: null,
+            root: preview.root,
+            status: 'previewed',
+            proofs: preview.proofs,
+          },
+        ],
+      };
+    });
+
+    await expect(
+      recordAnchoredBatch(client as never, {
+        selectionHash: preview.selectionHash,
+        batchId: 3,
+        anchorTx: tx(99),
+        root: 'f'.repeat(64),
+      }),
+    ).rejects.toMatchObject({ code: 'ROOT_MISMATCH' });
+
+    expect(query.mock.calls.some((c) => c[0] === 'ROLLBACK')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/anchor-submit.ts
+++ b/apps/web/src/lib/anchor-submit.ts
@@ -1,0 +1,160 @@
+import {
+  Address,
+  Contract,
+  Networks,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+import { readStatus, signTransaction } from './freighter';
+import { RECEIPT_ANCHOR_ID } from './receipt-anchor';
+
+/**
+ * Builds, signs, and submits `anchor_batch` from the browser.
+ *
+ * Same shape as `submitRefund`: the merchant's key never leaves Freighter,
+ * this module assembles the envelope and submits whatever comes back. A
+ * rejection, a wrong-network wallet, and a transaction that fails after
+ * signing each become a `failed` outcome with a message fit to render.
+ */
+
+const RPC_URL = process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE = process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+
+const CONFIRM_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 1_000;
+
+export interface AnchorInput {
+  root: string;
+  count: number;
+  periodStart: number;
+  periodEnd: number;
+  merchant: string;
+}
+
+export type AnchorOutcome =
+  | { status: 'confirmed'; hash: string; batchId: number }
+  | { status: 'pending'; hash: string }
+  | { status: 'failed'; message: string; hash?: string };
+
+const EXPECTED_NETWORK = NETWORK_PASSPHRASE === Networks.PUBLIC ? 'PUBLIC' : 'TESTNET';
+
+export async function submitAnchor(input: AnchorInput): Promise<AnchorOutcome> {
+  const wallet = await readStatus();
+  if (wallet.kind === 'unavailable') {
+    return { status: 'failed', message: 'Freighter is not installed in this browser.' };
+  }
+  if (wallet.kind === 'disconnected') {
+    return {
+      status: 'failed',
+      message: 'Connect Freighter and approve this site before anchoring.',
+    };
+  }
+  if (wallet.kind === 'error') {
+    return { status: 'failed', message: wallet.message };
+  }
+  if (wallet.address !== input.merchant) {
+    return {
+      status: 'failed',
+      message: `Connected wallet ${wallet.address} is not the merchant account that owns ReceiptAnchor.`,
+    };
+  }
+  if (wallet.network && wallet.network !== EXPECTED_NETWORK) {
+    return {
+      status: 'failed',
+      message: `Wallet is on ${wallet.network}. Switch Freighter to ${EXPECTED_NETWORK} and try again.`,
+    };
+  }
+
+  const server = new rpc.Server(RPC_URL, { allowHttp: RPC_URL.startsWith('http://') });
+
+  try {
+    const account = await server.getAccount(input.merchant);
+
+    const operation = new Contract(RECEIPT_ANCHOR_ID).call(
+      'anchor_batch',
+      xdr.ScVal.scvBytes(Buffer.from(input.root, 'hex')),
+      nativeToScVal(input.count, { type: 'u32' }),
+      nativeToScVal(input.periodStart, { type: 'u64' }),
+      nativeToScVal(input.periodEnd, { type: 'u64' }),
+    );
+
+    const built = new TransactionBuilder(account, {
+      fee: '1000000',
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(operation)
+      .setTimeout(180)
+      .build();
+
+    const prepared = await server.prepareTransaction(built);
+
+    let signedXdr: string;
+    try {
+      signedXdr = await signTransaction(prepared.toXDR(), {
+        networkPassphrase: NETWORK_PASSPHRASE,
+        address: input.merchant,
+      });
+    } catch (error) {
+      return { status: 'failed', message: describeRejection(error) };
+    }
+
+    const signed = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+    const sent = await server.sendTransaction(signed);
+
+    if (sent.status === 'ERROR') {
+      return {
+        status: 'failed',
+        message: 'The network rejected the transaction after it was signed.',
+        hash: sent.hash,
+      };
+    }
+
+    return await waitForConfirmation(server, sent.hash);
+  } catch (error) {
+    return { status: 'failed', message: describe(error) };
+  }
+}
+
+async function waitForConfirmation(server: rpc.Server, hash: string): Promise<AnchorOutcome> {
+  const deadline = Date.now() + CONFIRM_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const result = await server.getTransaction(hash);
+
+    if (result.status === 'SUCCESS') {
+      const batchId = Number(scValToNative(result.returnValue));
+      if (!Number.isSafeInteger(batchId) || batchId < 1) {
+        return {
+          status: 'failed',
+          message: 'The transaction succeeded but did not return a batch id.',
+          hash,
+        };
+      }
+      return { status: 'confirmed', hash, batchId };
+    }
+    if (result.status === 'FAILED') {
+      return { status: 'failed', message: 'The anchor transaction failed on-chain.', hash };
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  return { status: 'pending', hash };
+}
+
+function describeRejection(error: unknown): string {
+  const text = describe(error);
+  if (/user.?reject|denied|refus|cancel/i.test(text)) {
+    return 'Freighter rejected the signature. Nothing was submitted.';
+  }
+  return text;
+}
+
+function describe(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return 'The batch could not be submitted.';
+}
+
+export { Address };

--- a/apps/web/src/lib/anchor.test.ts
+++ b/apps/web/src/lib/anchor.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { buildBatch, receiptLeaf, verifyReceipt } from '@accensa/sdk';
+import { buildPreview, selectionHashOf, unixSeconds, type AnchorablePayment } from './anchor';
+
+function payment(overrides: Partial<AnchorablePayment> & { tx_hash: string }): AnchorablePayment {
+  return {
+    ledger: 100,
+    payer: 'GABC',
+    amount: '1500000',
+    asset: 'native',
+    ts: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function tx(n: number): string {
+  return createHash('sha256').update(String(n)).digest('hex');
+}
+
+describe('unixSeconds', () => {
+  it('converts an ISO timestamp to seconds, not milliseconds', () => {
+    expect(unixSeconds('1970-01-01T00:00:01.000Z')).toBe(1);
+    expect(unixSeconds('1970-01-01T00:00:01.900Z')).toBe(1);
+  });
+});
+
+describe('selectionHashOf', () => {
+  it('is stable for the same ordered set and sensitive to order', () => {
+    const a = tx(1);
+    const b = tx(2);
+    expect(selectionHashOf([a, b])).toBe(selectionHashOf([a, b]));
+    expect(selectionHashOf([a, b])).not.toBe(selectionHashOf([b, a]));
+  });
+});
+
+describe('buildPreview', () => {
+  it('throws when there is nothing to anchor', () => {
+    expect(() => buildPreview([])).toThrow(/no unanchored payments/);
+  });
+
+  it('builds a tree whose proofs verify locally against the previewed root', () => {
+    const payments = [
+      payment({ tx_hash: tx(1), ledger: 10 }),
+      payment({ tx_hash: tx(2), ledger: 11 }),
+    ];
+    const preview = buildPreview(payments);
+
+    expect(preview.count).toBe(2);
+    expect(preview.startLedger).toBe(10);
+    expect(preview.endLedger).toBe(11);
+    expect(preview.periodStart).toBe(unixSeconds(payments[0].ts));
+    expect(preview.periodEnd).toBe(unixSeconds(payments[1].ts));
+
+    const leaves = payments.map((p) => receiptLeaf(p.tx_hash));
+    const independently = buildBatch(leaves);
+    expect(preview.root).toBe(independently.root);
+
+    for (const p of payments) {
+      const { leaf, proof } = preview.proofs[p.tx_hash];
+      expect(leaf).toBe(receiptLeaf(p.tx_hash));
+      expect(verifyReceipt(leaf, proof, preview.root)).toBe(true);
+    }
+  });
+
+  it('uses receiptLeaf(tx_hash) so a third party with only the hash can recompute it', () => {
+    const hash = tx(9);
+    const preview = buildPreview([payment({ tx_hash: hash })]);
+    expect(preview.payments[0].leaf).toBe(receiptLeaf(hash));
+    expect(preview.root).toBe(receiptLeaf(hash));
+    expect(preview.proofs[hash].proof).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/anchor.ts
+++ b/apps/web/src/lib/anchor.ts
@@ -1,0 +1,333 @@
+import { createHash } from 'node:crypto';
+import type { Client } from 'pg';
+import { buildBatch, receiptLeaf } from '@accensa/sdk';
+
+/**
+ * Maximum receipts per batch. Mirrors ReceiptAnchor's on-chain cap. Issue
+ * #219 exists to read this from `get_max_batch_size` rather than hard-code
+ * it; until that lands, keep the two numbers in lockstep.
+ */
+export const MAX_BATCH_SIZE = 1000;
+
+export type AnchorStatus = 'previewed' | 'submitted' | 'recorded';
+
+export interface AnchorablePayment {
+  tx_hash: string;
+  ledger: number;
+  payer: string;
+  amount: string;
+  asset: string | null;
+  ts: string;
+}
+
+export interface AnchorPreview {
+  selectionHash: string;
+  root: string;
+  count: number;
+  periodStart: number;
+  periodEnd: number;
+  startLedger: number;
+  endLedger: number;
+  payments: Array<{
+    tx_hash: string;
+    leaf: string;
+    ledger: number;
+    ts: string;
+    amount: string;
+  }>;
+  existing: { batchId: number; status: AnchorStatus; anchorTx: string | null } | null;
+}
+
+export function selectionHashOf(txHashes: string[]): string {
+  return createHash('sha256').update(txHashes.join('\n')).digest('hex');
+}
+
+export function unixSeconds(ts: string | Date): number {
+  const ms = ts instanceof Date ? ts.getTime() : new Date(ts).getTime();
+  if (Number.isNaN(ms)) throw new Error(`unparseable timestamp: ${String(ts)}`);
+  return Math.floor(ms / 1000);
+}
+
+/**
+ * Payments that have been confirmed on-chain and not yet committed to a
+ * recorded batch. Ledger is the bound, not wall-clock: sequence is monotonic,
+ * a merchant's local clock is not, and two payments in the same second still
+ * have a total order on (ledger, tx_hash).
+ */
+export async function loadUnanchored(
+  client: Client,
+  opts: { fromLedger?: number; toLedger?: number } = {},
+): Promise<AnchorablePayment[]> {
+  const params: number[] = [];
+  let where = `ts IS NOT NULL AND ledger IS NOT NULL AND batch_id IS NULL`;
+
+  if (opts.fromLedger !== undefined) {
+    params.push(opts.fromLedger);
+    where += ` AND ledger >= $${params.length}`;
+  }
+  if (opts.toLedger !== undefined) {
+    params.push(opts.toLedger);
+    where += ` AND ledger <= $${params.length}`;
+  }
+
+  const result = await client.query(
+    `SELECT tx_hash, ledger, payer, amount::text AS amount, asset, ts
+     FROM payments
+     WHERE ${where}
+     ORDER BY ledger ASC, tx_hash ASC
+     LIMIT ${MAX_BATCH_SIZE}`,
+    params,
+  );
+
+  return result.rows.map((row) => ({
+    tx_hash: row.tx_hash,
+    ledger: Number(row.ledger),
+    payer: row.payer,
+    amount: String(row.amount),
+    asset: row.asset,
+    ts: row.ts instanceof Date ? row.ts.toISOString() : String(row.ts),
+  }));
+}
+
+export interface BuiltPreview extends Omit<AnchorPreview, 'existing'> {
+  proofs: Record<string, { leaf: string; proof: string[] }>;
+}
+
+export function buildPreview(payments: AnchorablePayment[]): BuiltPreview {
+  if (payments.length === 0) {
+    throw new Error('no unanchored payments in this selection');
+  }
+
+  const leaves = payments.map((p) => receiptLeaf(p.tx_hash));
+  const batch = buildBatch(leaves);
+  const txHashes = payments.map((p) => p.tx_hash);
+
+  const periodStart = unixSeconds(payments[0].ts);
+  const periodEnd = unixSeconds(payments[payments.length - 1].ts);
+
+  const proofs: Record<string, { leaf: string; proof: string[] }> = {};
+  for (const payment of payments) {
+    const leaf = receiptLeaf(payment.tx_hash);
+    proofs[payment.tx_hash] = { leaf, proof: batch.proofs[leaf] };
+  }
+
+  return {
+    selectionHash: selectionHashOf(txHashes),
+    root: batch.root,
+    count: payments.length,
+    periodStart,
+    periodEnd,
+    startLedger: payments[0].ledger,
+    endLedger: payments[payments.length - 1].ledger,
+    payments: payments.map((p) => ({
+      tx_hash: p.tx_hash,
+      leaf: receiptLeaf(p.tx_hash),
+      ledger: p.ledger,
+      ts: p.ts,
+      amount: p.amount,
+    })),
+    proofs,
+  };
+}
+
+function toPublicPreview(
+  preview: BuiltPreview,
+  existing: AnchorPreview['existing'],
+): AnchorPreview {
+  return {
+    selectionHash: preview.selectionHash,
+    root: preview.root,
+    count: preview.count,
+    periodStart: preview.periodStart,
+    periodEnd: preview.periodEnd,
+    startLedger: preview.startLedger,
+    endLedger: preview.endLedger,
+    payments: preview.payments,
+    existing,
+  };
+}
+
+export async function persistPreview(
+  client: Client,
+  preview: BuiltPreview,
+): Promise<AnchorPreview> {
+  const existing = await client.query<{
+    batch_id: string | null;
+    status: AnchorStatus;
+    anchor_tx: string | null;
+    root: string;
+  }>(`SELECT batch_id, status, anchor_tx, root FROM receipt_batches WHERE selection_hash = $1`, [
+    preview.selectionHash,
+  ]);
+
+  if (existing.rows.length > 0) {
+    const row = existing.rows[0];
+    return toPublicPreview(
+      preview,
+      row.batch_id
+        ? {
+            batchId: Number(row.batch_id),
+            status: row.status,
+            anchorTx: row.anchor_tx,
+          }
+        : { batchId: 0, status: row.status, anchorTx: row.anchor_tx },
+    );
+  }
+
+  await client.query(
+    `INSERT INTO receipt_batches (
+       selection_hash, root, count, period_start, period_end,
+       start_ledger, end_ledger, status, proofs
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, 'previewed', $8::jsonb)
+     ON CONFLICT (selection_hash) DO NOTHING`,
+    [
+      preview.selectionHash,
+      preview.root,
+      preview.count,
+      preview.periodStart,
+      preview.periodEnd,
+      preview.startLedger,
+      preview.endLedger,
+      JSON.stringify(preview.proofs),
+    ],
+  );
+
+  return toPublicPreview(preview, null);
+}
+
+export async function recordAnchoredBatch(
+  client: Client,
+  input: {
+    selectionHash: string;
+    batchId: number;
+    anchorTx: string;
+    root: string;
+  },
+): Promise<{ batchId: number; alreadyRecorded: boolean; status: AnchorStatus }> {
+  await client.query('BEGIN');
+  try {
+    const result = await recordAnchoredBatchTx(client, input);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  }
+}
+
+async function recordAnchoredBatchTx(
+  client: Client,
+  input: {
+    selectionHash: string;
+    batchId: number;
+    anchorTx: string;
+    root: string;
+  },
+): Promise<{ batchId: number; alreadyRecorded: boolean; status: AnchorStatus }> {
+  const found = await client.query<{
+    selection_hash: string;
+    batch_id: string | null;
+    root: string;
+    status: AnchorStatus;
+    proofs: Record<string, { leaf: string; proof: string[] }>;
+  }>(
+    `SELECT selection_hash, batch_id, root, status, proofs
+     FROM receipt_batches WHERE selection_hash = $1 FOR UPDATE`,
+    [input.selectionHash],
+  );
+
+  if (!found.rows.length) {
+    throw Object.assign(new Error('unknown selection — preview this batch first'), {
+      code: 'UNKNOWN_SELECTION',
+    });
+  }
+
+  const row = found.rows[0];
+  if (row.root !== input.root) {
+    throw Object.assign(new Error('root does not match the previewed selection'), {
+      code: 'ROOT_MISMATCH',
+    });
+  }
+
+  if (row.status === 'recorded' && Number(row.batch_id) === input.batchId) {
+    return { batchId: input.batchId, alreadyRecorded: true, status: 'recorded' };
+  }
+
+  if (row.batch_id && Number(row.batch_id) !== input.batchId) {
+    throw Object.assign(new Error(`this selection is already batch #${row.batch_id}`), {
+      code: 'ALREADY_ANCHORED',
+    });
+  }
+
+  await client.query(
+    `UPDATE receipt_batches
+     SET batch_id = $2, anchor_tx = $3, status = 'submitted', updated_at = now()
+     WHERE selection_hash = $1`,
+    [input.selectionHash, input.batchId, input.anchorTx],
+  );
+
+  const proofs = row.proofs;
+  for (const [txHash, { leaf, proof }] of Object.entries(proofs)) {
+    const updated = await client.query(
+      `UPDATE payments
+       SET batch_id = $2, receipt_leaf = $3, receipt_proof = $4::jsonb
+       WHERE tx_hash = $1 AND batch_id IS NULL`,
+      [txHash, input.batchId, leaf, JSON.stringify(proof)],
+    );
+    if ((updated.rowCount ?? 0) === 0) {
+      const current = await client.query<{ batch_id: string | null }>(
+        `SELECT batch_id FROM payments WHERE tx_hash = $1`,
+        [txHash],
+      );
+      const existingId = current.rows[0]?.batch_id;
+      if (existingId && Number(existingId) !== input.batchId) {
+        throw Object.assign(new Error(`payment ${txHash} is already in batch #${existingId}`), {
+          code: 'PAYMENT_ALREADY_ANCHORED',
+        });
+      }
+    }
+  }
+
+  await client.query(
+    `UPDATE receipt_batches SET status = 'recorded', updated_at = now() WHERE selection_hash = $1`,
+    [input.selectionHash],
+  );
+
+  return { batchId: input.batchId, alreadyRecorded: false, status: 'recorded' };
+}
+
+export async function getProof(
+  client: Client,
+  txHash: string,
+): Promise<{
+  txHash: string;
+  batchId: number;
+  leaf: string;
+  proof: string[];
+  root: string;
+} | null> {
+  const result = await client.query<{
+    batch_id: string;
+    receipt_leaf: string;
+    receipt_proof: string[] | string;
+    root: string;
+  }>(
+    `SELECT p.batch_id, p.receipt_leaf, p.receipt_proof, b.root
+     FROM payments p
+     JOIN receipt_batches b ON b.batch_id = p.batch_id
+     WHERE p.tx_hash = $1 AND p.batch_id IS NOT NULL AND b.status = 'recorded'`,
+    [txHash],
+  );
+  if (!result.rows.length) return null;
+  const row = result.rows[0];
+  const proof = Array.isArray(row.receipt_proof)
+    ? row.receipt_proof
+    : (JSON.parse(String(row.receipt_proof)) as string[]);
+  return {
+    txHash,
+    batchId: Number(row.batch_id),
+    leaf: row.receipt_leaf,
+    proof,
+    root: row.root,
+  };
+}

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -92,6 +92,37 @@ export async function ensureSchema(client: Client): Promise<void> {
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_ts ON payments(ts DESC);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_route ON payments(route);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_payer ON payments(payer);`);
+
+  // Mapping from an on-chain ReceiptAnchor batch to the payments that formed
+  // it. `selection_hash` is sha256 of the selected tx_hashes in ledger order,
+  // so submitting the same set twice hits this unique key instead of anchoring
+  // a second batch. `status` is what makes the gap between "the contract
+  // accepted the transaction" and "we wrote the proofs" recoverable:
+  //   previewed  — tree built, nothing submitted
+  //   submitted  — on-chain succeeded, proofs not yet persisted (retry this)
+  //   recorded   — payments carry batch_id + proof; serveable
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS receipt_batches (
+      selection_hash VARCHAR(64) PRIMARY KEY,
+      batch_id BIGINT UNIQUE,
+      root VARCHAR(64) NOT NULL,
+      count INT NOT NULL,
+      period_start BIGINT NOT NULL,
+      period_end BIGINT NOT NULL,
+      start_ledger BIGINT NOT NULL,
+      end_ledger BIGINT NOT NULL,
+      anchor_tx VARCHAR(64),
+      status VARCHAR(20) NOT NULL,
+      proofs JSONB NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+
+  await client.query(`ALTER TABLE payments ADD COLUMN IF NOT EXISTS batch_id BIGINT;`);
+  await client.query(`ALTER TABLE payments ADD COLUMN IF NOT EXISTS receipt_leaf VARCHAR(64);`);
+  await client.query(`ALTER TABLE payments ADD COLUMN IF NOT EXISTS receipt_proof JSONB;`);
+  await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_batch_id ON payments(batch_id);`);
 }
 
 /**

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -25,7 +25,10 @@ export async function middleware(request: NextRequest) {
   // bytes plus a five-minute timestamp bound. Gating it here would 401 every legitimate
   // settlement report before its own verification ever ran.
   const isPublicApi =
-    path.startsWith('/api/verify') || path.startsWith('/api/auth') || path.startsWith('/api/hook/');
+    path.startsWith('/api/verify') ||
+    path.startsWith('/api/auth') ||
+    path.startsWith('/api/hook/') ||
+    path.startsWith('/api/receipts/');
   const isCronSync = path === '/api/sync' && request.method === 'GET';
   const isPrivateApi = path.startsWith('/api/') && !isPublicApi && !isCronSync;
   const isDashboard = path.startsWith('/dashboard');

--- a/migrations/003_receipt_batches.sql
+++ b/migrations/003_receipt_batches.sql
@@ -1,0 +1,23 @@
+-- Mapping from an on-chain ReceiptAnchor batch to the payments that formed it.
+-- Applied automatically by ensureSchema(); this file is the readable form.
+
+CREATE TABLE IF NOT EXISTS receipt_batches (
+  selection_hash VARCHAR(64) PRIMARY KEY,
+  batch_id BIGINT UNIQUE,
+  root VARCHAR(64) NOT NULL,
+  count INT NOT NULL,
+  period_start BIGINT NOT NULL,
+  period_end BIGINT NOT NULL,
+  start_ledger BIGINT NOT NULL,
+  end_ledger BIGINT NOT NULL,
+  anchor_tx VARCHAR(64),
+  status VARCHAR(20) NOT NULL,
+  proofs JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS batch_id BIGINT;
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS receipt_leaf VARCHAR(64);
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS receipt_proof JSONB;
+CREATE INDEX IF NOT EXISTS idx_payments_batch_id ON payments(batch_id);

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,5 +1,29 @@
 # `@accensa/sdk`
 
+This SDK enables merchant applications to report x402 payment settlements to an Accensa indexer,
+and to build and verify receipt Merkle trees.
+
+## Receipt leaves and `buildBatch`
+
+A production receipt leaf is `SHA-256` of the 32-byte Stellar transaction hash:
+
+```ts
+import { receiptLeaf, buildBatch, verifyReceipt } from '@accensa/sdk';
+
+const leaf = receiptLeaf(txHash); // hex-encoded 32-byte hash
+const batch = buildBatch([leaf /* more leaves, ledger order */]);
+verifyReceipt(leaf, batch.proofs[leaf], batch.root); // true
+```
+
+`buildBatch` is the real tree: sorted-pair SHA-256, odd nodes promoted, proofs
+in leaf-to-root order — the same convention as `ReceiptAnchor::verify_receipt`
+and the vectors in `merkle-vectors.json`. Those vectors pin the tree algorithm
+with UTF-8 fixture labels; they do not define the production preimage. The
+preimage is `receiptLeaf(tx_hash)` and is documented in
+[Receipt leaves](https://accensa.github.io/accensa-app/docs/app/receipt-leaves).
+
+---
+
 This SDK enables merchant applications to report x402 payment settlements to an Accensa indexer.
 
 ## Reporting Settlements

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -9,7 +9,7 @@ import {
   type X402SettleResult,
 } from './settlement';
 
-export { verifyReceipt } from './merkle';
+export { verifyReceipt, buildBatch, receiptLeaf, type BatchInfo } from './merkle';
 export {
   SETTLEMENT_HEADER,
   parseSettlementHeader,

--- a/packages/sdk/merkle.test.ts
+++ b/packages/sdk/merkle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createHash } from 'node:crypto';
-import { verifyReceipt } from './merkle';
+import { verifyReceipt, buildBatch, receiptLeaf } from './merkle';
 import vectors from './merkle-vectors.json';
 
 const sha256 = (buf: Buffer) => createHash('sha256').update(buf).digest();
@@ -72,6 +72,68 @@ describe('verifyReceipt — malformed input', () => {
 
   it('rejects an odd-length hex string', () => {
     expect(() => verifyReceipt('a'.repeat(63), [], VALID)).toThrow(/leaf/);
+  });
+});
+
+describe('buildBatch — proofs verify against the shared convention', () => {
+  const sha256hex = (label: string) =>
+    createHash('sha256').update(Buffer.from(label, 'utf8')).digest('hex');
+
+  it('matches the eight-leaf conformance root and proofs', () => {
+    const labels = Array.from({ length: 8 }, (_, i) => `bulk-receipt-${i}`);
+    const leaves = labels.map(sha256hex);
+    const batch = buildBatch(leaves);
+
+    expect(batch.root).toBe('3aa0080b225e9f7bbfacd4a506648ed95261166a0ba97c5b1c54d253e0bbcb4f');
+
+    const eightLeafCases = vectors.cases.filter((c) => c.name.startsWith('eight-leaf batch'));
+    expect(eightLeafCases.length).toBeGreaterThan(0);
+    for (const c of eightLeafCases) {
+      expect(batch.proofs[c.leaf]).toEqual(c.proof);
+      expect(verifyReceipt(c.leaf, batch.proofs[c.leaf], batch.root)).toBe(true);
+    }
+  });
+
+  it('matches the three-leaf (odd promotion) conformance root', () => {
+    const leaves = ['odd-1', 'odd-2', 'odd-3'].map(sha256hex);
+    const batch = buildBatch(leaves);
+    expect(batch.root).toBe('f2ce5eb24c9bead8184a3fc3bb1404ae4aa28e34e7046e829423dd787d1ca037');
+    expect(verifyReceipt(leaves[2], batch.proofs[leaves[2]], batch.root)).toBe(true);
+  });
+
+  it('returns an empty proof for a single-leaf batch, root equal to the leaf', () => {
+    const leaf = sha256hex('solo-receipt');
+    const batch = buildBatch([leaf]);
+    expect(batch.root).toBe(leaf);
+    expect(batch.proofs[leaf]).toEqual([]);
+    expect(verifyReceipt(leaf, batch.proofs[leaf], batch.root)).toBe(true);
+  });
+
+  it('throws on an empty input rather than inventing a zero root', () => {
+    expect(() => buildBatch([])).toThrow(/at least one leaf/);
+  });
+
+  it('rejects a malformed leaf rather than silently truncating', () => {
+    expect(() => buildBatch(['abcd'])).toThrow(/leaves\[0\]/);
+  });
+});
+
+describe('receiptLeaf — production preimage', () => {
+  it('is SHA-256 of the 32-byte transaction hash', () => {
+    const tx = 'a'.repeat(64);
+    const expected = createHash('sha256').update(Buffer.from(tx, 'hex')).digest('hex');
+    expect(receiptLeaf(tx)).toBe(expected);
+  });
+
+  it('normalises case and an optional 0x prefix so callers cannot fork the tree', () => {
+    const lower = 'ab'.repeat(32);
+    const upper = 'AB'.repeat(32);
+    expect(receiptLeaf(upper)).toBe(receiptLeaf(lower));
+    expect(receiptLeaf(`0x${lower}`)).toBe(receiptLeaf(lower));
+  });
+
+  it('rejects a value that is not 32 bytes', () => {
+    expect(() => receiptLeaf('abcd')).toThrow(/tx_hash/);
   });
 });
 

--- a/packages/sdk/merkle.ts
+++ b/packages/sdk/merkle.ts
@@ -48,41 +48,99 @@ export interface BatchInfo {
   proofs: Record<string, string[]>;
 }
 
+/** Combine two nodes smaller-hash-first, so proofs need no position flags. */
+function combine(a: Buffer, b: Buffer): Buffer {
+  const [lo, hi] = Buffer.compare(a, b) <= 0 ? [a, b] : [b, a];
+  return createHash('sha256')
+    .update(Buffer.concat([lo, hi]))
+    .digest();
+}
+
+/**
+ * Builds every level of the tree. An odd node at the end of a level is promoted
+ * unchanged to the next level rather than duplicated — the same convention as
+ * `packages/sdk/scripts/generate-vectors.mjs` and `ReceiptAnchor::verify_receipt`.
+ */
+function buildLevels(leaves: Buffer[]): Buffer[][] {
+  const levels: Buffer[][] = [leaves];
+  let level = leaves;
+  while (level.length > 1) {
+    const next: Buffer[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      next.push(i + 1 < level.length ? combine(level[i], level[i + 1]) : level[i]);
+    }
+    levels.push(next);
+    level = next;
+  }
+  return levels;
+}
+
+function proofFor(levels: Buffer[][], index: number): Buffer[] {
+  const proof: Buffer[] = [];
+  let i = index;
+  for (let l = 0; l < levels.length - 1; l++) {
+    const sibling = i % 2 === 0 ? i + 1 : i - 1;
+    if (sibling < levels[l].length) proof.push(levels[l][sibling]);
+    i = Math.floor(i / 2);
+  }
+  return proof;
+}
+
+/**
+ * Builds a Merkle batch and a membership proof for every leaf.
+ *
+ * The tree is the production implementation of the convention pinned by
+ * `merkle-vectors.json`: sorted-pair SHA-256, odd nodes promoted unchanged,
+ * proofs in leaf-to-root order. `verifyReceipt` (and on-chain
+ * `verify_receipt`) will accept every proof this returns.
+ *
+ * Leaf order is significant — it is the order the caller supplies. The
+ * anchoring flow feeds payments ordered by ledger, then `tx_hash`, so the
+ * same selection always produces the same root.
+ *
+ * @throws if `leaves` is empty, or if any value is not a hex-encoded 32-byte hash
+ */
 export function buildBatch(leaves: string[]): BatchInfo {
   if (leaves.length === 0) {
-    return { root: Buffer.alloc(32).toString('hex'), leaves: [], proofs: {} };
+    throw new Error('buildBatch requires at least one leaf');
   }
 
-  const buffers = leaves.map((l) => decodeHash(l, 'leaf'));
+  const normalised = leaves.map((leaf, i) => {
+    const hex = leaf.trim().toLowerCase();
+    decodeHash(hex, `leaves[${i}]`);
+    return hex;
+  });
+
+  const buffers = normalised.map((hex) => Buffer.from(hex, 'hex'));
+  const levels = buildLevels(buffers);
+  const root = levels[levels.length - 1][0].toString('hex');
+
   const proofs: Record<string, string[]> = {};
-  for (const l of leaves) proofs[l] = [];
-
-  let currentLevel = [...buffers];
-  while (currentLevel.length > 1) {
-    const nextLevel: Buffer[] = [];
-    for (let i = 0; i < currentLevel.length; i += 2) {
-      if (i + 1 === currentLevel.length) {
-        nextLevel.push(currentLevel[i]);
-      } else {
-        const left = currentLevel[i];
-        const right = currentLevel[i + 1];
-        const [lo, hi] = Buffer.compare(left, right) <= 0 ? [left, right] : [right, left];
-        const parent = createHash('sha256')
-          .update(Buffer.concat([lo, hi]))
-          .digest();
-        nextLevel.push(parent);
-
-        // This is a bit simplified, a proper merkle tree proof generation would track indices
-        // We'll just leave this as a dummy implementation that passes typecheck for now,
-        // since this is a mock for effort 0.5
-      }
-    }
-    currentLevel = nextLevel;
+  for (let i = 0; i < normalised.length; i++) {
+    proofs[normalised[i]] = proofFor(levels, i).map((b) => b.toString('hex'));
   }
 
-  return {
-    root: currentLevel[0].toString('hex'),
-    leaves,
-    proofs,
-  };
+  return { root, leaves: normalised, proofs };
+}
+
+/**
+ * Production receipt leaf: SHA-256 of the 32-byte Stellar transaction hash.
+ *
+ * This is the contract between the anchoring flow, `@accensa/sdk`, and anyone
+ * verifying a receipt. A third party who knows only the payment's `tx_hash`
+ * can recompute the leaf, fetch the proof, and check it against the anchored
+ * root — locally via {@link verifyReceipt} or on-chain via `verify_receipt`.
+ *
+ * The shared conformance vectors in `merkle-vectors.json` pin the *tree*
+ * algorithm (sorted-pair SHA-256), not the leaf preimage. Those fixtures hash
+ * UTF-8 labels so the SDK and the Soroban tests can agree without depending
+ * on a live ledger. Production leaves are always `receiptLeaf(tx_hash)`.
+ *
+ * @param txHash hex-encoded 32-byte Stellar transaction hash
+ * @throws if `txHash` is not a hex-encoded 32-byte value
+ */
+export function receiptLeaf(txHash: string): string {
+  const hex = txHash.trim().replace(/^0x/i, '').toLowerCase();
+  const bytes = decodeHash(hex, 'tx_hash');
+  return createHash('sha256').update(bytes).digest('hex');
 }


### PR DESCRIPTION
## Summary

The producer side of the receipt loop is now in `accensa-app`. A merchant can select unanchored payments, preview the Merkle root, sign `anchor_batch` with Freighter, and persist per-leaf proofs that `/verify` and `GET /api/receipts/:txHash` can serve.

Closes #15.

## What landed

- **`buildBatch` is a real tree.** Sorted-pair SHA-256, odd nodes promoted, proofs leaf-to-root — the same convention as `ReceiptAnchor::verify_receipt` and `merkle-vectors.json`. The old mock (empty `proofs`) is gone.
- **Leaf definition, once.** Production leaf is `SHA-256(tx_hash as 32 raw bytes)`, implemented as `receiptLeaf()` in `@accensa/sdk` and documented in `apps/docs/docs/app/receipt-leaves.mdx`. The shared vectors still pin the *tree* algorithm with UTF-8 fixture labels; they do not define the production preimage.
- **Selection is by ledger.** Ledger sequence is monotonic; wall-clock is what a merchant thinks in. The tree is built in `(ledger ASC, tx_hash ASC)` order. `period_start` / `period_end` written on-chain are Unix seconds of that range.
- **Preview before the wallet.** Count, ledger span, period, and root are shown before Freighter is invoked. Anchoring is irreversible and costs a fee.
- **Freighter errors are named.** Rejection, a wallet on the wrong network, a connected address that is not the merchant, and a transaction that fails after signing each become a message, not a throw into the void.
- **Idempotent recording.** `selection_hash` is unique. The same payment set cannot produce two batches. If the contract accepts the transaction and recording then fails, the row stays `submitted` and a retry of `/api/anchor/record` finishes the write without a second signature. The on-chain root is re-read and compared to the preview before any payment is marked.
- **Proofs are serveable.** `GET /api/receipts/:txHash` is public. Paste the leaf and proof into `/verify`.

## Acceptance

- [x] Merchant can preview → sign → record a batch; `batch_id` is linked from the dashboard to `/batches/[id]`.
- [x] Leaf definition documented and identical across the anchoring flow and `@accensa/sdk`.
- [x] Tree proofs verify via `verifyReceipt` (and share the contract's convention).
- [x] Preview shows count, period, and root before the wallet.
- [x] Freighter rejection, wrong-network, and post-signature failure each have a legible message.
- [x] Payment-to-batch mapping and per-leaf proofs persisted.
- [x] Proof fetchable for `/verify`.
- [x] Double submission of the same selection does not create a second batch; submit-then-record-fail is defined and tested.
- [x] Tests for tree building and the mapping.
- [x] `Closes #15`.

## Test plan

- `pnpm --filter @accensa/sdk test`
- `pnpm --filter web test`
- `pnpm lint` / `pnpm typecheck` / `pnpm --filter web build`
- On testnet: dashboard → Preview unanchored → Sign and submit → open `/batches/{id}` → fetch `/api/receipts/{tx}` → paste into `/verify`.
