### PR TITLE
fix(web): align login page with dashboard design system

### DIFF
--- a/apps/web/src/app/login/login-page.test.tsx
+++ b/apps/web/src/app/login/login-page.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+import LoginPage from './page';
+
+describe('LoginPage design system consistency', () => {
+  it('renders with consistent design system classes (PageContainer, bg-grid, backdrop blur, emerald palette)', () => {
+    const html = renderToString(<LoginPage />);
+
+    // Page container and background treatment
+    expect(html).toContain('bg-grid');
+    expect(html).toContain('max-w-3xl'); // PageContainer width="narrow"
+    expect(html).toContain('max-w-md'); // w-full max-w-md
+
+    // Blurred translucent panel with emerald glow
+    expect(html).toContain('backdrop-blur-2xl');
+    expect(html).toContain('bg-white/50');
+    expect(html).toContain('dark:bg-white/5');
+    expect(html).toContain('bg-emerald-500/10');
+
+    // Typography hierarchy & tracking
+    expect(html).toContain('tracking-[0.25em]');
+    expect(html).toContain('Merchant Access');
+    expect(html).toContain('Merchant Login');
+
+    // Connect wallet button
+    expect(html).toContain('bg-emerald-600');
+    expect(html).toContain('dark:bg-emerald-500');
+    expect(html).toContain('Connect Wallet');
+    expect(html).toContain('aria-busy="false"');
+  });
+
+  it('does not contain undeclared semantic tokens or non-standard rounded classes', () => {
+    const html = renderToString(<LoginPage />);
+
+    // Undeclared semantic tokens that previously caused rendering bugs
+    expect(html).not.toContain('bg-card');
+    expect(html).not.toContain('text-muted-foreground');
+    expect(html).not.toContain('bg-primary');
+    expect(html).not.toContain('text-destructive');
+    expect(html).not.toContain('bg-secondary');
+    expect(html).not.toContain('text-primary-foreground');
+
+    // Sharp corners (no rounded-* classes)
+    expect(html).not.toContain('rounded-lg');
+    expect(html).not.toContain('rounded-full');
+    expect(html).not.toContain('rounded-md');
+  });
+});

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ShieldAlert, Loader2 } from 'lucide-react';
 import { signTransaction, readStatus, connect } from '@/lib/freighter';
+import { PageContainer } from '@/components/page-container';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -59,35 +60,58 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
-      <div className="w-full max-w-md p-8 space-y-6 bg-card border rounded-lg shadow-sm">
-        <div className="flex justify-center">
-          <div className="p-3 bg-secondary rounded-full">
-            <ShieldAlert className="w-8 h-8 text-primary" />
-          </div>
-        </div>
-
-        <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight">Merchant Login</h1>
-          <p className="text-sm text-muted-foreground">
+    <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32 flex items-center justify-center">
+      <PageContainer width="narrow" className="w-full max-w-md space-y-8">
+        <header className="space-y-4 text-center">
+          <p className="uppercase tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs">
+            Merchant Access
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tighter text-slate-900 dark:text-white transition-colors duration-300">
+            Merchant Login
+          </h1>
+          <p className="text-slate-600 dark:text-slate-400 leading-relaxed text-sm transition-colors duration-300">
             Authenticate with your Stellar wallet to access the Accensa dashboard.
           </p>
-        </div>
+        </header>
 
-        {error && (
-          <div className="p-3 text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-md">
-            {error}
+        <div className="bg-white/50 dark:bg-white/5 backdrop-blur-2xl p-8 space-y-6 shadow-[0_8px_30px_rgba(0,0,0,0.12),inset_0_1px_1px_rgba(255,255,255,0.8)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_1px_rgba(255,255,255,0.15)] relative overflow-hidden transition-colors duration-300">
+          <div className="absolute top-0 right-0 w-32 h-32 bg-emerald-500/10 blur-[40px] dark:blur-[50px] pointer-events-none" />
+
+          <div className="flex justify-center">
+            <div className="p-3 bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-200 dark:border-emerald-500/20 text-emerald-600 dark:text-emerald-400">
+              <ShieldAlert className="w-8 h-8" />
+            </div>
           </div>
-        )}
 
