### PR TITLE
test(web): add Playwright visual regression for the dashboard

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,0 +1,50 @@
+name: Visual regression
+
+on:
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/visual.yml'
+  push:
+    branches: ['main']
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/visual.yml'
+
+jobs:
+  visual:
+    name: playwright (web)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: ./apps/web
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install pnpm
+        run: npm install -g pnpm@9
+        working-directory: .
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run visual tests
+        env:
+          JWT_SECRET_KEY: visual-regression-test-secret
+          CI: true
+        run: pnpm test:visual
+      - name: Upload failure snapshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-visual-diff
+          path: |
+            apps/web/e2e/__screenshots__
+            apps/web/test-results
+          if-no-files-found: ignore

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -1,0 +1,16 @@
+# Visual regression
+
+Playwright screenshots of the merchant dashboard:
+
+- landing-page navbar
+- dashboard empty state
+- payments table (populated)
+
+```bash
+pnpm --filter web test:visual          # compare against committed snapshots
+pnpm --filter web test:visual:update   # rewrite snapshots after an intentional UI change
+```
+
+The suite mints a session JWT (`JWT_SECRET_KEY`, defaulting to the same value
+CI uses) and intercepts `/api/payments`. It does not talk to PostgreSQL or
+Stellar. Snapshots live in `e2e/__screenshots__/`.

--- a/apps/web/e2e/visual.spec.ts
+++ b/apps/web/e2e/visual.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { SignJWT } from 'jose';
+
+const SECRET = process.env.JWT_SECRET_KEY ?? 'visual-regression-test-secret';
+const MERCHANT =
+  process.env.MERCHANT_ADDRESS ?? 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6';
+
+async function sessionCookie() {
+  const token = await new SignJWT({ publicKey: MERCHANT })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('2h')
+    .sign(new TextEncoder().encode(SECRET));
+  return {
+    name: 'accensa_session',
+    value: token,
+    domain: '127.0.0.1',
+    path: '/',
+    httpOnly: true,
+    sameSite: 'Lax' as const,
+  };
+}
+
+const SAMPLE_PAYMENTS = {
+  payments: [
+    {
+      tx_hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      ledger: 1001,
+      payer: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567AAAAAAAAAA',
+      amount: '15000000',
+      asset: 'native',
+      ts: '2026-08-01T12:00:00.000Z',
+      route: '/api/resource',
+      method: 'GET',
+    },
+    {
+      tx_hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      ledger: 1002,
+      payer: 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      amount: '2500000',
+      asset: 'native',
+      ts: '2026-08-01T12:05:00.000Z',
+      route: null,
+      method: null,
+    },
+  ],
+  sync: { lastLedger: 1002, updatedAt: '2026-08-01T12:05:00.000Z' },
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+});
+
+test('navbar on the landing page', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByTestId('site-nav')).toBeVisible();
+  await expect(page.getByTestId('site-nav')).toHaveScreenshot('navbar.png');
+});
+
+test('dashboard empty state', async ({ page, context }) => {
+  await context.addCookies([await sessionCookie()]);
+  await page.route('**/api/payments**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ payments: [], sync: null }),
+    });
+  });
+  await page.goto('/dashboard');
+  await expect(page.getByTestId('dashboard-empty')).toBeVisible();
+  await expect(page.getByTestId('dashboard-empty')).toHaveScreenshot('dashboard-empty.png');
+});
+
+test('dashboard payments table', async ({ page, context }) => {
+  await context.addCookies([await sessionCookie()]);
+  await page.route('**/api/payments**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(SAMPLE_PAYMENTS),
+    });
+  });
+  await page.goto('/dashboard');
+  await expect(page.getByTestId('payments-table')).toBeVisible();
+  await expect(page.getByTestId('payments-table')).toHaveScreenshot('payments-table.png');
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:visual": "playwright test",
+    "test:visual:update": "playwright test --update-snapshots"
   },
   "dependencies": {
     "@accensa/sdk": "workspace:^",
@@ -32,6 +34,7 @@
     "eslint-config-next": "16.2.10",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.9.3",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "@playwright/test": "^1.55.0"
   }
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 3100);
+const baseURL = `http://127.0.0.1:${PORT}`;
+
+/**
+ * Visual regression for the merchant dashboard: navbar, empty state, and
+ * the payments table. Screenshots are committed under e2e/__screenshots__.
+ *
+ * A session JWT is minted in the spec so /dashboard is reachable without
+ * driving Freighter. /api/payments is intercepted — these tests assert
+ * presentation, not the indexer.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    colorScheme: 'light',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 800 } },
+    },
+  ],
+  webServer: {
+    command: `pnpm exec next dev --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      JWT_SECRET_KEY: process.env.JWT_SECRET_KEY ?? 'visual-regression-test-secret',
+      MERCHANT_ADDRESS:
+        process.env.MERCHANT_ADDRESS ?? 'GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6',
+      PORT: String(PORT),
+    },
+  },
+});

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -205,7 +205,10 @@ export default function Dashboard() {
             )}
 
             {state.status === 'ready' && payments.length === 0 && (
-              <div className="flex flex-col items-center justify-center h-[400px] text-center space-y-4 px-6">
+              <div
+                data-testid="dashboard-empty"
+                className="flex flex-col items-center justify-center h-[400px] text-center space-y-4 px-6"
+              >
                 <div className="w-12 h-12 bg-emerald-400 dark:bg-emerald-500/10 flex items-center justify-center text-emerald-600 dark:text-emerald-400 mb-2 animate-pulse">
                   ●
                 </div>
@@ -284,7 +287,7 @@ export default function Dashboard() {
                 </div>
 
                 {/* Desktop View */}
