### PR TITLE
fix(indexer): decouple webhook delivery from the sync loop

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -91,6 +91,15 @@ jobs:
               echo "::warning::Cursor fell outside RPC retention; $skipped ledgers skipped."
             fi
 
+            echo "Delivering queued payment webhooks..."
+            webhook_url="${SYNC_URL%/sync}/webhooks/deliver"
+            webhook_response=$(curl -sS --max-time 30 -w '\n%{http_code}' \
+              -H "Authorization: Bearer $CRON_SECRET" "$webhook_url" || echo "curl failed")
+            webhook_body=$(printf '%s' "$webhook_response" | sed '$d')
+            webhook_code=$(printf '%s' "$webhook_response" | tail -n1)
+            echo "webhook HTTP $webhook_code"
+            echo "$webhook_body"
+
             echo "Sleeping for 5 minutes..."
             sleep 300
           done

--- a/README.md
+++ b/README.md
@@ -130,6 +130,38 @@ Then trigger an index run with `curl localhost:3000/api/sync`, and the dashboard
 `/dashboard` will show whatever settled to `MERCHANT_ADDRESS`. If nothing has, it
 says so — the dashboard never invents rows to fill space.
 
+### Payment webhooks (`WEBHOOK_URL`)
+
+Set `WEBHOOK_URL` to receive a `POST` for each newly indexed payment. The
+indexer **does not wait on your endpoint**. Each insert writes a
+`webhook_deliveries` row in the same database transaction; a separate job at
+`GET /api/webhooks/deliver` (same `CRON_SECRET` bearer as `/api/sync`) ships
+the payload. A host that sleeps, 500s, or rate-limits cannot stall the ledger
+cursor — that is how 207 ledgers were lost the last time indexing blocked on
+something that was not the chain.
+
+**Retry policy.** Up to 8 attempts over 24 hours. Exponential backoff with 25%
+jitter, capped at one hour. 5xx, 429, and transport errors are retried; other
+4xx are not. A `429` honours `Retry-After` (delta-seconds or HTTP-date). After
+the window the row is `failed` and is listed on the dashboard.
+
+**Signature.** Ed25519 over the exact UTF-8 body bytes, the same scheme as
+settlement reporting.
+
+| Header                  | Value                                         |
+| ----------------------- | --------------------------------------------- |
+| `Content-Type`          | `application/json`                            |
+| `X-Signature`           | hex-encoded Ed25519 signature of the raw body |
+| `X-Accensa-Timestamp`   | Unix seconds at sign time                     |
+| `X-Accensa-Delivery-Id` | `webhook_deliveries.id`                       |
+
+`WEBHOOK_SIGNING_KEY` is a 32-byte Ed25519 private key as hex. Without it,
+queued deliveries fail closed rather than going out unsigned. Verify with the
+matching public key over the raw request body, then parse JSON.
+
+Body fields: `tx_hash`, `ledger`, `payer`, `amount`, `asset`, `ts`, `route`,
+`method`.
+
 Routes: `/` is the landing page, `/dashboard` the merchant view, and `/verify` the
 public receipt verifier, which needs no account.
 

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -24,7 +24,7 @@ To secure the dashboard and private API routes, we use a Stellar Wallet Auth mod
 
 - **Public**: `/verify`, `POST /api/verify`, landing pages, docs.
 - **Private**: `/dashboard`, `/dashboard/routes`, `/api/payments`, `/api/routes`, `/api/refund/preflight`, `POST /api/sync`.
