### PR TITLE
feat(web): complete dark mode coverage across dashboard components

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -198,7 +198,7 @@ export default function Dashboard() {
                 </p>
                 <button
                   onClick={reload}
-                  className="mt-4 px-6 py-3 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white text-sm font-bold hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 transition-colors shadow-sm dark:shadow-none"
+                  className="mt-4 px-6 py-3 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white text-sm font-bold hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 dark:hover:border-white/20 transition-colors shadow-sm dark:shadow-none"
                 >
                   Try Again
                 </button>
@@ -388,7 +388,7 @@ export function PaymentModal({
               href={explorerUrl(selected.tx_hash)}
               target="_blank"
               rel="noreferrer"
-              className="flex items-center justify-center gap-1.5 w-full py-4 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 shadow-sm dark:shadow-none transition-all font-bold text-sm tracking-wide uppercase"
+               className="flex items-center justify-center gap-1.5 w-full py-4 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 dark:hover:border-white/20 shadow-sm dark:shadow-none transition-all font-bold text-sm tracking-wide uppercase"
             >
               View on Explorer <ArrowUpRight className="w-4 h-4 opacity-70" />
             </a>
@@ -482,7 +482,7 @@ export function PaymentsTable({
                 <span className="text-slate-400 dark:text-slate-600">-</span>
               )}
             </td>
-            <td className="px-8 py-5 text-slate-500 text-sm">
+            <td className="px-8 py-5 text-slate-500 dark:text-slate-400 text-sm">
               {new Date(payment.ts).toLocaleString()}
             </td>
           </tr>

--- a/apps/web/src/app/dashboard/routes/page.tsx
+++ b/apps/web/src/app/dashboard/routes/page.tsx
@@ -329,7 +329,7 @@ function Segmented({
           aria-pressed={option.key === value}
           className={`px-3 py-2 text-[10px] font-bold uppercase tracking-widest transition-colors cursor-pointer ${
             option.key === value
-              ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300'
+              ? 'bg-emerald-500/15 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-300'
               : 'text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-white/5'
           }`}
         >

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -89,7 +89,7 @@ export default function LoginPage() {
               aria-live="assertive"
               className="border border-red-200 dark:border-red-500/20 bg-red-50 dark:bg-[#0a111a] p-4 flex gap-3 items-start text-sm text-red-600 dark:text-red-400 transition-colors duration-300"
             >
-              <ShieldAlert className="w-5 h-5 flex-shrink-0 mt-0.5 text-red-500" />
+              <ShieldAlert className="w-5 h-5 flex-shrink-0 mt-0.5 text-red-500 dark:text-red-400" />
               <p>{error}</p>
             </div>
           )}

--- a/apps/web/src/app/verify/page.tsx
+++ b/apps/web/src/app/verify/page.tsx
@@ -329,7 +329,7 @@ function CheckCard({
           <p className="text-slate-900 dark:text-white font-bold text-lg transition-colors duration-300">
             {title}
           </p>
-          <p className="text-slate-500 text-xs mt-1 transition-colors duration-300">{source}</p>
+          <p className="text-slate-500 dark:text-slate-400 text-xs mt-1 transition-colors duration-300">{source}</p>
         </div>
         <div
           className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-black uppercase tracking-widest border transition-colors duration-300 ${result.ok ? 'bg-emerald-50 dark:bg-emerald-500/5 text-emerald-600 dark:text-emerald-400 border-emerald-200 dark:border-emerald-500/20' : 'bg-red-50 dark:bg-red-500/5 text-red-600 dark:text-red-400 border-red-200 dark:border-red-500/20'}`}

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -161,7 +161,7 @@ export function Nav() {
             className={`text-4xl font-bold tracking-tight transition-colors flex items-center gap-3.5 ${
               pathname === '/'
                 ? 'text-emerald-600 dark:text-emerald-400'
-                : 'text-slate-900 dark:text-white hover:text-emerald-500'
+                : 'text-slate-900 dark:text-white hover:text-emerald-500 dark:hover:text-emerald-400'
             }`}
           >
             Home
@@ -174,7 +174,7 @@ export function Nav() {
             className={`text-4xl font-bold tracking-tight transition-colors flex items-center gap-3.5 ${
               pathname === '/verify'
                 ? 'text-emerald-600 dark:text-emerald-400'
-                : 'text-slate-900 dark:text-white hover:text-emerald-500'
+                : 'text-slate-900 dark:text-white hover:text-emerald-500 dark:hover:text-emerald-400'
             }`}
           >
             Verify
@@ -187,7 +187,7 @@ export function Nav() {
             className={`text-4xl font-bold tracking-tight transition-colors flex items-center gap-3.5 ${
               pathname === '/dashboard'
                 ? 'text-emerald-600 dark:text-emerald-400'
-                : 'text-slate-900 dark:text-white hover:text-emerald-500'
+                : 'text-slate-900 dark:text-white hover:text-emerald-500 dark:hover:text-emerald-400'
             }`}
           >
             Dashboard

--- a/apps/web/src/components/refund-panel.tsx
+++ b/apps/web/src/components/refund-panel.tsx
@@ -247,7 +247,7 @@ function SmallButton({
       disabled={disabled}
       className={`px-3 py-2 text-[10px] font-bold uppercase tracking-widest border transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
         tone === 'primary'
-          ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/25'
+          ? 'border-emerald-500/40 dark:border-emerald-500/30 bg-emerald-500/15 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/25 dark:hover:bg-emerald-500/30'
           : 'border-slate-200 dark:border-white/10 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/5'
       }`}
     >


### PR DESCRIPTION
## Summary

Completes the dark mode implementation for the merchant dashboard (apps/web) by filling in the remaining missing `dark:` CSS variant gaps across 6 component files.

## Context

The dark mode infrastructure was already substantially in place — `next-themes` integration, `ThemeProvider` with `attribute="class"`, `defaultTheme="system"`, `enableSystem`, and a `ThemeToggle` component in the navbar all existed. The inline SVG revenue chart already renders with dark-mode-aware stroke/fill classes. However, an audit revealed ~20 specific instances where hardcoded light-mode-only classes caused inconsistent rendering in dark mode.

## Changes

| File | Fix |
|------|-----|
| `nav.tsx` | Mobile nav link hover states: added `dark:hover:text-emerald-400` to Home, Verify, Dashboard links |
| `dashboard/page.tsx` | "Try Again" button hover border: added `dark:hover:border-white/20` |
| `dashboard/page.tsx` | "View on Explorer" button hover border: added `dark:hover:border-white/20` |
| `dashboard/page.tsx` | Table timestamp column: added `dark:text-slate-400` |
| `verify/page.tsx` | CheckCard source label: added `dark:text-slate-400` |
| `login/page.tsx` | ShieldAlert error icon: added `dark:text-red-400` |
| `routes/page.tsx` | Segmented control active state: added `dark:bg-emerald-500/20` |
| `refund-panel.tsx` | Primary SmallButton: added `dark:border-emerald-500/30`, `dark:bg-emerald-500/20`, `dark:hover:bg-emerald-500/30` |

## What was already in place (no changes needed)

- **Tailwind v4** configured with `@custom-variant dark (&:where(.dark, .dark *))` in `globals.css`
- **next-themes** v0.4.6 installed with `ThemeProvider` wrapping the app in `layout.tsx`
- **ThemeToggle** component with Light/Dark/System support in the navbar
- **suppressHydrationWarning** on `<html>` to prevent hydration flash
- **Revenue chart** (inline SVG) using Tailwind dark: classes directly — no `useTheme()` hook needed
- **global-error.tsx** intentionally has no dark variants (documented: it replaces the layout and has no ThemeProvider context)
- **Status indicator dots** (small colored circles) left without dark variants — they are accent colors that read well on both backgrounds

## Acceptance criteria

- [x] `next-themes` integrated without hydration mismatches or layout shifts
- [x] Tailwind configured with class-based dark mode strategy
- [x] All charts, tables, and data grids dynamically respond to the active theme
- [x] ThemeToggle present in navbar with Light, Dark, and System states
- [x] OS-level `prefers-color-scheme` correctly dictates the default rendering
- [x] Lint and typecheck pass cleanly

Closes #121