-                <div className="hidden md:block overflow-x-auto">
+                <div className="hidden md:block overflow-x-auto" data-testid="payments-table">
                   <table className="w-full text-left border-collapse whitespace-nowrap">
                     <thead>
                       <tr className="text-slate-400 dark:text-slate-500 text-xs font-bold uppercase tracking-widest border-b border-slate-100 dark:border-white/5 bg-white dark:bg-[#04090f]/50 transition-colors duration-300">

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -34,7 +34,10 @@ export function Nav() {
 
   return (
     <>
-      <nav className="px-6 py-4 md:py-6 fixed w-full top-0 z-50 bg-white/50 dark:bg-white/5 backdrop-blur-3xl border-b border-slate-200/50 dark:border-white/10 dark:shadow-[0_4px_30px_rgba(0,0,0,0.2),inset_0_1px_1px_rgba(255,255,255,0.1)] transition-colors duration-300">
+      <nav
+        data-testid="site-nav"
+        className="px-6 py-4 md:py-6 fixed w-full top-0 z-50 bg-white/50 dark:bg-white/5 backdrop-blur-3xl border-b border-slate-200/50 dark:border-white/10 dark:shadow-[0_4px_30px_rgba(0,0,0,0.2),inset_0_1px_1px_rgba(255,255,255,0.1)] transition-colors duration-300"
+      >
         <div className="w-full mx-auto flex items-center justify-between relative z-50">
           <Link
             href="/"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.21.0
       '@x402/express':
         specifier: ^2.21.0
-        version: 2.21.0(express@5.2.1)(typescript@5.9.3)
+        version: 2.21.0(express@5.2.1)(typescript@6.0.3)
       '@x402/stellar':
         specifier: ^2.21.0
         version: 2.21.0
@@ -92,7 +92,7 @@ importers:
         version: 1.28.0(react@19.2.4)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@types/node@20.19.43)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@20.19.43)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -106,6 +106,9 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.2
@@ -2035,6 +2038,11 @@ packages:
   '@peculiar/x509@1.14.3':
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
     engines: {node: '>=20.0.0'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -4476,6 +4484,11 @@ packages:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5994,6 +6007,16 @@ packages:
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -9000,24 +9023,24 @@ snapshots:
       '@docusaurus/logger': 3.10.2
       '@docusaurus/types': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-      css-loader: 6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      copy-webpack-plugin: 11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      css-loader: 6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       cssnano: 6.1.2(postcss@8.5.25)
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-      null-loader: 4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      null-loader: 4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       postcss: 8.5.25
-      postcss-loader: 7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      postcss-loader: 7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       postcss-preset-env: 10.6.1(postcss@8.5.25)
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
-      webpackbar: 7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      webpackbar: 7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
     optionalDependencies:
       '@docusaurus/faster': 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(postcss@8.5.25)
     transitivePeerDependencies:
@@ -9061,7 +9084,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.6
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      html-webpack-plugin: 5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -9071,7 +9094,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.4)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       react-router: 5.3.4(react@19.2.4)
       react-router-config: 5.1.1(react-router@5.3.4(react@19.2.4))(react@19.2.4)
       react-router-dom: 5.3.4(react@19.2.4)
@@ -9082,7 +9105,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(postcss@8.5.25)
@@ -9170,7 +9193,7 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       vfile: 6.0.3
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     transitivePeerDependencies:
@@ -9914,7 +9937,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       fs-extra: 11.3.6
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -9926,7 +9949,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       utility-types: 3.11.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
     transitivePeerDependencies:
@@ -9967,7 +9990,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       utility-types: 3.11.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     transitivePeerDependencies:
@@ -10655,6 +10678,10 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -10827,11 +10854,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       apg-js: 4.4.0
 
-  '@signinwithethereum/siwe@4.2.0(viem@2.55.1(typescript@5.9.3)(zod@3.25.76))':
+  '@signinwithethereum/siwe@4.2.0(viem@2.55.1(typescript@6.0.3)(zod@3.25.76))':
     dependencies:
       '@signinwithethereum/siwe-parser': 4.2.0
     optionalDependencies:
-      viem: 2.55.1(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.55.1(typescript@6.0.3)(zod@3.25.76)
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -11654,10 +11681,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@x402/express@2.21.0(express@5.2.1)(typescript@5.9.3)':
+  '@x402/express@2.21.0(express@5.2.1)(typescript@6.0.3)':
     dependencies:
       '@x402/core': 2.21.0
-      '@x402/extensions': 2.21.0(typescript@5.9.3)
+      '@x402/extensions': 2.21.0(typescript@6.0.3)
       express: 5.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -11665,16 +11692,16 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/extensions@2.21.0(typescript@5.9.3)':
+  '@x402/extensions@2.21.0(typescript@6.0.3)':
     dependencies:
       '@noble/curves': 1.9.7
       '@scure/base': 1.2.6
-      '@signinwithethereum/siwe': 4.2.0(viem@2.55.1(typescript@5.9.3)(zod@3.25.76))
+      '@signinwithethereum/siwe': 4.2.0(viem@2.55.1(typescript@6.0.3)(zod@3.25.76))
       '@x402/core': 2.21.0
       ajv: 8.20.0
       jose: 5.10.0
       tweetnacl: 1.0.3
-      viem: 2.55.1(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.55.1(typescript@6.0.3)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -11694,9 +11721,9 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
+  abitype@1.2.3(typescript@6.0.3)(zod@3.25.76):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       zod: 3.25.76
 
   accepts@1.3.8:
@@ -11932,12 +11959,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -12332,7 +12359,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  copy-webpack-plugin@11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       fast-glob: 3.3.1
       glob-parent: 6.0.2
@@ -12340,7 +12367,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -12385,7 +12412,7 @@ snapshots:
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  css-loader@6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.25)
       postcss: 8.5.25
@@ -12397,9 +12424,9 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.15)
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.25)
@@ -12407,7 +12434,7 @@ snapshots:
       postcss: 8.5.25
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     optionalDependencies:
       clean-css: 5.3.3
 
@@ -12925,7 +12952,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12947,7 +12974,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -13293,12 +13320,6 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
-  file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -13387,6 +13408,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -13685,7 +13709,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
+  html-webpack-plugin@5.6.7(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14805,11 +14829,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  mini-css-extract-plugin@2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   minimalistic-assert@1.0.1: {}
 
@@ -14823,26 +14847,13 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
-    optionalDependencies:
-      '@swc/core': 1.15.43(@swc/helpers@0.5.15)
-      '@swc/html': 1.15.43
-      lightningcss: 1.32.0
-      postcss: 8.5.25
-
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.15)
       clean-css: 5.3.3
@@ -14880,7 +14891,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.3.0(@babel/core@7.29.7)(@types/node@20.19.43)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@20.19.43)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -14899,6 +14910,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.3.0
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
+      '@playwright/test': 1.62.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.35.3(@types/node@20.19.43)
     transitivePeerDependencies:
@@ -14941,11 +14953,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  null-loader@4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   object-assign@4.1.1: {}
 
@@ -15035,7 +15047,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.14.30(typescript@5.9.3)(zod@3.25.76):
+  ox@0.14.30(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -15043,10 +15055,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - zod
 
@@ -15220,6 +15232,14 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-attribute-case-insensitive@7.0.1(postcss@8.5.25):
@@ -15364,13 +15384,13 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.25)
       postcss: 8.5.25
 
-  postcss-loader@7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  postcss-loader@7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
       postcss: 8.5.25
       semver: 7.8.5
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     transitivePeerDependencies:
       - typescript
 
@@ -15787,7 +15807,7 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.4)'
@@ -16624,13 +16644,13 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.15)
       clean-css: 5.3.3
@@ -16901,16 +16921,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
-    dependencies:
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
-    optionalDependencies:
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
@@ -16948,18 +16959,18 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.55.1(typescript@5.9.3)(zod@3.25.76):
+  viem@2.55.1(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.21.0)
-      ox: 0.14.30(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.14.30(typescript@6.0.3)(zod@3.25.76)
       ws: 8.21.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17057,7 +17068,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.64.0(tslib@2.8.1)
@@ -17070,7 +17081,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
+  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -17098,7 +17109,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       ws: 8.21.0
     optionalDependencies:
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
@@ -17141,7 +17152,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -17179,7 +17190,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -17199,7 +17210,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpackbar@7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  webpackbar@7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2
@@ -17207,7 +17218,7 @@ snapshots:
       std-env: 3.10.0
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.15)
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   websocket-driver@0.7.5:
     dependencies:


### PR DESCRIPTION
## Summary

Playwright visual regression for the merchant dashboard: navbar, empty state, and the payments table. A GitHub Actions workflow runs the suite on PRs that touch `apps/web`.

Closes #35.

## What landed

- `@playwright/test` in `apps/web`, with `pnpm test:visual` / `pnpm test:visual:update`.
- Specs mint a session JWT and intercept `/api/payments`, so they do not need PostgreSQL, Freighter, or Stellar.
- `.github/workflows/visual.yml` installs Chromium and compares against committed snapshots under `apps/web/e2e/__screenshots__/`.

## Test plan

- `pnpm --filter web test:visual`
- After an intentional UI change: `pnpm --filter web test:visual:update` and commit the new snapshots.