-        <button
-          onClick={handleLogin}
-          disabled={loading}
-          className="w-full flex items-center justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50"
-        >
-          {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Connect Wallet'}
-        </button>
-      </div>
-    </div>
+          {error && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="border border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-[#0a111a] p-4 flex gap-3 items-start text-sm text-red-600 dark:text-red-400 transition-colors duration-300"
+            >
+              <ShieldAlert className="w-5 h-5 flex-shrink-0 mt-0.5 text-red-500" />
+              <p>{error}</p>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={handleLogin}
+            disabled={loading}
+            aria-busy={loading}
+            className="w-full flex items-center justify-center gap-2 px-8 py-4 bg-emerald-600 dark:bg-emerald-500 text-white dark:text-black font-black text-sm uppercase tracking-wider hover:bg-emerald-500 dark:hover:bg-emerald-400 disabled:opacity-50 transition-all shadow-md shadow-emerald-600/20 dark:shadow-[0_0_20px_rgba(16,185,129,0.2)] cursor-pointer disabled:cursor-not-allowed"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>Connecting...</span>
+              </>
+            ) : (
+              'Connect Wallet'
+            )}
+          </button>
+        </div>
+      </PageContainer>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

- Restyled [apps/web/src/app/login/page.tsx](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/accensa-app/apps/web/src/app/login/page.tsx) to align with the design language used across `/dashboard` and `/verify`.
- Replaced undeclared semantic tokens and `rounded-*` classes with `PageContainer`, `bg-grid`, translucent backdrop blur panels, sharp corners, slate/emerald palettes, uppercase tracking-widest typography, and consistent error alert styling.
- Added unit tests in [apps/web/src/app/login/login-page.test.tsx](file:///home/abujulaybeeb/Documents/Drips/Drips%2013/accensa-app/apps/web/src/app/login/login-page.test.tsx) ensuring design system compliance and preventing token regressions.

## Why

- The login page was previously built using an isolated set of semantic tokens (`bg-card`, `text-muted-foreground`, `bg-primary`, `text-destructive`, `bg-secondary`, `text-primary-foreground`, `rounded-lg`, etc.).
- **Token Investigation**: These tokens were **not defined** in the project's Tailwind config or `@theme` in `globals.css`. They resolved to nothing, meaning the page suffered from unstyled fallback rendering bugs.
- Furthermore, the lack of `PageContainer` and `bg-grid` created an abrupt visual disconnect when transitioning from login into the dashboard.

## Implementation

- **`apps/web/src/app/login/page.tsx`**:
  - Wrapped page in `PageContainer width="narrow"` with `bg-grid` background.
  - Implemented the standard translucent blurred panel (`bg-white/50 dark:bg-white/5 backdrop-blur-2xl`) with sharp edges and subtle emerald glow.
  - Aligned typography with display headings and `tracking-[0.25em] text-emerald-600 dark:text-emerald-400 font-bold text-xs` uppercase category kicker.
  - Updated error state to match the app's established error alert banner (`border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-[#0a111a] text-red-600 dark:text-red-400`).
  - Updated wallet connection CTA button to the standard emerald uppercase action button with `aria-busy` and loading spinner state.
  - Kept all Freighter authentication, challenge-signing, and verification logic intact.
- **`apps/web/src/app/login/login-page.test.tsx`**:
  - Added unit tests verifying presence of design system classes and absence of undeclared tokens or `rounded-*` styles.

## Testing

- `pnpm format:check` (All matched files use Prettier code style)
- `pnpm --filter web lint` (0 errors)
- `pnpm --filter web typecheck` (0 errors)
- `pnpm --filter web test` (20 test files, 250 passed)
- `pnpm --filter web build` (Next.js production build completed successfully)

## Scope / Risk

- **Scope**: Presentation only for `apps/web/src/app/login/page.tsx` and accompanying test suite.
- **Risk**: None; authentication flow and API communication remain identical.

## Issue

Closes #197