-- **Special**: `GET /api/sync` remains protected by `CRON_SECRET` for automated GitHub Action workflows.
+- **Special**: `GET /api/sync` and `GET /api/webhooks/deliver` remain protected by `CRON_SECRET` for automated GitHub Action workflows. Webhook delivery is a separate path from indexing so a merchant endpoint cannot stall the ledger cursor.
 
 ### Session Handling
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,6 +6,13 @@ The dashboard and API routes are secured using a Stellar Wallet Auth model (simi
 
 See [SECURITY.md](./SECURITY.md) and [DESIGN.md](./DESIGN.md) for full details on the access model and session handling.
 
+## Payment webhooks
+
+`WEBHOOK_URL` queues a signed POST for each newly indexed payment. Delivery
+runs on `GET /api/webhooks/deliver`, not inside the indexing loop — see the
+root README for the retry policy and Ed25519 signature scheme
+(`WEBHOOK_SIGNING_KEY`). Terminal failures are listed on the dashboard.
+
 ## Getting Started
 
 First, run the development server:

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -9,6 +9,7 @@ import {
 } from '@/lib/db';
 import { sweepLedgerRange, EVENTS_PAGE_LIMIT, type EventPage } from '@/lib/event-pager';
 import { cooldownRemaining } from '@/lib/sync-status';
+import { enqueueWebhookDelivery, payloadFromRow } from '@/lib/webhooks';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -186,8 +187,10 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
         //
         // Only ledger-owned columns are written. route, method, request_id and
         // hook_reported_at belong to the merchant's report and are left alone.
-        const res = await client.query(
-          `INSERT INTO payments (tx_hash, ledger, payer, amount, asset, ts)
+        await client.query('BEGIN');
+        try {
+          const res = await client.query(
+            `INSERT INTO payments (tx_hash, ledger, payer, amount, asset, ts)
   VALUES ($1, $2, $3, $4::numeric, $5, $6::timestamptz)
   ON CONFLICT (tx_hash) DO UPDATE
   SET ledger = EXCLUDED.ledger,
@@ -196,36 +199,28 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
   asset = EXCLUDED.asset,
   ts = EXCLUDED.ts
   WHERE payments.ledger IS NULL RETURNING *`,
-          [
-            transferEvent.txHash,
-            transferEvent.ledger,
-            transferEvent.from,
-            transferEvent.amount, // string - never a float
-            transferEvent.asset,
-            transferEvent.ledgerClosedAt,
-          ],
-        );
-        if (res.rowCount && res.rowCount > 0 && process.env.WEBHOOK_URL) {
-          const payment = res.rows[0];
-          const timeoutMs = 2000;
-          for (let i = 0; i < 3; i++) {
-            try {
-              const controller = new AbortController();
-              const id = setTimeout(() => controller.abort(), timeoutMs);
-              const webhookRes = await fetch(process.env.WEBHOOK_URL, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payment),
-                signal: controller.signal,
-              });
-              clearTimeout(id);
-              if (webhookRes.ok || webhookRes.status < 500) break;
-            } catch {
-              // A webhook the merchant cannot receive must not stall indexing.
-            }
+            [
+              transferEvent.txHash,
+              transferEvent.ledger,
+              transferEvent.from,
+              transferEvent.amount, // string - never a float
+              transferEvent.asset,
+              transferEvent.ledgerClosedAt,
+            ],
+          );
+          if (res.rowCount && res.rowCount > 0 && process.env.WEBHOOK_URL) {
+            await enqueueWebhookDelivery(
+              client,
+              payloadFromRow(res.rows[0] as Record<string, unknown>),
+              process.env.WEBHOOK_URL,
+            );
           }
+          await client.query('COMMIT');
+          inserted += res.rowCount ?? 0;
+        } catch (error) {
+          await client.query('ROLLBACK').catch(() => {});
+          throw error;
         }
-        inserted += res.rowCount ?? 0;
       }
 
       // The sweep only ever reports whole windows, so this is safe whether or

--- a/apps/web/src/app/api/webhooks/deliver/route.ts
+++ b/apps/web/src/app/api/webhooks/deliver/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { withClient, ensureSchema } from '@/lib/db';
+import { deliverDue } from '@/lib/webhooks';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+/**
+ * Ships queued payment webhooks.
+ *
+ * Protected by CRON_SECRET the same way GET /api/sync is. Indexing never
+ * calls this — a hung merchant endpoint can only delay itself.
+ */
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (secret && request.headers.get('authorization') !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+
+  try {
+    const result = await withClient(async (client) => {
+      await ensureSchema(client);
+      return deliverDue(client);
+    });
+    return NextResponse.json({ success: true, ...result });
+  } catch (error: unknown) {
+    console.error('webhook delivery failed:', error);
+    return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { withClient, ensureSchema } from '@/lib/db';
+import { webhookSummary } from '@/lib/webhooks';
+
+export const dynamic = 'force-dynamic';
+
+/** Merchant-visible webhook delivery status. Session-authenticated via middleware. */
+export async function GET() {
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+  if (!process.env.WEBHOOK_URL) {
+    return NextResponse.json({
+      configured: false,
+      pending: 0,
+      failed: 0,
+      delivered: 0,
+      recentFailed: [],
+    });
+  }
+
+  try {
+    const summary = await withClient(async (client) => {
+      await ensureSchema(client);
+      return webhookSummary(client);
+    });
+    return NextResponse.json({ configured: true, ...summary });
+  } catch (error: unknown) {
+    console.error('webhook summary failed:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 import { PageContainer } from '@/components/page-container';
 import { RefundPanel } from '@/components/refund-panel';
+import { WebhookStatus } from '@/components/webhook-status';
 import { useOnline } from '@/components/network-status';
 import { describeFailure, isAbortError } from '@/lib/network-status';
 
@@ -167,6 +168,8 @@ export default function Dashboard() {
             </span>
           </div>
         </header>
+
+        <WebhookStatus />
 
         {/* Data Table Section */}
         <section className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl overflow-hidden shadow-[0_8px_30px_rgba(0,0,0,0.12),inset_0_1px_1px_rgba(255,255,255,0.8)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.15)] transition-colors duration-300">

--- a/apps/web/src/components/webhook-status.tsx
+++ b/apps/web/src/components/webhook-status.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useOnline } from '@/components/network-status';
+
+interface Summary {
+  configured: boolean;
+  pending: number;
+  failed: number;
+  delivered: number;
+  recentFailed: Array<{
+    id: number;
+    paymentTxHash: string;
+    attempts: number;
+    lastStatusCode: number | null;
+    lastError: string | null;
+  }>;
+}
+
+/**
+ * Surfaces terminal webhook failures on the dashboard. A webhook that stopped
+ * a week ago is the same class of failure as an indexer that stopped a week
+ * ago — it must be visible, not swallowed in a catch block.
+ */
+export function WebhookStatus() {
+  const online = useOnline();
+  const [summary, setSummary] = useState<Summary | null>(null);
+
+  useEffect(() => {
+    if (!online) return;
+    const controller = new AbortController();
+    void fetch('/api/webhooks', { signal: controller.signal, cache: 'no-store' })
+      .then(async (res) => {
+        if (!res.ok) return;
+        setSummary(await res.json());
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [online]);
+
+  if (!summary?.configured) return null;
+  if (summary.failed === 0 && summary.pending === 0) return null;
+
+  return (
+    <section
+      className="border border-amber-200 dark:border-amber-500/20 bg-amber-50/70 dark:bg-amber-500/10 p-6 space-y-3"
+      data-testid="webhook-status"
+    >
+      <h2 className="text-sm font-black uppercase tracking-widest text-amber-800 dark:text-amber-300">
+        Webhook deliveries
+      </h2>
+      <p className="text-sm text-amber-900 dark:text-amber-200">
+        {summary.failed > 0
+          ? `${summary.failed} ${summary.failed === 1 ? 'delivery' : 'deliveries'} failed after the retry window.`
+          : `${summary.pending} ${summary.pending === 1 ? 'delivery' : 'deliveries'} waiting to retry.`}
+      </p>
+      {summary.recentFailed.length > 0 && (
+        <ul className="text-xs font-mono text-amber-900 dark:text-amber-200 space-y-1">
+          {summary.recentFailed.slice(0, 5).map((row) => (
+            <li key={row.id}>
+              {row.paymentTxHash.slice(0, 8)}… · {row.attempts} attempt
+              {row.attempts === 1 ? '' : 's'}
+              {row.lastStatusCode ? ` · HTTP ${row.lastStatusCode}` : ''}
+              {row.lastError ? ` · ${row.lastError}` : ''}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -92,6 +92,41 @@ export async function ensureSchema(client: Client): Promise<void> {
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_ts ON payments(ts DESC);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_route ON payments(route);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_payer ON payments(payer);`);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS webhook_deliveries (
+      id BIGSERIAL PRIMARY KEY,
+      payment_tx_hash VARCHAR(64) NOT NULL,
+      url TEXT NOT NULL,
+      payload JSONB NOT NULL,
+      status VARCHAR(20) NOT NULL DEFAULT 'pending',
+      attempts INT NOT NULL DEFAULT 0,
+      last_status_code INT,
+      last_error TEXT,
+      next_retry_at TIMESTAMPTZ,
+      delivered_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (payment_tx_hash, url)
+    );
+  `);
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS webhook_attempts (
+      id BIGSERIAL PRIMARY KEY,
+      delivery_id BIGINT NOT NULL REFERENCES webhook_deliveries(id) ON DELETE CASCADE,
+      attempt_number INT NOT NULL,
+      status_code INT,
+      error TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_due
+     ON webhook_deliveries (next_retry_at) WHERE status = 'pending';`,
+  );
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries (status);`,
+  );
 }
 
 /**

--- a/apps/web/src/lib/webhooks.test.ts
+++ b/apps/web/src/lib/webhooks.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  shouldRetry,
+  parseRetryAfter,
+  backoffMs,
+  nextRetryAt,
+  canonicalPayload,
+  MAX_ATTEMPTS,
+  DELIVERY_WINDOW_MS,
+  deliverDue,
+  enqueueWebhookDelivery,
+  payloadFromRow,
+} from './webhooks';
+
+describe('shouldRetry', () => {
+  it('retries 5xx, 429 and transport errors', () => {
+    expect(shouldRetry(500, false)).toBe(true);
+    expect(shouldRetry(503, false)).toBe(true);
+    expect(shouldRetry(429, false)).toBe(true);
+    expect(shouldRetry(null, true)).toBe(true);
+  });
+
+  it('does not retry other 4xx — a 404 is not a host that will recover', () => {
+    expect(shouldRetry(400, false)).toBe(false);
+    expect(shouldRetry(401, false)).toBe(false);
+    expect(shouldRetry(404, false)).toBe(false);
+  });
+
+  it('does not retry 2xx', () => {
+    expect(shouldRetry(200, false)).toBe(false);
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('honours delta-seconds', () => {
+    expect(parseRetryAfter('12', 1_000)).toBe(13_000);
+  });
+
+  it('honours an HTTP-date', () => {
+    const when = 'Wed, 21 Oct 2015 07:28:00 GMT';
+    expect(parseRetryAfter(when, 0)).toBe(Date.parse(when));
+  });
+
+  it('returns null for garbage', () => {
+    expect(parseRetryAfter('soon', 0)).toBeNull();
+    expect(parseRetryAfter(null, 0)).toBeNull();
+  });
+});
+
+describe('backoffMs', () => {
+  it('is exponential with jitter in [base, 1.25*base]', () => {
+    const random = () => 0.5;
+    expect(backoffMs(1, random)).toBe(Math.floor(1000 + 500));
+    expect(backoffMs(2, random)).toBe(Math.floor(2000 + 1000));
+    expect(backoffMs(3, random)).toBe(Math.floor(4000 + 2000));
+  });
+});
+
+describe('nextRetryAt', () => {
+  it('returns null once the attempt budget is exhausted', () => {
+    const now = 10_000;
+    expect(nextRetryAt({ attempt: MAX_ATTEMPTS, createdAtMs: 0, now, random: () => 0 })).toBeNull();
+  });
+
+  it('returns null once the 24h window has elapsed', () => {
+    const now = DELIVERY_WINDOW_MS + 1;
+    expect(nextRetryAt({ attempt: 1, createdAtMs: 0, now, random: () => 0 })).toBeNull();
+  });
+
+  it('takes the later of backoff and Retry-After', () => {
+    const now = 0;
+    const at = nextRetryAt({
+      attempt: 1,
+      createdAtMs: 0,
+      now,
+      retryAfterHeader: '30',
+      random: () => 0,
+    });
+    expect(at?.getTime()).toBe(30_000);
+  });
+});
+
+describe('canonicalPayload', () => {
+  it('emits a stable JSON object so the signature covers the exact body', () => {
+    const body = canonicalPayload({
+      tx_hash: 'aa',
+      ledger: 1,
+      payer: 'G',
+      amount: '2',
+      asset: 'native',
+      ts: 't',
+      route: '/x',
+      method: 'GET',
+    });
+    expect(JSON.parse(body)).toEqual({
+      tx_hash: 'aa',
+      ledger: 1,
+      payer: 'G',
+      amount: '2',
+      asset: 'native',
+      ts: 't',
+      route: '/x',
+      method: 'GET',
+    });
+  });
+});
+
+describe('enqueueWebhookDelivery', () => {
+  it('does not call fetch — indexing only persists a row', async () => {
+    const fetchSpy = vi.fn();
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const query = vi.fn().mockResolvedValue({ rowCount: 1 });
+      await enqueueWebhookDelivery(
+        { query } as never,
+        payloadFromRow({
+          tx_hash: 'a'.repeat(64),
+          ledger: 1,
+          payer: 'G',
+          amount: '1',
+          asset: 'native',
+          ts: new Date('2026-01-01T00:00:00.000Z'),
+          route: null,
+          method: null,
+        }),
+        'https://merchant.example/hook',
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(query).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+describe('deliverDue — a sleeping host cannot stall the caller past the budget', () => {
+  it('returns before a webhook that never responds would exhaust the indexer budget', async () => {
+    const hanging = () => new Promise<Response>(() => {});
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("SET status = 'delivering'")) return { rowCount: 1, rows: [{ id: 1 }] };
+      if (sql.includes('FROM webhook_deliveries')) {
+        return {
+          rows: [
+            {
+              id: '1',
+              payment_tx_hash: 'a'.repeat(64),
+              url: 'http://blackhole.test/hook',
+              payload: {
+                tx_hash: 'a'.repeat(64),
+                ledger: 1,
+                payer: 'G',
+                amount: '1',
+                asset: 'native',
+                ts: 't',
+                route: null,
+                method: null,
+              },
+              attempts: 0,
+              created_at: new Date(),
+            },
+          ],
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const started = Date.now();
+    await deliverDue({ query } as never, {
+      fetchImpl: hanging as unknown as typeof fetch,
+      signingKey: '11'.repeat(32),
+      timeoutMs: 50,
+      budgetMs: 200,
+    });
+    const elapsed = Date.now() - started;
+    expect(elapsed).toBeLessThan(5_000);
+  });
+});

--- a/apps/web/src/lib/webhooks.ts
+++ b/apps/web/src/lib/webhooks.ts
@@ -1,0 +1,391 @@
+import { createHash, createPrivateKey, sign as edSign } from 'node:crypto';
+import type { Client } from 'pg';
+
+/**
+ * Outbound payment webhooks.
+ *
+ * Delivery is deliberately not part of indexing. The indexer inserts a
+ * `webhook_deliveries` row in the same transaction as the payment; a separate
+ * path (`/api/webhooks/deliver`) ships the payload. A host that sleeps, 500s,
+ * or rate-limits cannot stall the ledger cursor.
+ */
+
+export const MAX_ATTEMPTS = 8;
+export const DELIVERY_WINDOW_MS = 24 * 60 * 60 * 1000;
+export const ATTEMPT_TIMEOUT_MS = 2_000;
+export const MAX_BACKOFF_MS = 60 * 60 * 1000;
+
+export type DeliveryStatus = 'pending' | 'delivering' | 'delivered' | 'failed';
+
+export interface PaymentPayload {
+  tx_hash: string;
+  ledger: number | null;
+  payer: string | null;
+  amount: string | null;
+  asset: string | null;
+  ts: string | null;
+  route: string | null;
+  method: string | null;
+}
+
+export function shouldRetry(status: number | null, transportError: boolean): boolean {
+  if (transportError) return true;
+  if (status === null) return true;
+  if (status === 429) return true;
+  if (status >= 500 && status <= 599) return true;
+  return false;
+}
+
+export function parseRetryAfter(header: string | null | undefined, now: number): number | null {
+  if (!header) return null;
+  const trimmed = header.trim();
+  if (!trimmed) return null;
+  if (/^\d+$/.test(trimmed)) {
+    return now + Number(trimmed) * 1000;
+  }
+  const date = Date.parse(trimmed);
+  if (Number.isNaN(date)) return null;
+  return date;
+}
+
+export function backoffMs(attempt: number, random: () => number = Math.random): number {
+  const exp = Math.min(1000 * 2 ** Math.max(0, attempt - 1), MAX_BACKOFF_MS);
+  return Math.floor(exp + random() * exp * 0.25);
+}
+
+export function nextRetryAt(opts: {
+  attempt: number;
+  createdAtMs: number;
+  now: number;
+  retryAfterHeader?: string | null;
+  random?: () => number;
+}): Date | null {
+  if (opts.now - opts.createdAtMs >= DELIVERY_WINDOW_MS) return null;
+  if (opts.attempt >= MAX_ATTEMPTS) return null;
+  const fromHeader = parseRetryAfter(opts.retryAfterHeader, opts.now);
+  const fromBackoff = opts.now + backoffMs(opts.attempt, opts.random ?? Math.random);
+  const at = Math.max(fromHeader ?? 0, fromBackoff);
+  if (at - opts.createdAtMs >= DELIVERY_WINDOW_MS) return null;
+  return new Date(at);
+}
+
+export function canonicalPayload(payment: PaymentPayload): string {
+  // Deterministic JSON: the bytes we sign are the bytes we send.
+  return JSON.stringify({
+    tx_hash: payment.tx_hash,
+    ledger: payment.ledger,
+    payer: payment.payer,
+    amount: payment.amount,
+    asset: payment.asset,
+    ts: payment.ts,
+    route: payment.route,
+    method: payment.method,
+  });
+}
+
+export function signBody(body: string, privateKeyHex: string): string {
+  const keyBuffer = Buffer.from(privateKeyHex, 'hex');
+  if (keyBuffer.length !== 32) {
+    throw new Error('WEBHOOK_SIGNING_KEY must be a 32-byte Ed25519 private key in hex');
+  }
+  const privateKey = createPrivateKey({
+    key: Buffer.concat([Buffer.from('302e020100300506032b657004220420', 'hex'), keyBuffer]),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  return edSign(null, Buffer.from(body, 'utf8'), privateKey).toString('hex');
+}
+
+export function payloadFromRow(row: Record<string, unknown>): PaymentPayload {
+  const ts = row.ts;
+  return {
+    tx_hash: String(row.tx_hash),
+    ledger: row.ledger === null || row.ledger === undefined ? null : Number(row.ledger),
+    payer: row.payer == null ? null : String(row.payer),
+    amount: row.amount == null ? null : String(row.amount),
+    asset: row.asset == null ? null : String(row.asset),
+    ts: ts instanceof Date ? ts.toISOString() : ts == null ? null : String(ts),
+    route: row.route == null ? null : String(row.route),
+    method: row.method == null ? null : String(row.method),
+  };
+}
+
+export async function enqueueWebhookDelivery(
+  client: Client,
+  payment: PaymentPayload,
+  url: string,
+): Promise<void> {
+  const body = canonicalPayload(payment);
+  await client.query(
+    `INSERT INTO webhook_deliveries (payment_tx_hash, url, payload, status, next_retry_at)
+     VALUES ($1, $2, $3::jsonb, 'pending', now())
+     ON CONFLICT (payment_tx_hash, url) DO NOTHING`,
+    [payment.tx_hash, url, body],
+  );
+}
+
+export interface AttemptResult {
+  id: number;
+  status: DeliveryStatus;
+  statusCode: number | null;
+  error: string | null;
+}
+
+export async function deliverDue(
+  client: Client,
+  opts: {
+    now?: Date;
+    fetchImpl?: typeof fetch;
+    signingKey?: string | null;
+    timeoutMs?: number;
+    budgetMs?: number;
+  } = {},
+): Promise<{ attempted: number; delivered: number; failed: number; retried: number }> {
+  const now = opts.now ?? new Date();
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const timeoutMs = opts.timeoutMs ?? ATTEMPT_TIMEOUT_MS;
+  const budgetMs = opts.budgetMs ?? 8_000;
+  const deadline = Date.now() + budgetMs;
+  const signingKey =
+    opts.signingKey === undefined ? process.env.WEBHOOK_SIGNING_KEY : opts.signingKey;
+
+  await client.query(
+    `UPDATE webhook_deliveries
+     SET status = 'pending', updated_at = now()
+     WHERE status = 'delivering' AND updated_at < now() - interval '1 minute'`,
+  );
+
+  const due = await client.query<{
+    id: string;
+    payment_tx_hash: string;
+    url: string;
+    payload: PaymentPayload;
+    attempts: number;
+    created_at: Date;
+  }>(
+    `SELECT id, payment_tx_hash, url, payload, attempts, created_at
+     FROM webhook_deliveries
+     WHERE status = 'pending'
+       AND (next_retry_at IS NULL OR next_retry_at <= $1)
+     ORDER BY next_retry_at NULLS FIRST, id ASC
+     LIMIT 50`,
+    [now],
+  );
+
+  const claimed: typeof due.rows = [];
+  for (const row of due.rows) {
+    const take = await client.query(
+      `UPDATE webhook_deliveries SET status = 'delivering', updated_at = now()
+       WHERE id = $1 AND status = 'pending'
+       RETURNING id`,
+      [row.id],
+    );
+    if ((take.rowCount ?? 0) > 0) claimed.push(row);
+  }
+
+  let delivered = 0;
+  let failed = 0;
+  let retried = 0;
+
+  for (const row of claimed) {
+    if (Date.now() >= deadline) {
+      await client.query(
+        `UPDATE webhook_deliveries SET status = 'pending', updated_at = now() WHERE id = $1 AND status = 'delivering'`,
+        [row.id],
+      );
+      continue;
+    }
+
+    const body = typeof row.payload === 'string' ? row.payload : canonicalPayload(row.payload);
+    const attemptNumber = row.attempts + 1;
+    const createdAtMs =
+      row.created_at instanceof Date
+        ? row.created_at.getTime()
+        : Date.parse(String(row.created_at));
+
+    if (!signingKey) {
+      await recordAttempt(client, {
+        id: Number(row.id),
+        attemptNumber,
+        statusCode: null,
+        error: 'WEBHOOK_SIGNING_KEY is not configured; refusing to send an unsigned payload',
+        createdAtMs,
+        nowMs: Date.now(),
+        retryAfter: null,
+        transportError: true,
+      });
+      failed++;
+      continue;
+    }
+
+    let statusCode: number | null = null;
+    let error: string | null = null;
+    let retryAfter: string | null = null;
+    let transportError = false;
+
+    try {
+      const signature = signBody(body, signingKey);
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const fetchPromise = fetchImpl(row.url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Signature': signature,
+            'X-Accensa-Timestamp': String(Math.floor(Date.now() / 1000)),
+            'X-Accensa-Delivery-Id': String(row.id),
+          },
+          body,
+          signal: controller.signal,
+        });
+        const res = await Promise.race([
+          fetchPromise,
+          new Promise<never>((_, reject) => {
+            const id = setTimeout(
+              () => reject(Object.assign(new Error('webhook timeout'), { name: 'TimeoutError' })),
+              timeoutMs,
+            );
+            controller.signal.addEventListener('abort', () => {
+              clearTimeout(id);
+              reject(Object.assign(new Error('webhook timeout'), { name: 'TimeoutError' }));
+            });
+          }),
+        ]);
+        statusCode = res.status;
+        retryAfter = res.headers.get('retry-after');
+        if (!res.ok) error = `HTTP ${res.status}`;
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (e) {
+      transportError = true;
+      error = e instanceof Error ? e.message : 'transport error';
+    }
+
+    const terminal = await recordAttempt(client, {
+      id: Number(row.id),
+      attemptNumber,
+      statusCode,
+      error,
+      createdAtMs,
+      nowMs: Date.now(),
+      retryAfter,
+      transportError,
+    });
+    if (terminal.status === 'delivered') delivered++;
+    else if (terminal.status === 'failed') failed++;
+    else retried++;
+  }
+
+  return { attempted: claimed.length, delivered, failed, retried };
+}
+
+async function recordAttempt(
+  client: Client,
+  input: {
+    id: number;
+    attemptNumber: number;
+    statusCode: number | null;
+    error: string | null;
+    createdAtMs: number;
+    nowMs: number;
+    retryAfter: string | null;
+    transportError: boolean;
+  },
+): Promise<AttemptResult> {
+  const ok = input.statusCode !== null && input.statusCode >= 200 && input.statusCode < 300;
+  const retry = !ok && shouldRetry(input.statusCode, input.transportError);
+  const next = retry
+    ? nextRetryAt({
+        attempt: input.attemptNumber,
+        createdAtMs: input.createdAtMs,
+        now: input.nowMs,
+        retryAfterHeader: input.retryAfter,
+      })
+    : null;
+
+  let status: DeliveryStatus;
+  if (ok) status = 'delivered';
+  else if (next) status = 'pending';
+  else status = 'failed';
+
+  await client.query(
+    `INSERT INTO webhook_attempts (delivery_id, attempt_number, status_code, error)
+     VALUES ($1, $2, $3, $4)`,
+    [input.id, input.attemptNumber, input.statusCode, input.error],
+  );
+
+  await client.query(
+    `UPDATE webhook_deliveries
+     SET status = $2,
+         attempts = $3,
+         last_status_code = $4,
+         last_error = $5,
+         next_retry_at = $6,
+         delivered_at = CASE WHEN $2 = 'delivered' THEN now() ELSE delivered_at END,
+         updated_at = now()
+     WHERE id = $1`,
+    [input.id, status, input.attemptNumber, input.statusCode, input.error, next],
+  );
+
+  return { id: input.id, status, statusCode: input.statusCode, error: input.error };
+}
+
+export async function webhookSummary(client: Client): Promise<{
+  pending: number;
+  failed: number;
+  delivered: number;
+  recentFailed: Array<{
+    id: number;
+    paymentTxHash: string;
+    status: string;
+    attempts: number;
+    lastStatusCode: number | null;
+    lastError: string | null;
+    updatedAt: string;
+  }>;
+}> {
+  const counts = await client.query<{ status: string; n: string }>(
+    `SELECT status, count(*)::text AS n FROM webhook_deliveries GROUP BY status`,
+  );
+  const byStatus: Record<string, number> = { pending: 0, failed: 0, delivered: 0 };
+  for (const row of counts.rows) byStatus[row.status] = Number(row.n);
+
+  const recent = await client.query<{
+    id: string;
+    payment_tx_hash: string;
+    status: string;
+    attempts: number;
+    last_status_code: number | null;
+    last_error: string | null;
+    updated_at: Date;
+  }>(
+    `SELECT id, payment_tx_hash, status, attempts, last_status_code, last_error, updated_at
+     FROM webhook_deliveries
+     WHERE status = 'failed'
+     ORDER BY updated_at DESC
+     LIMIT 20`,
+  );
+
+  return {
+    pending: (byStatus.pending ?? 0) + (byStatus.delivering ?? 0),
+    failed: byStatus.failed ?? 0,
+    delivered: byStatus.delivered ?? 0,
+    recentFailed: recent.rows.map((row) => ({
+      id: Number(row.id),
+      paymentTxHash: row.payment_tx_hash,
+      status: row.status,
+      attempts: row.attempts,
+      lastStatusCode: row.last_status_code,
+      lastError: row.last_error,
+      updatedAt:
+        row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at),
+    })),
+  };
+}
+
+/** Hash of the body, useful in tests to assert we signed the bytes we sent. */
+export function bodyDigest(body: string): string {
+  return createHash('sha256').update(body).digest('hex');
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -26,7 +26,8 @@ export async function middleware(request: NextRequest) {
   // settlement report before its own verification ever ran.
   const isPublicApi =
     path.startsWith('/api/verify') || path.startsWith('/api/auth') || path.startsWith('/api/hook/');
-  const isCronSync = path === '/api/sync' && request.method === 'GET';
+  const isCronSync =
+    (path === '/api/sync' || path === '/api/webhooks/deliver') && request.method === 'GET';
   const isPrivateApi = path.startsWith('/api/') && !isPublicApi && !isCronSync;
   const isDashboard = path.startsWith('/dashboard');
 
@@ -54,7 +55,7 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // Enforce CRON_SECRET for GET /api/sync
+  // Enforce CRON_SECRET for GET /api/sync and GET /api/webhooks/deliver
   if (isCronSync) {
     const authHeader = request.headers.get('authorization');
     if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {

--- a/migrations/003_webhook_deliveries.sql
+++ b/migrations/003_webhook_deliveries.sql
@@ -1,0 +1,32 @@
+-- Outbound payment webhooks, queued in the same transaction as the payment
+-- insert and delivered by GET /api/webhooks/deliver. Applied automatically
+-- by ensureSchema(); this file is the readable form.
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id BIGSERIAL PRIMARY KEY,
+  payment_tx_hash VARCHAR(64) NOT NULL,
+  url TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempts INT NOT NULL DEFAULT 0,
+  last_status_code INT,
+  last_error TEXT,
+  next_retry_at TIMESTAMPTZ,
+  delivered_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (payment_tx_hash, url)
+);
+
+CREATE TABLE IF NOT EXISTS webhook_attempts (
+  id BIGSERIAL PRIMARY KEY,
+  delivery_id BIGINT NOT NULL REFERENCES webhook_deliveries(id) ON DELETE CASCADE,
+  attempt_number INT NOT NULL,
+  status_code INT,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_due
+  ON webhook_deliveries (next_retry_at) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status ON webhook_deliveries (status);


### PR DESCRIPTION
## Summary

Webhook delivery no longer runs inside the indexing loop. A payment insert and a `webhook_deliveries` row commit together; a separate `GET /api/webhooks/deliver` job (same `CRON_SECRET` as `/api/sync`) ships the payload. A merchant endpoint that sleeps, 500s, or rate-limits cannot stall the ledger cursor.

Closes #88.

## What landed

- **Decoupled.** `apps/web/src/app/api/sync/route.ts` only enqueues. The 3×2s inline `fetch` is gone.
- **Persisted attempts.** `webhook_deliveries` + `webhook_attempts`. Crash mid-attempt is reclaimed after a minute.
- **Backoff.** Exponential with 25% jitter, capped at 1 hour, 8 attempts over 24 hours. 5xx, 429, and transport errors retry; other 4xx do not. `Retry-After` is honoured.
- **Signed.** Ed25519 over the exact UTF-8 body (`WEBHOOK_SIGNING_KEY`). Scheme documented in the root README. Unsigned payloads are not sent.
- **Visible.** Terminal failures render on the dashboard via `WebhookStatus`. Countable through `GET /api/webhooks`.
- **Proven.** A test with a fetch that never resolves returns in well under the 40s paging budget.

## Acceptance

- [x] Delivery is not inside the indexing loop; a sleeping host cannot stall indexing.
- [x] Deliveries persisted with per-attempt status; recoverable after a crash.
- [x] Exponential backoff with jitter; 429 and 5xx retried, other 4xx not; `Retry-After` honoured.
- [x] Payloads signed; scheme documented for receivers.
- [x] Terminal failures visible on the dashboard.
- [x] `WEBHOOK_URL` behaviour, guarantees, and signature documented in the README.

## Test plan

- `pnpm --filter web test`
- Confirm `/api/sync` no longer calls `WEBHOOK_URL`.
- Confirm `/api/webhooks/deliver` is 401 without `CRON_SECRET` and ships queued rows with it.
