### PR TITLE
fix(web): announce verify result and in-progress state to screen readers

### DIFF
--- a/apps/web/src/app/verify/page.tsx
+++ b/apps/web/src/app/verify/page.tsx
@@ -75,6 +75,17 @@ export default function VerifyPage() {
   const [proof, setProof] = useState('');
   const [state, setState] = useState<State>({ status: 'idle' });
 
+  const resultRef = React.useRef<HTMLDivElement>(null);
+  const errorRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (state.status === 'done') {
+      resultRef.current?.focus();
+    } else if (state.status === 'error') {
+      errorRef.current?.focus();
+    }
+  }, [state.status]);
+
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     setState({ status: 'checking' });
@@ -124,6 +135,11 @@ export default function VerifyPage() {
             locally from the proof, and independently by the contract.
           </p>
         </header>
+
+        {/* In-progress status live region for screen readers */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {state.status === 'checking' && 'Verification in progress. Please wait...'}
+        </div>
 
         <div className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl p-6 md:p-12 shadow-[0_8px_30px_rgba(0,0,0,0.12),inset_0_1px_1px_rgba(255,255,255,0.8)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.15)] transition-colors duration-300">
           <div className="flex flex-wrap gap-4 mb-8">
@@ -187,6 +203,7 @@ export default function VerifyPage() {
             <button
               type="submit"
               disabled={state.status === 'checking'}
+              aria-busy={state.status === 'checking'}
               className="w-full px-8 py-5 bg-emerald-600 dark:bg-emerald-500 text-white dark:text-black font-black text-lg uppercase tracking-wider hover:bg-emerald-600 dark:hover:bg-emerald-400 disabled:opacity-50 transition-all shadow-md shadow-emerald-600/20 dark:shadow-[0_0_20px_rgba(16,185,129,0.2)]"
             >
               {state.status === 'checking' ? 'Processing...' : 'Verify Cryptographic Proof'}
@@ -195,14 +212,23 @@ export default function VerifyPage() {
         </div>
 
         {state.status === 'error' && (
-          <div className="border border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-[#0a111a] p-6 flex gap-4 items-start shadow-sm dark:shadow-none transition-colors duration-300">
-            <div className="w-8 h-8 bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400 flex items-center justify-center shrink-0">
+          <div
+            ref={errorRef}
+            tabIndex={-1}
+            role="alert"
+            aria-live="assertive"
+            className="outline-none focus:ring-2 focus:ring-red-500 border border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-[#0a111a] p-6 flex gap-4 items-start shadow-sm dark:shadow-none transition-colors duration-300"
+          >
+            <div
+              aria-hidden="true"
+              className="w-8 h-8 bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400 flex items-center justify-center shrink-0"
+            >
               ✕
             </div>
             <div>
-              <p className="text-red-700 dark:text-red-400 font-bold transition-colors duration-300">
+              <h2 className="text-red-700 dark:text-red-400 font-bold transition-colors duration-300">
                 Verification Error
-              </p>
+              </h2>
               <p className="text-red-600 dark:text-red-400/80 text-sm mt-1 transition-colors duration-300">
                 {state.message}
               </p>
@@ -210,31 +236,46 @@ export default function VerifyPage() {
           </div>
         )}
 
-        {state.status === 'done' && <Result result={state.result} />}
+        {state.status === 'done' && <Result result={state.result} resultRef={resultRef} />}
       </PageContainer>
     </main>
   );
 }
 
-function Result({ result }: { result: VerifyResponse }) {
+export function Result({
+  result,
+  resultRef,
+}: {
+  result: VerifyResponse;
+  resultRef?: React.RefObject<HTMLDivElement | null>;
+}) {
   const { local, onchain, verified, batch } = result;
 
   return (
     <div className="space-y-6 mt-12 animate-in fade-in slide-in-from-bottom-4 duration-300">
       <div
-        className={` border p-6 md:p-12 transition-colors duration-300 ${verified ? 'border-emerald-200 dark:border-emerald-500/30 bg-emerald-50 dark:bg-[#0a111a] shadow-lg shadow-emerald-600/10 dark:shadow-[0_0_50px_rgba(16,185,129,0.1)]' : 'border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-[#0a111a] shadow-lg shadow-red-600/10 dark:shadow-[0_0_50px_rgba(239,68,68,0.1)]'}`}
+        ref={resultRef}
+        tabIndex={-1}
+        role="region"
+        aria-label="Verification verdict"
+        aria-live="polite"
+        className={`outline-none focus:ring-2 focus:ring-emerald-500 border p-6 md:p-12 transition-colors duration-300 ${verified ? 'border-emerald-200 dark:border-emerald-500/30 bg-emerald-50 dark:bg-[#0a111a] shadow-lg shadow-emerald-600/10 dark:shadow-[0_0_50px_rgba(16,185,129,0.1)]' : 'border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-[#0a111a] shadow-lg shadow-red-600/10 dark:shadow-[0_0_50px_rgba(239,68,68,0.1)]'}`}
       >
         <div className="flex items-center gap-4 mb-4">
           <div
+            aria-hidden="true"
             className={`w-12 h-12 flex items-center justify-center text-xl font-bold transition-colors duration-300 ${verified ? 'bg-emerald-600 dark:bg-emerald-500 text-white dark:text-black' : 'bg-red-600 dark:bg-red-500 text-white dark:text-black'}`}
           >
             {verified ? '✓' : '✕'}
           </div>
-          <p
-            className={`text-3xl font-black tracking-tight transition-colors duration-300 ${verified ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}
-          >
-            {verified ? 'Proof Verified' : 'Proof Rejected'}
-          </p>
+          <div>
+            <h2
+              className={`text-3xl font-black tracking-tight transition-colors duration-300 ${verified ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}
+            >
+              <span className="sr-only">Verdict: </span>
+              {verified ? 'Proof Verified' : 'Proof Rejected'}
+            </h2>
+          </div>
         </div>
         <p className="text-slate-600 dark:text-slate-400 text-lg transition-colors duration-300">
           {verified
@@ -293,9 +334,12 @@ function CheckCard({
           className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest border transition-colors duration-300 ${result.ok ? 'bg-emerald-50 dark:bg-emerald-500/5 text-emerald-600 dark:text-emerald-400 border-emerald-200 dark:border-emerald-500/20' : 'bg-red-50 dark:bg-red-500/5 text-red-600 dark:text-red-400 border-red-200 dark:border-red-500/20'}`}
         >
           {result.ok ? (
-            <span className="w-1.5 h-1.5 bg-emerald-500 dark:bg-emerald-400 animate-pulse" />
+            <span
+              aria-hidden="true"
+              className="w-1.5 h-1.5 bg-emerald-500 dark:bg-emerald-400 animate-pulse"
+            />
           ) : (
-            <span className="w-1.5 h-1.5 bg-red-500 dark:bg-red-400" />
+            <span aria-hidden="true" className="w-1.5 h-1.5 bg-red-500 dark:bg-red-400" />
           )}
           <span>{result.ok ? 'Valid' : 'Failed'}</span>
         </div>

--- a/apps/web/src/app/verify/verify-accessibility.test.tsx
+++ b/apps/web/src/app/verify/verify-accessibility.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import VerifyPage, { Result } from './page';
+
+describe('Verify page accessibility', () => {
+  it('renders an in-progress status live region for screen readers', () => {
+    const html = renderToString(<VerifyPage />);
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('aria-atomic="true"');
+    expect(html).toContain('sr-only');
+  });
+
+  it('renders the form submit button with aria-busy="false"', () => {
+    const html = renderToString(<VerifyPage />);
+
+    expect(html).toContain('aria-busy="false"');
+    expect(html).toContain('Verify Cryptographic Proof');
+  });
+
+  it('renders the verified Result block with live region, focusable tabIndex, and sr-only verdict label', () => {
+    const resultRef = { current: null };
+    const html = renderToString(
+      <Result
+        result={{
+          verified: true,
+          disagreement: false,
+          contract: 'CC...',
+          local: { ok: true },
+          onchain: { ok: true },
+          batch: {
+            id: 1,
+            count: 42,
+            periodStart: 1700000000,
+            periodEnd: 1700003600,
+            root: 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+          },
+        }}
+        resultRef={resultRef}
+      />,
+    );
+
+    // Live region and focus attributes
+    expect(html).toContain('tabindex="-1"');
+    expect(html).toContain('role="region"');
+    expect(html).toContain('aria-label="Verification verdict"');
+    expect(html).toContain('aria-live="polite"');
+
+    // Standalone verdict heading with screen-reader context
+    expect(html).toContain('sr-only">Verdict: </span>');
+    expect(html).toContain('Proof Verified');
+
+    // Decorative checkmark icon has aria-hidden
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it('renders the rejected Result block with live region, focusable tabIndex, and sr-only verdict label', () => {
+    const resultRef = { current: null };
+    const html = renderToString(
+      <Result
+        result={{
+          verified: false,
+          disagreement: false,
+          contract: 'CC...',
+          local: { ok: false, error: 'Hash mismatch' },
+          onchain: { ok: null },
+        }}
+        resultRef={resultRef}
+      />,
+    );
+
+    expect(html).toContain('tabindex="-1"');
+    expect(html).toContain('role="region"');
+    expect(html).toContain('aria-label="Verification verdict"');
+    expect(html).toContain('aria-live="polite"');
+
+    expect(html).toContain('sr-only">Verdict: </span>');
+    expect(html).toContain('Proof Rejected');
+  });
+});


### PR DESCRIPTION
## Summary

- Added an `aria-live="polite"` live region to announce in-progress verification status on [apps/web/src/app/verify/page.tsx](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/accensa-app/apps/web/src/app/verify/page.tsx).
- Implemented focus management and live region semantics on the verdict result container (`tabIndex={-1}`, `role="region"`, `aria-label="Verification verdict"`).
- Implemented focus management and alert semantics on the error panel (`tabIndex={-1}`, `role="alert"`, `aria-live="assertive"`).
- Structured the verdict heading into an `<h2>` containing an explicit `<span className="sr-only">Verdict: </span>` context label so the outcome is unambiguous when read by assistive technologies.
- Marked decorative icons (`✓`, `✕`, indicator dots) with `aria-hidden="true"`.
- Added unit tests in [apps/web/src/app/verify/verify-accessibility.test.tsx](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/accensa-app/apps/web/src/app/verify/verify-accessibility.test.tsx).

## Why

- On `/verify`, submitting the form renders the verdict block or error panel below the fold while focus remained stuck on the submit button.
- For screen-reader users, the outcome was silent, leaving no feedback on whether the cryptographic receipt proof was verified or rejected.

## Implementation

- **`apps/web/src/app/verify/page.tsx`**:
  - Added `resultRef` and `errorRef` via `useRef<HTMLDivElement>` with a `useEffect` hook that moves keyboard and screen-reader focus directly to the verdict block (on `'done'`) or error panel (on `'error'`).
  - Added a visually hidden live status element (`role="status"`, `aria-live="polite"`, `aria-atomic="true"`) announcing `"Verification in progress. Please wait..."` when `state.status === 'checking'`.
  - Added `aria-busy={state.status === 'checking'}` to the submit button.
  - Added `aria-hidden="true"` to visual icons in the verdict card, error alert, and `CheckCard` status pills.
- **`apps/web/src/app/verify/verify-accessibility.test.tsx`**:
  - Added tests verifying presence and behavior of `role="status"`, `aria-live`, `aria-busy`, `tabIndex="-1"`, and standalone verdict labels.

## Testing

- `pnpm --filter web lint` (0 errors)
- `pnpm --filter web typecheck` (0 errors)
- `pnpm --filter web test` (18 test files, 246 passed)
- `pnpm --filter web build` (Next.js production build succeeded)
- Verified with **Orca Screen Reader** (Linux). Confirmed that submitting the form announces `"Verification in progress..."`, shifts focus directly to the verdict region, and reads `"Verdict: Proof Verified"` / `"Verdict: Proof Rejected"`.

## Scope / Risk

- **Scope**: Limited to `apps/web/src/app/verify/page.tsx` and its accessibility unit tests.
- **Risk**: None; standard non-breaking React accessibility attributes and focus management.

## Issue

Closes #192
