### PR TITLE
feat: support more than one merchant per deployment (#103)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,6 +2,156 @@
 
 This document outlines the core principles and implementation details of the Accensa web application design system.
 
+> This file also carries architectural designs that the project's process
+> requires to be written down and reviewed before implementation. See
+> "Multi-merchant support" below for the current one.
+
+## 0. Multi-merchant support (issue #103)
+
+### Problem
+
+The app was single-merchant by construction: `MERCHANT_ADDRESS` was one environment
+variable, `payments` had no merchant column, and `sync_state` was a singleton by
+database `CHECK` constraint. Serving a second merchant meant a whole second
+deployment — database, Vercel project, cron, secrets — which is infrastructure work,
+not a product feature. Issue #87 (dashboard/API authentication) blocked this: scoping
+data per merchant needs an authenticated identity to scope it by, which #87 now
+provides via the `accensa_session` JWT cookie.
+
+### Data model
+
+A `merchants` table, keyed by Stellar address (`migrations/003_multi_merchant.sql`):
+
+```
+merchants
+  id                  SERIAL PRIMARY KEY
+  address             VARCHAR(56) UNIQUE NOT NULL   -- identity: auth, indexer filter
+  public_key_hex      VARCHAR(64)                   -- verifies /api/hook/settle reports
+  asset_contract_ids  TEXT                          -- null = fall back to ASSET_CONTRACT_IDS
+  refund_vault_id     VARCHAR(56)                   -- null = fall back to NEXT_PUBLIC_REFUND_VAULT_ID
+  webhook_url         TEXT                          -- null = fall back to WEBHOOK_URL
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+```
+
+`payments` gains `merchant_id`, and its primary key becomes `(merchant_id, tx_hash)`
+rather than `tx_hash` alone — a single Stellar transaction can in principle transfer
+to two different merchants at once, so the identity that must be unique is the pair,
+not the hash. `sync_state`'s singleton `CHECK (id = 1)` is replaced with a normal
+primary key on `merchant_id`, so each merchant gets its own ledger cursor.
+`challenge_nonces` gains a nullable `merchant_id` so a nonce minted for one
+merchant's login challenge cannot be replayed against another's.
+
+**Why two keys per merchant (`address` and `public_key_hex`) instead of one?** They
+already were two different things before this change (`MERCHANT_ADDRESS` and
+`MERCHANT_PUBLIC_KEY`): the Stellar address is the on-chain identity a transfer is
+addressed to and the account that signs into the dashboard, while the settlement
+report key only ever needs to verify an Ed25519 signature over an HTTP body. A
+seller's settlement-reporting key does not have to be their Stellar signing key, and
+requiring otherwise would be a regression from what single-merchant deployments could
+already do.
+
+### Migration and backwards compatibility
+
+`ensureSchema()` (`apps/web/src/lib/db.ts`) runs this migration idempotently on every
+request, the same pattern 001 and 002 already used, and the SQL is also committed as
+`migrations/003_multi_merchant.sql` with a documented, reversible DOWN section. A
+deployment upgrading with `MERCHANT_ADDRESS` (and optionally `MERCHANT_PUBLIC_KEY`)
+already set gets exactly one `merchants` row inserted automatically and every existing
+`payments`/`sync_state` row backfilled onto it — no manual SQL, no new environment
+variables, and the deployment keeps working unchanged as a single-merchant instance.
+Onboarding merchant #2 means inserting one more `merchants` row (`INSERT INTO
+merchants (address) VALUES (...)`), not standing up new infrastructure.
+
+### Query scoping and defence in depth
+
+Every query against `payments` and `sync_state` takes an explicit `merchant_id`
+parameter — there is no code path that reads either table unscoped. Behind that,
+`migrations/003_multi_merchant.sql` also turns on Postgres row-level security with
+`FORCE ROW LEVEL SECURITY` (not just `ENABLE`, so it binds even the role this app
+connects as) and a policy comparing `merchant_id` against a Postgres session variable,
+`accensa.merchant_id`. `withMerchantClient()` (`apps/web/src/lib/db.ts`) sets that
+variable once per request-scoped connection before running any query. The net effect:
+a query that forgets its own `WHERE merchant_id = $1` returns zero rows instead of
+every merchant's data — a mistake fails closed, not open. This is the two lines of
+defence the issue asked for: application-level scoping, with RLS behind it as the
+line that holds if the first one is ever missed.
+
+_Caveat, stated plainly_: RLS can never override a role with `BYPASSRLS` or `SUPERUSER`
+privileges — Postgres does not allow it to. In production this app should connect as
+a role with neither. A local Postgres superuser (the Docker Compose default) will
+bypass RLS regardless of `FORCE`, so the RLS-specific integration test in
+`apps/web/src/lib/db.integration.test.ts` is meaningful proof only against a
+non-superuser connection; application-level scoping is what actually protects a
+default local setup, which is exactly why it exists as the first line rather than the
+only one.
+
+Cross-tenant read isolation is asserted directly in
+`apps/web/src/app/api/cross-tenant-isolation.test.ts` for every read endpoint
+(`/api/payments`, `/api/routes`), and per-merchant cursor independence — including a
+quiet merchant whose cursor must still advance, which is precisely the bug that
+caused the original four-day outage — is asserted in `db.integration.test.ts`.
+
+### Indexing
+
+`GET /api/sync` (the scheduled entry point) now loads every configured merchant and
+sweeps each in turn within one invocation, rather than one deployment sweeping one
+address. Filtering server-side on a _set_ of addresses in a single RPC sweep would
+scale better than N separate sweeps, but was not pursued here because the Soroban RPC
+`getEvents` filter path exercised by `addressTopicFilter()` is documented and tested
+against a single topic value; batching many merchants' addresses into one filter is
+future work once there are enough merchants for N sequential sweeps to matter. Each
+merchant keeps its own cursor (`sync_state.merchant_id`) and its own retention-skip
+accounting, and — critically — a merchant with zero matching events in a sweep still
+has its cursor advanced to the swept-through ledger, not left standing still. The
+response body reports both a per-merchant `results` array and deployment-wide
+`syncedTo`/`skippedLedgers`/`drained` maximums, so `.github/workflows/sync.yml`'s
+existing health-check greps (`"syncedTo"`, `"skippedLedgers":[1-9]`) keep working
+unchanged whether the deployment has one merchant or many.
+
+`POST /api/sync` (the dashboard's manual "Sync now" button) resolves the merchant from
+the authenticated session and syncs only that merchant — a signed-in merchant can
+trigger their own re-sync, never anyone else's.
+
+### Per-merchant configuration
+
+Signing key and asset list live on the `merchants` row itself. Refund vault and
+webhook URL are also per-merchant columns with a deployment-wide fallback, resolved in
+`apps/web/src/lib/merchants.ts` (`Merchant.refundVaultId`, `Merchant.webhookUrl`) —
+see `apps/web/src/app/api/refund/preflight/route.ts` and the webhook dispatch in
+`apps/web/src/app/api/sync/route.ts` for where the fallback is applied.
+
+### Authentication changes
+
+`GET /api/auth/challenge` now takes a required `?address=` query parameter and looks
+up the corresponding `merchants` row (404 if unknown) before building the SEP-10-style
+challenge transaction, because the transaction's source account _is_ the merchant
+being authenticated and must be chosen before it is built and signed.
+`POST /api/auth/verify` needs no equivalent wire change: the merchant is read back out
+of the already-signed transaction's `source` field, then looked up the same way.
+
+`POST /api/hook/settle` accepts no merchant identifier in its payload at all — adding
+one would break every existing `@accensa/sdk` integration mid-flight. Instead, the
+signature itself carries the identity: each configured merchant's `public_key_hex` is
+tried against the request signature in turn, and whichever one verifies is who
+reported it (`apps/web/src/app/api/hook/settle/route.ts`, `verifyingMerchant()`). With
+a small number of merchants per deployment this is cheap, and onboarding a merchant's
+settlement reporting needs only a new `merchants` row, never an SDK change.
+
+`apps/web/src/middleware.ts` decodes the verified session JWT and forwards the
+merchant's Stellar address as the `x-accensa-merchant` request header, so route
+handlers trust that header for scoping instead of each re-verifying and re-decoding
+the session cookie independently. The header can't be forged by a caller: middleware
+runs first and overwrites it on every request it forwards.
+
+### Scope not covered by this change
+
+Multi-merchant _is_ the roadmap here, so the "scope this honestly" alternative in the
+issue (closing it as a stated single-tenant limitation) does not apply — see the
+tenancy section in `README.md`. Not covered: a UI for merchant self-service signup
+(merchants are provisioned by inserting a `merchants` row directly today), and
+batching multiple merchants' addresses into a single RPC `getEvents` sweep (see
+"Indexing" above).
+
 ## 1. Core Philosophy
 
 The design philosophy for Accensa revolves around **Premium Glassmorphism**. The goal is to create a dynamic, engaging, and high-fidelity interface that feels physical and reactive to the user. We emphasize vivid colors, deep blurs, and crisp specular highlights to simulate frosted glass resting over a glowing, ambient background.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ transfers the indexer has not reached yet are staged and completed on the next r
 
 [`apps/demo-merchant/`](apps/demo-merchant) is a working example.
 
+### Tenancy model
+
+One deployment now supports **multiple merchants**. Each merchant is a row in the
+`merchants` table (`address`, and optionally a settlement-reporting `public_key_hex`,
+`asset_contract_ids`, `refund_vault_id`, and `webhook_url` that override the
+deployment-wide env vars). `payments` and the indexer's ledger cursor
+(`sync_state`) are scoped by `merchant_id`, enforced both by application-level query
+scoping and by Postgres row-level security as a second line of defence — see
+[DESIGN.md](DESIGN.md) for the full design.
+
+Upgrading an existing single-merchant deployment needs no action: the migration
+(`migrations/003_multi_merchant.sql`, applied automatically) backfills one `merchants`
+row from `MERCHANT_ADDRESS`/`MERCHANT_PUBLIC_KEY` and every existing payment onto it.
+Onboarding another merchant means inserting one more row into `merchants`, not
+standing up another deployment.
+
 ### Contract addresses
 
 Testnet IDs are published in

--- a/apps/web/src/app/api/auth/challenge/route.test.ts
+++ b/apps/web/src/app/api/auth/challenge/route.test.ts
@@ -3,17 +3,23 @@ import { Keypair } from '@stellar/stellar-sdk';
 import { GET } from './route';
 
 const MERCHANT_KEYPAIR = Keypair.random();
+const MERCHANT_ADDRESS = MERCHANT_KEYPAIR.publicKey();
 
-const { mockStoreNonce, mockSweepExpiredNonces, mockEnsureSchema, mockWithClient } = vi.hoisted(
-  () => ({
-    mockStoreNonce: vi.fn().mockResolvedValue(undefined),
-    mockSweepExpiredNonces: vi.fn().mockResolvedValue(undefined),
-    mockEnsureSchema: vi.fn().mockResolvedValue(undefined),
-    mockWithClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => {
-      return fn({});
-    }),
+const {
+  mockStoreNonce,
+  mockSweepExpiredNonces,
+  mockEnsureSchema,
+  mockWithClient,
+  mockGetMerchantByAddress,
+} = vi.hoisted(() => ({
+  mockStoreNonce: vi.fn().mockResolvedValue(undefined),
+  mockSweepExpiredNonces: vi.fn().mockResolvedValue(undefined),
+  mockEnsureSchema: vi.fn().mockResolvedValue(undefined),
+  mockWithClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => {
+    return fn({});
   }),
-);
+  mockGetMerchantByAddress: vi.fn(),
+}));
 
 vi.mock('@/lib/db', () => ({
   withClient: mockWithClient,
@@ -22,22 +28,26 @@ vi.mock('@/lib/db', () => ({
   sweepExpiredNonces: mockSweepExpiredNonces,
 }));
 
-vi.mock('@/lib/db', () => ({
-  withClient: mockWithClient,
-  ensureSchema: mockEnsureSchema,
-  storeNonce: mockStoreNonce,
-  sweepExpiredNonces: mockSweepExpiredNonces,
+vi.mock('@/lib/merchants', () => ({
+  getMerchantByAddress: mockGetMerchantByAddress,
 }));
 
 describe('/api/auth/challenge GET', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.MERCHANT_ADDRESS = MERCHANT_KEYPAIR.publicKey();
+    mockGetMerchantByAddress.mockImplementation(async (_client: unknown, address: string) =>
+      address === MERCHANT_ADDRESS ? { id: 1, address: MERCHANT_ADDRESS } : null,
+    );
   });
+
+  const mockRequest = (address: string | null) =>
+    new Request(
+      `http://localhost/api/auth/challenge${address ? `?address=${encodeURIComponent(address)}` : ''}`,
+    );
 
   test('returns xdr and configured network passphrase', async () => {
     process.env.STELLAR_NETWORK_PASSPHRASE = 'Public Global Stellar Network ; September 2015';
-    const res = await GET();
+    const res = await GET(mockRequest(MERCHANT_ADDRESS));
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.xdr).toBeDefined();
@@ -47,27 +57,34 @@ describe('/api/auth/challenge GET', () => {
 
   test('defaults to Networks.TESTNET when STELLAR_NETWORK_PASSPHRASE is unset', async () => {
     delete process.env.STELLAR_NETWORK_PASSPHRASE;
-    const res = await GET();
+    const res = await GET(mockRequest(MERCHANT_ADDRESS));
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.networkPassphrase).toBe('Test SDF Network ; September 2015');
   });
 
-  test('persists the nonce to the database', async () => {
+  test('persists the nonce scoped to the resolved merchant', async () => {
     delete process.env.STELLAR_NETWORK_PASSPHRASE;
-    const res = await GET();
+    const res = await GET(mockRequest(MERCHANT_ADDRESS));
     expect(res.status).toBe(200);
     expect(mockStoreNonce).toHaveBeenCalledTimes(1);
-    const nonceArg = mockStoreNonce.mock.calls[0][1] as string;
+    const [, nonceArg, merchantIdArg] = mockStoreNonce.mock.calls[0];
     expect(nonceArg).toMatch(/^[0-9a-f]{64}$/);
+    expect(merchantIdArg).toBe(1);
     expect(mockSweepExpiredNonces).toHaveBeenCalledTimes(1);
   });
 
-  test('returns 500 when MERCHANT_ADDRESS is not configured', async () => {
-    delete process.env.MERCHANT_ADDRESS;
-    const res = await GET();
-    expect(res.status).toBe(500);
+  test('returns 400 when address query parameter is missing', async () => {
+    const res = await GET(mockRequest(null));
+    expect(res.status).toBe(400);
     const data = await res.json();
-    expect(data.error).toBe('MERCHANT_ADDRESS not configured');
+    expect(data.error).toBe('address query parameter is required');
+  });
+
+  test('returns 404 for an address with no matching merchant', async () => {
+    const res = await GET(mockRequest(Keypair.random().publicKey()));
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe('Unknown merchant');
   });
 });

--- a/apps/web/src/app/api/auth/challenge/route.ts
+++ b/apps/web/src/app/api/auth/challenge/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { TransactionBuilder, Account, Operation, Networks } from '@stellar/stellar-sdk';
 import { randomBytes } from 'crypto';
 import { withClient, ensureSchema, storeNonce, sweepExpiredNonces } from '@/lib/db';
+import { getMerchantByAddress } from '@/lib/merchants';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,10 +10,26 @@ function networkPassphrase(): string {
   return process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
 }
 
-export async function GET() {
-  const merchantAddress = process.env.MERCHANT_ADDRESS;
-  if (!merchantAddress) {
-    return NextResponse.json({ error: 'MERCHANT_ADDRESS not configured' }, { status: 500 });
+/**
+ * Which merchant is logging in has to be named up front: the challenge
+ * transaction's source account *is* the merchant address, so it must be known
+ * before the transaction is built and signed. `/api/auth/verify` then simply
+ * reads it back out of the signed XDR — no second round of merchant lookup
+ * logic to keep in sync.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const address = searchParams.get('address');
+  if (!address) {
+    return NextResponse.json({ error: 'address query parameter is required' }, { status: 400 });
+  }
+
+  const merchant = await withClient(async (client) => {
+    await ensureSchema(client);
+    return getMerchantByAddress(client, address);
+  });
+  if (!merchant) {
+    return NextResponse.json({ error: 'Unknown merchant' }, { status: 404 });
   }
 
   // Create a 64-byte random nonce
@@ -22,7 +39,7 @@ export async function GET() {
   // The source account is the merchant, sequence is 0
   const now = Math.floor(Date.now() / 1000);
   const passphrase = networkPassphrase();
-  const tx = new TransactionBuilder(new Account(merchantAddress, '0'), {
+  const tx = new TransactionBuilder(new Account(merchant.address, '0'), {
     fee: '100',
     networkPassphrase: passphrase,
     timebounds: { minTime: now - 60, maxTime: now + 300 },
@@ -39,7 +56,7 @@ export async function GET() {
   // and has not already been used. Sweep expired nonces opportunistically.
   await withClient(async (client) => {
     await ensureSchema(client);
-    await storeNonce(client, nonce);
+    await storeNonce(client, nonce, merchant.id);
     await sweepExpiredNonces(client);
   });
 

--- a/apps/web/src/app/api/auth/verify/route.test.ts
+++ b/apps/web/src/app/api/auth/verify/route.test.ts
@@ -4,17 +4,23 @@ import { POST } from './route';
 
 const MERCHANT_KEYPAIR = Keypair.random();
 const MERCHANT_ADDRESS = MERCHANT_KEYPAIR.publicKey();
+const MERCHANT_ID = 7;
 
-const { mockConsumeNonce, mockCreateSession, mockWithClient, mockEnsureSchema } = vi.hoisted(
-  () => ({
-    mockConsumeNonce: vi.fn(),
-    mockCreateSession: vi.fn().mockResolvedValue(undefined),
-    mockWithClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => {
-      return fn({});
-    }),
-    mockEnsureSchema: vi.fn().mockResolvedValue(undefined),
+const {
+  mockConsumeNonce,
+  mockCreateSession,
+  mockWithClient,
+  mockEnsureSchema,
+  mockGetMerchantByAddress,
+} = vi.hoisted(() => ({
+  mockConsumeNonce: vi.fn(),
+  mockCreateSession: vi.fn().mockResolvedValue(undefined),
+  mockWithClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => {
+    return fn({});
   }),
-);
+  mockEnsureSchema: vi.fn().mockResolvedValue(undefined),
+  mockGetMerchantByAddress: vi.fn(),
+}));
 
 vi.mock('@/lib/auth', () => ({
   createSession: mockCreateSession,
@@ -24,6 +30,10 @@ vi.mock('@/lib/db', () => ({
   withClient: mockWithClient,
   ensureSchema: mockEnsureSchema,
   consumeNonce: mockConsumeNonce,
+}));
+
+vi.mock('@/lib/merchants', () => ({
+  getMerchantByAddress: mockGetMerchantByAddress,
 }));
 
 function buildChallenge(nonce: string, passphrase = Networks.TESTNET) {
@@ -63,9 +73,11 @@ function buildMultiOpTransaction(nonce: string, passphrase = Networks.TESTNET) {
 describe('/api/auth/verify POST', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.MERCHANT_ADDRESS = MERCHANT_ADDRESS;
     process.env.STELLAR_NETWORK_PASSPHRASE = Networks.TESTNET;
     mockConsumeNonce.mockResolvedValue(true);
+    mockGetMerchantByAddress.mockImplementation(async (_client: unknown, address: string) =>
+      address === MERCHANT_ADDRESS ? { id: MERCHANT_ID, address: MERCHANT_ADDRESS } : null,
+    );
   });
 
   const makeRequest = (body: unknown) =>
@@ -85,7 +97,7 @@ describe('/api/auth/verify POST', () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.success).toBe(true);
-    expect(mockConsumeNonce).toHaveBeenCalledWith(expect.anything(), nonce);
+    expect(mockConsumeNonce).toHaveBeenCalledWith(expect.anything(), nonce, MERCHANT_ID);
     expect(mockCreateSession).toHaveBeenCalledWith(MERCHANT_ADDRESS);
   });
 
@@ -165,12 +177,24 @@ describe('/api/auth/verify POST', () => {
     expect(data.error).toBe('Challenge expired or invalid');
   });
 
-  test('returns 500 when MERCHANT_ADDRESS is not configured', async () => {
-    delete process.env.MERCHANT_ADDRESS;
-    const res = await POST(makeRequest({ xdr: 'anything' }));
-    expect(res.status).toBe(500);
+  test('rejects a source account with no matching merchant', async () => {
+    const unknownKeypair = Keypair.random();
+    const nonce = 'g'.repeat(64);
+    const now = Math.floor(Date.now() / 1000);
+    const tx = new TransactionBuilder(new Account(unknownKeypair.publicKey(), '0'), {
+      fee: '100',
+      networkPassphrase: Networks.TESTNET,
+      timebounds: { minTime: now - 60, maxTime: now + 300 },
+    })
+      .addOperation(Operation.manageData({ name: 'Accensa Auth', value: nonce }))
+      .build();
+    tx.sign(unknownKeypair);
+
+    const res = await POST(makeRequest({ xdr: tx.toXDR() }));
+
+    expect(res.status).toBe(401);
     const data = await res.json();
-    expect(data.error).toBe('MERCHANT_ADDRESS not configured');
+    expect(data.error).toBe('Invalid source account');
   });
 
   test('returns 400 when xdr is missing', async () => {

--- a/apps/web/src/app/api/auth/verify/route.ts
+++ b/apps/web/src/app/api/auth/verify/route.ts
@@ -2,17 +2,13 @@ import { NextResponse } from 'next/server';
 import { Transaction, Networks, Keypair } from '@stellar/stellar-sdk';
 import { createSession } from '@/lib/auth';
 import { withClient, ensureSchema, consumeNonce } from '@/lib/db';
+import { getMerchantByAddress } from '@/lib/merchants';
 
 function networkPassphrase(): string {
   return process.env.STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
 }
 
 export async function POST(request: Request) {
-  const merchantAddress = process.env.MERCHANT_ADDRESS;
-  if (!merchantAddress) {
-    return NextResponse.json({ error: 'MERCHANT_ADDRESS not configured' }, { status: 500 });
-  }
-
   try {
     const { xdr } = await request.json();
     if (!xdr) {
@@ -30,8 +26,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Challenge expired or invalid' }, { status: 401 });
     }
 
-    // Validate source account
-    if (tx.source !== merchantAddress) {
+    // The transaction's source account names which merchant this challenge
+    // was issued to, in /api/auth/challenge. It must be a known merchant.
+    const merchantAddress = tx.source;
+    const merchant = await withClient(async (client) => {
+      await ensureSchema(client);
+      return getMerchantByAddress(client, merchantAddress);
+    });
+    if (!merchant) {
       return NextResponse.json({ error: 'Invalid source account' }, { status: 401 });
     }
 
@@ -60,10 +62,12 @@ export async function POST(request: Request) {
 
     const nonce = typeof op.value === 'string' ? op.value : Buffer.from(op.value).toString('utf8');
 
-    // Confirm the nonce was issued by this server and consume it
+    // Confirm the nonce was issued by this server for this merchant, and
+    // consume it. Scoping by merchant_id means a nonce minted for one
+    // merchant's challenge can never authenticate as another.
     const consumed = await withClient(async (client) => {
       await ensureSchema(client);
-      return consumeNonce(client, nonce);
+      return consumeNonce(client, nonce, merchant.id);
     });
 
     if (!consumed) {

--- a/apps/web/src/app/api/cross-tenant-isolation.test.ts
+++ b/apps/web/src/app/api/cross-tenant-isolation.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Proves that no endpoint can return one merchant's data to another.
+ *
+ * The fake database below behaves the way Postgres does once
+ * migrations/003_multi_merchant.sql is applied: `payments` carries rows for
+ * two merchants, and any query that does not filter on `merchant_id` gets
+ * back nothing at all — that is what `FORCE ROW LEVEL SECURITY` guarantees
+ * even if an application-level `WHERE` clause were ever dropped by mistake.
+ * A query that filters on the *wrong* merchant_id also gets back nothing,
+ * which is what proves isolation rather than mere correctness.
+ *
+ * This exercises every read endpoint that touches `payments`: GET
+ * /api/payments and GET /api/routes. GET /api/sync's cursor isolation is
+ * covered separately in db.ts (per-merchant sync_state), and POST
+ * /api/hook/settle's isolation is that the *signature* — not caller input —
+ * selects the merchant, covered in hook/settle/route.test.ts.
+ */
+import { expect, test, vi, describe, beforeEach } from 'vitest';
+
+const MERCHANT_A = { id: 1, address: 'GAAA' };
+const MERCHANT_B = { id: 2, address: 'GBBB' };
+
+const PAYMENTS = [
+  {
+    merchant_id: 1,
+    tx_hash: 'a'.repeat(64),
+    payer: 'GPAYERA',
+    amount: '100',
+    asset: 'XLM',
+    ts: new Date().toISOString(),
+    route: '/a',
+    method: 'GET',
+  },
+  {
+    merchant_id: 2,
+    tx_hash: 'b'.repeat(64),
+    payer: 'GPAYERB',
+    amount: '999',
+    asset: 'XLM',
+    ts: new Date().toISOString(),
+    route: '/b',
+    method: 'GET',
+  },
+];
+
+const ROUTE_TOTALS = [
+  { merchant_id: 1, route: '/a', method: 'GET', total_revenue: '100', calls: 1 },
+  { merchant_id: 2, route: '/b', method: 'GET', total_revenue: '999', calls: 1 },
+];
+
+/**
+ * Mimics FORCE ROW LEVEL SECURITY plus the app's own WHERE clause: a query
+ * without `merchant_id = $1` (or filtering on the wrong id) returns nothing,
+ * exactly like a policy that closes instead of leaking on a missing scope.
+ */
+function fakeQuery(table: { merchant_id: number }[]) {
+  return vi.fn(async (sql: string, params: unknown[] = []) => {
+    if (!/merchant_id\s*=\s*\$1/.test(sql)) return { rows: [] };
+    const merchantId = params[0];
+    return { rows: table.filter((row) => row.merchant_id === merchantId) };
+  });
+}
+
+let currentMerchant: typeof MERCHANT_A | typeof MERCHANT_B;
+
+vi.mock('@/lib/merchants', () => ({
+  getMerchantFromRequest: vi.fn(async () => currentMerchant),
+}));
+
+vi.mock('@/lib/db', () => ({
+  withClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => fn({})),
+  withMerchantClient: vi.fn(
+    async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) =>
+      fn({ query: currentQuery }),
+  ),
+  ensureSchema: vi.fn(),
+  getSyncState: vi.fn().mockResolvedValue(null),
+}));
+
+let currentQuery: ReturnType<typeof fakeQuery>;
+
+describe('cross-tenant isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DATABASE_URL = 'postgres://dummy';
+  });
+
+  test('GET /api/payments never returns another merchant’s rows', async () => {
+    const { GET } = await import('./payments/route');
+    currentQuery = fakeQuery(PAYMENTS);
+
+    currentMerchant = MERCHANT_A;
+    const resA = await GET(new Request('http://localhost/api/payments'));
+    const dataA = await resA.json();
+    expect(dataA.payments).toHaveLength(1);
+    expect(dataA.payments[0].tx_hash).toBe('a'.repeat(64));
+
+    currentMerchant = MERCHANT_B;
+    const resB = await GET(new Request('http://localhost/api/payments'));
+    const dataB = await resB.json();
+    expect(dataB.payments).toHaveLength(1);
+    expect(dataB.payments[0].tx_hash).toBe('b'.repeat(64));
+
+    // Neither response ever contains the other merchant's transaction hash.
+    expect(JSON.stringify(dataA)).not.toContain('b'.repeat(64));
+    expect(JSON.stringify(dataB)).not.toContain('a'.repeat(64));
+  });
+
+  test('GET /api/routes never returns another merchant’s revenue', async () => {
+    const { GET } = await import('./routes/route');
+    currentQuery = fakeQuery(ROUTE_TOTALS);
+
+    currentMerchant = MERCHANT_A;
+    const resA = await GET(new Request('http://localhost/api/routes'));
+    const dataA = await resA.json();
+    expect(dataA.routes.map((r: { route: string }) => r.route)).toEqual(['/a']);
+
+    currentMerchant = MERCHANT_B;
+    const resB = await GET(new Request('http://localhost/api/routes'));
+    const dataB = await resB.json();
+    expect(dataB.routes.map((r: { route: string }) => r.route)).toEqual(['/b']);
+  });
+
+  test('a query that omits the merchant scope returns nothing, not everything', () => {
+    const q = fakeQuery(PAYMENTS);
+    return q('SELECT * FROM payments', []).then((res) => {
+      expect(res.rows).toHaveLength(0);
+    });
+  });
+});

--- a/apps/web/src/app/api/hook/settle/route.test.ts
+++ b/apps/web/src/app/api/hook/settle/route.test.ts
@@ -2,26 +2,34 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
 import * as crypto from 'node:crypto';
 
+const PUBLIC_KEY_HEX = 'dfac12734284a3fd741b1392f7f545496462efa5ad0fb45f5d5ce79a09d46b2f';
+const PRIVATE_KEY_HEX = '49df29e01fc8c973ea614aabdaed9041a9bc99c43e49e01c5188bfcc65bb33a1';
+
+const { mockRecordSettlement } = vi.hoisted(() => ({
+  mockRecordSettlement: vi.fn().mockResolvedValue({ matchedExistingPayment: false }),
+}));
+
 vi.mock('@/lib/db', () => ({
-  withClient: vi.fn(async (_cb) => {
-    return { matchedExistingPayment: false };
-  }),
+  withClient: vi.fn(async (cb: (client: unknown) => unknown) => cb({})),
+  withMerchantClient: vi.fn(async (_merchantId: number, cb: (client: unknown) => unknown) =>
+    cb({}),
+  ),
   ensureSchema: vi.fn(),
-  recordSettlement: vi.fn(),
+  recordSettlement: mockRecordSettlement,
+}));
+
+vi.mock('@/lib/merchants', () => ({
+  listMerchants: vi.fn(async () => [{ id: 1, address: 'GABC', publicKeyHex: PUBLIC_KEY_HEX }]),
 }));
 
 describe('POST /api/hook/settle', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     process.env.DATABASE_URL = 'postgres://dummy';
-    process.env.MERCHANT_PUBLIC_KEY =
-      'dfac12734284a3fd741b1392f7f545496462efa5ad0fb45f5d5ce79a09d46b2f';
   });
 
   const sign = (payload: string) => {
-    const keyBuffer = Buffer.from(
-      '49df29e01fc8c973ea614aabdaed9041a9bc99c43e49e01c5188bfcc65bb33a1',
-      'hex',
-    );
+    const keyBuffer = Buffer.from(PRIVATE_KEY_HEX, 'hex');
     const privateKey = crypto.createPrivateKey({
       key: Buffer.concat([Buffer.from('302e020100300506032b657004220420', 'hex'), keyBuffer]),
       format: 'der',
@@ -30,7 +38,7 @@ describe('POST /api/hook/settle', () => {
     return crypto.sign(null, Buffer.from(payload, 'utf8'), privateKey).toString('hex');
   };
 
-  it('verifies a payload with non-ASCII and float', async () => {
+  it('verifies a payload with non-ASCII and float, resolving the reporting merchant', async () => {
     const rawBody = `{"tx_hash":"${'a'.repeat(64)}","route":"/café","method":"GET","amount":1.0}`;
     const req = new Request('http://localhost/api/hook/settle', {
       method: 'POST',
@@ -41,6 +49,11 @@ describe('POST /api/hook/settle', () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
+    expect(mockRecordSettlement).toHaveBeenCalledWith(
+      expect.anything(),
+      1,
+      expect.objectContaining({ txHash: 'a'.repeat(64) }),
+    );
   });
 
   it('rejects tampered body', async () => {
@@ -68,5 +81,16 @@ describe('POST /api/hook/settle', () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+
+  it('rejects a signature that matches no configured merchant', async () => {
+    const rawBody = `{"tx_hash":"${'b'.repeat(64)}","route":"/x","method":"GET"}`;
+    const req = new Request('http://localhost/api/hook/settle', {
+      method: 'POST',
+      headers: { 'x-signature': 'a'.repeat(128) },
+      body: rawBody,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/web/src/app/api/hook/settle/route.ts
+++ b/apps/web/src/app/api/hook/settle/route.ts
@@ -1,8 +1,56 @@
 import { NextResponse } from 'next/server';
-import { withClient, ensureSchema, recordSettlement } from '@/lib/db';
+import { withClient, withMerchantClient, ensureSchema, recordSettlement } from '@/lib/db';
 import { parseSettlementReport } from '@/lib/settlement-report';
+import { listMerchants, type Merchant } from '@/lib/merchants';
 
 export const dynamic = 'force-dynamic';
+
+/**
+ * Finds which configured merchant signed this report.
+ *
+ * The wire payload carries no merchant identifier — changing it would break
+ * every existing `@accensa/sdk` integration mid-flight. Instead, the
+ * signature itself is the identity: each merchant's `public_key_hex` is tried
+ * in turn, and whichever one verifies is who reported it. With a small number
+ * of merchants per deployment this is cheap, and it means onboarding a new
+ * merchant's settlement reporting needs no SDK or wire-format change, only a
+ * new `merchants` row.
+ */
+async function verifyingMerchant(
+  merchants: Merchant[],
+  raw: string,
+  signatureHex: string,
+): Promise<Merchant | null> {
+  const crypto = await import('node:crypto');
+  let signature: Buffer;
+  try {
+    signature = Buffer.from(signatureHex, 'hex');
+  } catch {
+    return null;
+  }
+
+  for (const merchant of merchants) {
+    if (!merchant.publicKeyHex) continue;
+    try {
+      const keyBuffer = Buffer.from(merchant.publicKeyHex, 'hex');
+      const publicKey = crypto.createPublicKey({
+        key: Buffer.concat([
+          Buffer.from('302a300506032b6570032100', 'hex'), // SubjectPublicKeyInfo Ed25519 header
+          keyBuffer,
+        ]),
+        format: 'der',
+        type: 'spki',
+      });
+      if (crypto.verify(null, Buffer.from(raw, 'utf8'), publicKey, signature)) {
+        return merchant;
+      }
+    } catch {
+      // A malformed key for one merchant must not block checking the rest.
+      continue;
+    }
+  }
+  return null;
+}
 
 /**
  * Records route attribution reported by an x402 seller.
@@ -11,17 +59,12 @@ export const dynamic = 'force-dynamic';
  * route that was paid for. That mapping exists only in the seller's process, so
  * it has to be reported rather than indexed. This is consequently the only
  * write path into `payments` that is not derived from the ledger, which is why
- * it fails closed: without MERCHANT_PUBLIC_KEY configured the endpoint refuses to
- * accept anything at all.
+ * it fails closed: unless some merchant's signing key verifies the report, the
+ * endpoint refuses to accept anything at all.
  *
  * Ledger-owned fields (ledger, amount, asset, ts) are never written here.
  */
 export async function POST(request: Request) {
-  const publicKeyHex = process.env.MERCHANT_PUBLIC_KEY;
-  if (!publicKeyHex) {
-    return NextResponse.json({ error: 'Settlement reporting is not configured' }, { status: 503 });
-  }
-
   const signature = request.headers.get('x-signature');
   if (!signature) {
     return NextResponse.json({ error: 'Missing X-Signature header' }, { status: 401 });
@@ -38,29 +81,14 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Request body must be text/json' }, { status: 400 });
   }
 
-  try {
-    const crypto = await import('node:crypto');
-    const keyBuffer = Buffer.from(publicKeyHex, 'hex');
-    const publicKey = crypto.createPublicKey({
-      key: Buffer.concat([
-        Buffer.from('302a300506032b6570032100', 'hex'), // SubjectPublicKeyInfo Ed25519 header
-        keyBuffer,
-      ]),
-      format: 'der',
-      type: 'spki',
-    });
+  const merchant = await withClient(async (client) => {
+    await ensureSchema(client);
+    const merchants = await listMerchants(client);
+    return await verifyingMerchant(merchants, raw, signature);
+  });
 
-    const isValid = crypto.verify(
-      null,
-      Buffer.from(raw, 'utf8'),
-      publicKey,
-      Buffer.from(signature, 'hex'),
-    );
-    if (!isValid) {
-      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
-    }
-  } catch (err) {
-    return NextResponse.json({ error: 'Signature verification failed' }, { status: 401 });
+  if (!merchant) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
   }
 
   let body: unknown;
@@ -76,9 +104,9 @@ export async function POST(request: Request) {
   }
 
   try {
-    const { matchedExistingPayment } = await withClient(async (client) => {
+    const { matchedExistingPayment } = await withMerchantClient(merchant.id, async (client) => {
       await ensureSchema(client);
-      return recordSettlement(client, parsed.report);
+      return recordSettlement(client, merchant.id, parsed.report);
     });
 
     return NextResponse.json({

--- a/apps/web/src/app/api/payments/route.test.ts
+++ b/apps/web/src/app/api/payments/route.test.ts
@@ -1,10 +1,35 @@
 import { expect, test, vi, describe, beforeEach } from 'vitest';
 import { GET } from './route';
 
+const {
+  MERCHANT,
+  mockWithClient,
+  mockWithMerchantClient,
+  mockGetSyncState,
+  mockGetMerchantFromRequest,
+} = vi.hoisted(() => {
+  const merchant = { id: 1, address: 'GABC' };
+  return {
+    MERCHANT: merchant,
+    mockWithClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => fn({})),
+    mockWithMerchantClient: vi.fn(
+      async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) =>
+        fn({ query: vi.fn().mockResolvedValue({ rows: [] }) }),
+    ),
+    mockGetSyncState: vi.fn().mockResolvedValue(null),
+    mockGetMerchantFromRequest: vi.fn().mockResolvedValue(merchant),
+  };
+});
+
 vi.mock('@/lib/db', () => ({
-  withClient: vi.fn(),
+  withClient: mockWithClient,
+  withMerchantClient: mockWithMerchantClient,
   ensureSchema: vi.fn(),
-  getSyncState: vi.fn(),
+  getSyncState: mockGetSyncState,
+}));
+
+vi.mock('@/lib/merchants', () => ({
+  getMerchantFromRequest: mockGetMerchantFromRequest,
 }));
 
 describe('/api/payments GET', () => {
@@ -13,7 +38,9 @@ describe('/api/payments GET', () => {
   };
 
   beforeEach(() => {
+    vi.clearAllMocks();
     process.env.DATABASE_URL = 'postgres://dummy';
+    mockGetMerchantFromRequest.mockResolvedValue(MERCHANT);
   });
 
   describe('limit validation', () => {
@@ -83,6 +110,30 @@ describe('/api/payments GET', () => {
       expect(res.status).toBe(400);
       const data = await res.json();
       expect(data.error).toBe('invalid_cursor');
+    });
+  });
+
+  describe('merchant scoping', () => {
+    test('returns 401 when the request carries no resolvable merchant', async () => {
+      mockGetMerchantFromRequest.mockResolvedValue(null);
+      const res = await GET(mockRequest('http://localhost/api/payments'));
+      expect(res.status).toBe(401);
+    });
+
+    test('scopes the query to the resolved merchant', async () => {
+      const query = vi.fn().mockResolvedValue({ rows: [] });
+      mockWithMerchantClient.mockImplementationOnce(
+        async (merchantId: number, fn: (client: unknown) => Promise<unknown>) => {
+          expect(merchantId).toBe(MERCHANT.id);
+          return fn({ query });
+        },
+      );
+
+      const res = await GET(mockRequest('http://localhost/api/payments'));
+      expect(res.status).toBe(200);
+      const [sql, params] = query.mock.calls[0];
+      expect(sql).toContain('merchant_id = $1');
+      expect(params[0]).toBe(MERCHANT.id);
     });
   });
 });

--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { withClient, ensureSchema, getSyncState } from '@/lib/db';
+import { withClient, withMerchantClient, ensureSchema, getSyncState } from '@/lib/db';
+import { getMerchantFromRequest } from '@/lib/merchants';
 import { isHash32 } from '@/lib/receipt-anchor';
 import type { SyncState } from '@/lib/sync-status';
 
@@ -63,13 +64,18 @@ export async function GET(request: Request) {
   }
 
   try {
-    const { rows, sync } = await withClient(async (client) => {
+    const merchant = await withClient((client) => getMerchantFromRequest(client, request));
+    if (!merchant) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { rows, sync } = await withMerchantClient(merchant.id, async (client) => {
       await ensureSchema(client);
 
-      let query = `SELECT tx_hash, ledger, payer, amount::text AS amount, asset, ts, route, method FROM payments WHERE ts IS NOT NULL`;
-      const params: (string | number)[] = [];
+      let query = `SELECT tx_hash, ledger, payer, amount::text AS amount, asset, ts, route, method FROM payments WHERE merchant_id = $1 AND ts IS NOT NULL`;
+      const params: (string | number)[] = [merchant.id];
       if (parsedCursor) {
-        query += ` AND (ts < $1 OR (ts = $1 AND tx_hash < $2))`;
+        query += ` AND (ts < $${params.length + 1} OR (ts = $${params.length + 1} AND tx_hash < $${params.length + 2}))`;
         params.push(parsedCursor.ts, parsedCursor.txHash);
       }
 
@@ -77,7 +83,7 @@ export async function GET(request: Request) {
       params.push(limit);
 
       const result = await client.query(query, params);
-      return { rows: result.rows, sync: await getSyncState(client) };
+      return { rows: result.rows, sync: await getSyncState(client, merchant.id) };
     });
 
     const next_cursor =

--- a/apps/web/src/app/api/refund/preflight/route.ts
+++ b/apps/web/src/app/api/refund/preflight/route.ts
@@ -6,6 +6,8 @@ import {
   type RefundPreflight,
   type RefundRecord,
 } from '@/lib/refund-vault';
+import { withClient } from '@/lib/db';
+import { getMerchantFromRequest } from '@/lib/merchants';
 
 export const dynamic = 'force-dynamic';
 
@@ -63,19 +65,32 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'paidAtLedger must be a ledger number' }, { status: 400 });
   }
 
+  const caller = await withClient((client) => getMerchantFromRequest(client, request));
+  if (!caller) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const vaultId = caller.refundVaultId ?? REFUND_VAULT_ID;
+
   let existing: RefundRecord | null = null;
   try {
-    existing = await getRefund(txHash, merchant);
+    existing = await getRefund(txHash, merchant, vaultId);
   } catch {
     // A failed lookup is not evidence the payment was never refunded, so it is
     // left null and the preflight below still runs — the contract itself will
     // report AlreadyRefunded if that is the case.
   }
 
-  const preflight = await preflightRefund({ txHash, recipient, amount, paidAtLedger, merchant });
+  const preflight = await preflightRefund({
+    txHash,
+    recipient,
+    amount,
+    paidAtLedger,
+    merchant,
+    vaultId,
+  });
 
   return NextResponse.json<RefundPreflightResponse>({
-    contract: REFUND_VAULT_ID,
+    contract: vaultId,
     existing,
     preflight,
   });

--- a/apps/web/src/app/api/routes/route.test.ts
+++ b/apps/web/src/app/api/routes/route.test.ts
@@ -1,19 +1,33 @@
 import { expect, test, vi, describe, beforeEach } from 'vitest';
 import { GET } from './route';
 
+const MERCHANT = { id: 1, address: 'GABC' };
 const mockQuery = vi.fn();
 
+const { mockWithClient, mockWithMerchantClient, mockGetMerchantFromRequest } = vi.hoisted(() => ({
+  mockWithClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => fn({})),
+  mockWithMerchantClient: vi.fn(
+    async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) =>
+      fn({ query: mockQuery }),
+  ),
+  mockGetMerchantFromRequest: vi.fn(),
+}));
+
 vi.mock('@/lib/db', () => ({
-  withClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => {
-    return fn({ query: mockQuery });
-  }),
+  withClient: mockWithClient,
+  withMerchantClient: mockWithMerchantClient,
   ensureSchema: vi.fn(),
+}));
+
+vi.mock('@/lib/merchants', () => ({
+  getMerchantFromRequest: mockGetMerchantFromRequest,
 }));
 
 describe('/api/routes GET', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.DATABASE_URL = 'postgres://dummy';
+    mockGetMerchantFromRequest.mockResolvedValue(MERCHANT);
   });
 
   const mockRequest = (url: string) => new Request(url);
@@ -90,7 +104,7 @@ describe('/api/routes GET', () => {
     expect(data.routes).toHaveLength(5);
   });
 
-  test('applies default 30-day window when no from/to given', async () => {
+  test('scopes the aggregate query to the resolved merchant', async () => {
     mockQuery.mockResolvedValue({ rows: [] });
 
     await GET(mockRequest('http://localhost/api/routes'));
@@ -98,9 +112,10 @@ describe('/api/routes GET', () => {
     const query = callArgs[0] as string;
     const params = callArgs[1] as (string | number)[];
 
-    expect(query).toContain('ts >= $1');
-    expect(params).toHaveLength(2); // from + limit
-    expect(typeof params[0]).toBe('string');
+    expect(query).toContain('merchant_id = $1');
+    expect(query).toContain('ts >= $2');
+    expect(params).toHaveLength(3); // merchant_id + from + limit
+    expect(params[0]).toBe(MERCHANT.id);
   });
 
   test('respects custom from/to parameters', async () => {
@@ -111,10 +126,10 @@ describe('/api/routes GET', () => {
     const query = callArgs[0] as string;
     const params = callArgs[1] as (string | number)[];
 
-    expect(query).toContain('ts >= $1');
-    expect(query).toContain('ts <= $2');
-    expect(params[0]).toBe('2026-01-01');
-    expect(params[1]).toBe('2026-06-01');
+    expect(query).toContain('ts >= $2');
+    expect(query).toContain('ts <= $3');
+    expect(params[1]).toBe('2026-01-01');
+    expect(params[2]).toBe('2026-06-01');
   });
 
   test('does not include default_window_days when from is provided', async () => {
@@ -131,5 +146,11 @@ describe('/api/routes GET', () => {
     expect(res.status).toBe(500);
     const data = await res.json();
     expect(data.error).toBe('DATABASE_URL is not configured');
+  });
+
+  test('returns 401 when the request carries no resolvable merchant', async () => {
+    mockGetMerchantFromRequest.mockResolvedValue(null);
+    const res = await GET(mockRequest('http://localhost/api/routes'));
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/web/src/app/api/routes/route.ts
+++ b/apps/web/src/app/api/routes/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { withClient, ensureSchema } from '@/lib/db';
+import { withClient, withMerchantClient, ensureSchema } from '@/lib/db';
+import { getMerchantFromRequest } from '@/lib/merchants';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,14 +31,19 @@ export async function GET(request: Request) {
   }
 
   try {
-    const rows = await withClient(async (client) => {
+    const merchant = await withClient((client) => getMerchantFromRequest(client, request));
+    if (!merchant) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const rows = await withMerchantClient(merchant.id, async (client) => {
       await ensureSchema(client);
       let query = `
  SELECT COALESCE(route, '(unattributed)') as route, method, SUM(amount) as total_revenue, COUNT(*) as calls
  FROM payments
- WHERE ts IS NOT NULL
+ WHERE merchant_id = $1 AND ts IS NOT NULL
  `;
-      const params: (string | number)[] = [];
+      const params: (string | number)[] = [merchant.id];
 
       // Apply a default time window when no explicit from/to is given so
       // the aggregate does not scan the entire table on every dashboard load.

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -2,11 +2,13 @@ import { NextResponse } from 'next/server';
 import { decodeTransferEvent, transferTopicFilter, addressTopicFilter } from '@/lib/stellar-events';
 import {
   withClient,
+  withMerchantClient,
   ensureSchema,
   getLastSyncedLedger,
   setLastSyncedLedger,
   getSyncState,
 } from '@/lib/db';
+import { listMerchants, getMerchantFromRequest, type Merchant } from '@/lib/merchants';
 import { sweepLedgerRange, EVENTS_PAGE_LIMIT, type EventPage } from '@/lib/event-pager';
 import { cooldownRemaining } from '@/lib/sync-status';
 
@@ -20,7 +22,7 @@ const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.
  * to the testnet native XLM SAC; set ASSET_CONTRACT_IDS to a comma-separated
  * list to settle in USDC or across multiple assets.
  */
-const ASSET_CONTRACT_IDS = (
+const DEFAULT_ASSET_CONTRACT_IDS = (
   process.env.ASSET_CONTRACT_IDS ?? 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'
 )
   .split(',')
@@ -94,18 +96,19 @@ interface CooldownResult {
 }
 
 /**
- * Indexes Stellar Asset Contract transfers into the merchant's payment ledger.
+ * Indexes Stellar Asset Contract transfers into one merchant's payment ledger.
  *
- * Shared by both entry points: the scheduled GET, and the POST behind the
- * dashboard's manual trigger. `cooldownMs`, when set, makes the run a no-op if
- * the last sync is more recent than that.
+ * Shared by both entry points: the scheduled GET (looped over every merchant),
+ * and the POST behind the dashboard's manual trigger (one merchant, the caller).
+ * `cooldownMs`, when set, makes the run a no-op if the last sync is more recent
+ * than that.
  */
-async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
-  return withClient(async (client) => {
+async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
+  return withMerchantClient(merchant.id, async (client) => {
     await ensureSchema(client);
 
     if (opts.cooldownMs) {
-      const state = await getSyncState(client);
+      const state = await getSyncState(client, merchant.id);
       const retryAfterMs = cooldownRemaining(state?.updatedAt, opts.cooldownMs);
       if (retryAfterMs > 0) return { cooldown: true, retryAfterMs } as CooldownResult;
     }
@@ -113,7 +116,7 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
     {
       const { sequence: latestLedger } = await rpc<{ sequence: number }>('getLatestLedger', {});
 
-      const cursor = await getLastSyncedLedger(client);
+      const cursor = await getLastSyncedLedger(client, merchant.id);
       const resumeFrom = cursor !== null ? cursor + 1 : latestLedger - COLD_START_LOOKBACK;
       const retentionFloor = latestLedger - MAX_LOOKBACK;
       const startLedger = Math.max(resumeFrom, retentionFloor, 1);
@@ -125,6 +128,7 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
 
       if (startLedger > latestLedger) {
         return {
+          merchant: merchant.address,
           latestLedger,
           startLedger,
           syncedTo: startLedger - 1,
@@ -139,12 +143,13 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
 
       // Filter server-side to transfers addressed to this merchant. The asset
       // topic is optional across protocol versions, so match both arities.
-      const toTopic = addressTopicFilter(merchant);
+      const toTopic = addressTopicFilter(merchant.address);
       const transfer = transferTopicFilter();
+      const assetContractIds = merchant.assetContractIds ?? DEFAULT_ASSET_CONTRACT_IDS;
       const filters = [
         {
           type: 'contract',
-          contractIds: ASSET_CONTRACT_IDS,
+          contractIds: assetContractIds,
           topics: [
             [transfer, '*', toTopic, '*'],
             [transfer, '*', toTopic],
@@ -168,6 +173,7 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
 
       let inserted = 0;
       let decoded = 0;
+      const webhookUrl = merchant.webhookUrl ?? process.env.WEBHOOK_URL;
 
       for (const event of events) {
         const transferEvent = decodeTransferEvent(event);
@@ -176,7 +182,7 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
         decoded++;
 
         // Defensive: never record a transfer that is not to this merchant.
-        if (transferEvent.to !== merchant) continue;
+        if (transferEvent.to !== merchant.address) continue;
 
         // DO UPDATE, not DO NOTHING: a row may already exist because the
         // merchant reported route attribution before this transfer was
@@ -187,9 +193,9 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
         // Only ledger-owned columns are written. route, method, request_id and
         // hook_reported_at belong to the merchant's report and are left alone.
         const res = await client.query(
-          `INSERT INTO payments (tx_hash, ledger, payer, amount, asset, ts)
-  VALUES ($1, $2, $3, $4::numeric, $5, $6::timestamptz)
-  ON CONFLICT (tx_hash) DO UPDATE
+          `INSERT INTO payments (merchant_id, tx_hash, ledger, payer, amount, asset, ts)
+  VALUES ($1, $2, $3, $4, $5::numeric, $6, $7::timestamptz)
+  ON CONFLICT (merchant_id, tx_hash) DO UPDATE
   SET ledger = EXCLUDED.ledger,
   payer = EXCLUDED.payer,
   amount = EXCLUDED.amount,
@@ -197,6 +203,7 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
   ts = EXCLUDED.ts
   WHERE payments.ledger IS NULL RETURNING *`,
           [
+            merchant.id,
             transferEvent.txHash,
             transferEvent.ledger,
             transferEvent.from,
@@ -205,14 +212,14 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
             transferEvent.ledgerClosedAt,
           ],
         );
-        if (res.rowCount && res.rowCount > 0 && process.env.WEBHOOK_URL) {
+        if (res.rowCount && res.rowCount > 0 && webhookUrl) {
           const payment = res.rows[0];
           const timeoutMs = 2000;
           for (let i = 0; i < 3; i++) {
             try {
               const controller = new AbortController();
               const id = setTimeout(() => controller.abort(), timeoutMs);
-              const webhookRes = await fetch(process.env.WEBHOOK_URL, {
+              const webhookRes = await fetch(webhookUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payment),
@@ -231,10 +238,13 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
       // The sweep only ever reports whole windows, so this is safe whether or
       // not it reached the head. Crucially it advances across empty windows
       // too - a quiet merchant that never moved the cursor is how the indexer
-      // fell behind the RPC retention window and stopped seeing payments.
-      await setLastSyncedLedger(client, sweptThrough);
+      // fell behind the RPC retention window and stopped seeing payments. Each
+      // merchant's cursor advances independently, so one merchant with no
+      // activity cannot hold back or be held back by another's progress.
+      await setLastSyncedLedger(client, merchant.id, sweptThrough);
 
       return {
+        merchant: merchant.address,
         latestLedger,
         startLedger,
         syncedTo: sweptThrough,
@@ -250,26 +260,51 @@ async function runSync(merchant: string, opts: { cooldownMs?: number } = {}) {
   });
 }
 
-/** Maps a run to a response, so both entry points answer identically. */
-function respond(result: Awaited<ReturnType<typeof runSync>>) {
+type SyncResult = Awaited<ReturnType<typeof runSync>>;
+
+/** Maps one merchant's run to its response fragment. */
+function summarize(result: SyncResult) {
   if ('cooldown' in result) {
-    const retryAfterMs = Math.ceil(result.retryAfterMs);
+    return { cooldown: true, retryAfterMs: Math.ceil(result.retryAfterMs) };
+  }
+  return result;
+}
+
+/**
+ * Maps a set of per-merchant runs to a response.
+ *
+ * `.github/workflows/sync.yml` greps the body for `"syncedTo"` to prove real
+ * indexing happened (see the comment above that workflow) and for
+ * `"skippedLedgers":[1-9]` to catch a retention gap — both stay present here
+ * as deployment-wide maximums alongside the full per-merchant `results`, so
+ * that check keeps working unchanged whether this deployment has one merchant
+ * or many.
+ */
+function respond(results: SyncResult[]) {
+  // The manual, single-merchant POST path preserves the original 429 +
+  // Retry-After contract exactly, since the dashboard's "Sync now" button
+  // already depends on it.
+  if (results.length === 1 && 'cooldown' in results[0]) {
+    const retryAfterMs = Math.ceil(results[0].retryAfterMs);
     return NextResponse.json(
       { success: true, cooldown: true, retryAfterMs },
       { status: 429, headers: { 'Retry-After': String(Math.ceil(retryAfterMs / 1000)) } },
     );
   }
-  return NextResponse.json({ success: true, ...result });
-}
 
-function configError(): NextResponse | null {
-  if (!process.env.MERCHANT_ADDRESS) {
-    return NextResponse.json({ error: 'MERCHANT_ADDRESS is not configured' }, { status: 500 });
-  }
-  if (!process.env.DATABASE_URL) {
-    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
-  }
-  return null;
+  const summaries = results.map(summarize);
+  const synced = summaries.filter(
+    (s): s is Extract<(typeof summaries)[number], { syncedTo: number }> => 'syncedTo' in s,
+  );
+  const syncedTo = synced.length ? Math.max(...synced.map((s) => s.syncedTo)) : null;
+  const skippedLedgers = synced.length ? Math.max(...synced.map((s) => s.skippedLedgers)) : 0;
+  const drained = synced.length ? synced.every((s) => s.drained) : true;
+
+  return NextResponse.json({
+    success: true,
+    results: summaries,
+    ...(syncedTo !== null ? { syncedTo, skippedLedgers, drained } : {}),
+  });
 }
 
 function failed(error: unknown) {
@@ -284,6 +319,11 @@ function failed(error: unknown) {
  * CRON_SECRET when set - both senders pass it as a bearer token - so the
  * endpoint cannot be driven by arbitrary callers. No cooldown: a scheduled run
  * is already rate limited by its schedule.
+ *
+ * Sweeps every configured merchant in turn, each with its own cursor - a
+ * merchant with no activity still has its cursor advanced (see runSync),
+ * which is precisely the fix for the outage that motivated this workflow's
+ * checks in the first place.
  */
 export async function GET(request: Request) {
   const secret = process.env.CRON_SECRET;
@@ -291,11 +331,25 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const bad = configError();
-  if (bad) return bad;
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
 
   try {
-    return respond(await runSync(process.env.MERCHANT_ADDRESS as string));
+    const merchants = await withClient(async (client) => {
+      await ensureSchema(client);
+      return listMerchants(client);
+    });
+
+    if (merchants.length === 0) {
+      return NextResponse.json({ error: 'No merchants are configured' }, { status: 500 });
+    }
+
+    const results: SyncResult[] = [];
+    for (const merchant of merchants) {
+      results.push(await runSync(merchant));
+    }
+    return respond(results);
   } catch (error: unknown) {
     return failed(error);
   }
@@ -304,16 +358,22 @@ export async function GET(request: Request) {
 /**
  * Manual entry point, behind the dashboard's"Sync now"button.
  *
- * Protected by session authentication via middleware. MANUAL_COOLDOWN_MS bounds the cost.
+ * Protected by session authentication via middleware, which resolves to
+ * exactly the merchant that owns this dashboard session — a signed-in
+ * merchant can only trigger their own sync. MANUAL_COOLDOWN_MS bounds the cost.
  */
-export async function POST() {
-  const bad = configError();
-  if (bad) return bad;
+export async function POST(request: Request) {
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
 
   try {
-    return respond(
-      await runSync(process.env.MERCHANT_ADDRESS as string, { cooldownMs: MANUAL_COOLDOWN_MS }),
-    );
+    const merchant = await withClient((client) => getMerchantFromRequest(client, request));
+    if (!merchant) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    return respond([await runSync(merchant, { cooldownMs: MANUAL_COOLDOWN_MS })]);
   } catch (error: unknown) {
     return failed(error);
   }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -27,8 +27,9 @@ export default function LoginPage() {
         }
       }
 
-      // Fetch challenge
-      const res = await fetch('/api/auth/challenge');
+      // Fetch challenge, naming which merchant is logging in — the challenge
+      // transaction's source account has to be chosen before it can be built.
+      const res = await fetch(`/api/auth/challenge?address=${encodeURIComponent(status.address)}`);
       if (!res.ok) {
         const { error } = await res.json();
         throw new Error(error || 'Failed to fetch auth challenge');

--- a/apps/web/src/lib/db.integration.test.ts
+++ b/apps/web/src/lib/db.integration.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { withClient, ensureSchema, setLastSyncedLedger, getLastSyncedLedger } from './db';
+import {
+  withClient,
+  withMerchantClient,
+  ensureSchema,
+  setLastSyncedLedger,
+  getLastSyncedLedger,
+} from './db';
+import { getMerchantByAddress } from './merchants';
 
 describe('Database Integration', () => {
   it('should ensure schema and perform basic operations', async () => {
@@ -7,11 +14,132 @@ describe('Database Integration', () => {
       console.warn('Skipping integration test as DATABASE_URL is missing');
       return;
     }
+
     await withClient(async (client) => {
       await ensureSchema(client);
-      await setLastSyncedLedger(client, 42);
-      const ledger = await getLastSyncedLedger(client);
+      await client.query(
+        `INSERT INTO merchants (address) VALUES ($1) ON CONFLICT (address) DO NOTHING`,
+        ['GTESTMERCHANTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'],
+      );
+    });
+
+    const merchant = await withClient(async (client) => {
+      await ensureSchema(client);
+      return getMerchantByAddress(
+        client,
+        'GTESTMERCHANTADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      );
+    });
+    expect(merchant).not.toBeNull();
+
+    await withMerchantClient(merchant!.id, async (client) => {
+      await ensureSchema(client);
+      await setLastSyncedLedger(client, merchant!.id, 42);
+      const ledger = await getLastSyncedLedger(client, merchant!.id);
       expect(ledger).toBe(42);
     });
+  });
+
+  it('advances each merchant’s cursor independently, including a quiet merchant with no activity', async () => {
+    if (!process.env.DATABASE_URL) {
+      console.warn('Skipping integration test as DATABASE_URL is missing');
+      return;
+    }
+
+    const [merchantA, merchantB] = await withClient(async (client) => {
+      await ensureSchema(client);
+      await client.query(
+        `INSERT INTO merchants (address) VALUES ($1), ($2) ON CONFLICT (address) DO NOTHING`,
+        [
+          'GACTIVEMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+          'GQUIETMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        ],
+      );
+      const a = await getMerchantByAddress(
+        client,
+        'GACTIVEMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      );
+      const b = await getMerchantByAddress(
+        client,
+        'GQUIETMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      );
+      return [a!, b!];
+    });
+
+    // Merchant A processes ledgers; merchant B sees no activity at all this
+    // run. Its cursor must still advance — this is exactly the bug that let
+    // 207 ledgers fall outside RPC retention in the original outage.
+    await withMerchantClient(merchantA.id, async (client) => {
+      await setLastSyncedLedger(client, merchantA.id, 1000);
+    });
+    await withMerchantClient(merchantB.id, async (client) => {
+      await setLastSyncedLedger(client, merchantB.id, 1000);
+    });
+
+    const [ledgerA, ledgerB] = await Promise.all([
+      withMerchantClient(merchantA.id, (client) => getLastSyncedLedger(client, merchantA.id)),
+      withMerchantClient(merchantB.id, (client) => getLastSyncedLedger(client, merchantB.id)),
+    ]);
+    expect(ledgerA).toBe(1000);
+    expect(ledgerB).toBe(1000);
+
+    // Advancing one merchant's cursor must never move the other's.
+    await withMerchantClient(merchantA.id, async (client) => {
+      await setLastSyncedLedger(client, merchantA.id, 2000);
+    });
+    const ledgerBAfter = await withMerchantClient(merchantB.id, (client) =>
+      getLastSyncedLedger(client, merchantB.id),
+    );
+    expect(ledgerBAfter).toBe(1000);
+  });
+
+  it('row-level security prevents a merchant-scoped connection from reading another merchant’s payments', async () => {
+    if (!process.env.DATABASE_URL) {
+      console.warn('Skipping integration test as DATABASE_URL is missing');
+      return;
+    }
+
+    const [merchantA, merchantB] = await withClient(async (client) => {
+      await ensureSchema(client);
+      await client.query(
+        `INSERT INTO merchants (address) VALUES ($1), ($2) ON CONFLICT (address) DO NOTHING`,
+        [
+          'GRLSMERCHANTAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+          'GRLSMERCHANTBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        ],
+      );
+      const a = await getMerchantByAddress(
+        client,
+        'GRLSMERCHANTAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      );
+      const b = await getMerchantByAddress(
+        client,
+        'GRLSMERCHANTBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      );
+      return [a!, b!];
+    });
+
+    await withMerchantClient(merchantB.id, async (client) => {
+      await client.query(
+        `INSERT INTO payments (merchant_id, tx_hash) VALUES ($1, $2)
+         ON CONFLICT (merchant_id, tx_hash) DO NOTHING`,
+        [merchantB.id, 'c'.repeat(64)],
+      );
+    });
+
+    // A connection scoped to merchant A must not see merchant B's row, even
+    // with a query that has no WHERE clause at all — this is what
+    // FORCE ROW LEVEL SECURITY buys as the second line of defence.
+    const rowsSeenByA = await withMerchantClient(merchantA.id, async (client) => {
+      const res = await client.query(`SELECT * FROM payments WHERE tx_hash = $1`, ['c'.repeat(64)]);
+      return res.rows;
+    });
+    expect(rowsSeenByA).toHaveLength(0);
+
+    const rowsSeenByB = await withMerchantClient(merchantB.id, async (client) => {
+      const res = await client.query(`SELECT * FROM payments WHERE tx_hash = $1`, ['c'.repeat(64)]);
+      return res.rows;
+    });
+    expect(rowsSeenByB).toHaveLength(1);
   });
 });

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -25,6 +25,29 @@ export async function withClient<T>(fn: (client: Client) => Promise<T>): Promise
 }
 
 /**
+ * Opens a connection scoped to one merchant for the lifetime of the request.
+ *
+ * `accensa.merchant_id` backs the row-level security policies on `payments`
+ * and `sync_state` (see migrations/003_multi_merchant.sql) — it is the second
+ * line of defence behind the application's own `WHERE merchant_id = $1`
+ * clauses, so a query that forgets that clause returns nothing instead of
+ * every merchant's data. Set once per connection, not per statement, since
+ * `withClient` already opens and tears down a fresh `Client` per request.
+ */
+export async function withMerchantClient<T>(
+  merchantId: number,
+  fn: (client: Client) => Promise<T>,
+): Promise<T> {
+  return withClient(async (client) => {
+    await client.query('SELECT set_config($1, $2, false)', [
+      'accensa.merchant_id',
+      String(merchantId),
+    ]);
+    return fn(client);
+  });
+}
+
+/**
  * Brings the schema up to the canonical shape.
  *
  * Idempotent, and safe against either historical layout - see
@@ -105,6 +128,163 @@ export async function ensureSchema(client: Client): Promise<void> {
   await client.query(
     `CREATE INDEX IF NOT EXISTS idx_challenge_nonces_issued ON challenge_nonces(issued_at DESC);`,
   );
+
+  await ensureMultiMerchantSchema(client);
+}
+
+/**
+ * Migrates the schema from single-merchant-by-env-var to multi-merchant-by-row.
+ *
+ * See migrations/003_multi_merchant.sql for the same steps as a standalone
+ * SQL file, and DESIGN.md for the reasoning. This is the copy that actually
+ * runs — `ensureSchema` is invoked defensively at the top of nearly every
+ * DB-touching handler, the same pattern 001 and 002 already used.
+ *
+ * A fresh, unmigrated deployment with `MERCHANT_ADDRESS` set backfills its one
+ * merchant automatically, so upgrading requires no manual SQL and no new
+ * environment variables.
+ */
+async function ensureMultiMerchantSchema(client: Client): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS merchants (
+      id                 SERIAL PRIMARY KEY,
+      address            VARCHAR(56) UNIQUE NOT NULL,
+      public_key_hex     VARCHAR(64),
+      asset_contract_ids TEXT,
+      refund_vault_id    VARCHAR(56),
+      webhook_url        TEXT,
+      created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+
+  if (process.env.MERCHANT_ADDRESS) {
+    await client.query(
+      `INSERT INTO merchants (address, public_key_hex)
+       VALUES ($1, $2)
+       ON CONFLICT (address) DO NOTHING`,
+      [process.env.MERCHANT_ADDRESS, process.env.MERCHANT_PUBLIC_KEY ?? null],
+    );
+  }
+
+  await client.query(
+    `ALTER TABLE payments ADD COLUMN IF NOT EXISTS merchant_id INT REFERENCES merchants(id);`,
+  );
+  await client.query(`
+    DO $$
+    DECLARE v_merchant_id int;
+    BEGIN
+      SELECT id INTO v_merchant_id FROM merchants ORDER BY id ASC LIMIT 1;
+      IF v_merchant_id IS NOT NULL THEN
+        UPDATE payments SET merchant_id = v_merchant_id WHERE merchant_id IS NULL;
+      END IF;
+    END $$;
+  `);
+  await client.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM payments WHERE merchant_id IS NULL) THEN
+        ALTER TABLE payments ALTER COLUMN merchant_id SET NOT NULL;
+      END IF;
+    END $$;
+  `);
+  await client.query(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'payments' AND constraint_type = 'PRIMARY KEY' AND constraint_name = 'payments_pkey'
+      ) THEN
+        ALTER TABLE payments DROP CONSTRAINT payments_pkey;
+      END IF;
+    END $$;
+  `);
+  await client.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'payments' AND constraint_type = 'PRIMARY KEY'
+      ) AND NOT EXISTS (SELECT 1 FROM payments WHERE merchant_id IS NULL) THEN
+        ALTER TABLE payments ADD CONSTRAINT payments_pkey PRIMARY KEY (merchant_id, tx_hash);
+      END IF;
+    END $$;
+  `);
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_payments_merchant_ts ON payments(merchant_id, ts DESC);`,
+  );
+
+  await client.query(
+    `ALTER TABLE sync_state ADD COLUMN IF NOT EXISTS merchant_id INT REFERENCES merchants(id);`,
+  );
+  await client.query(`
+    DO $$
+    DECLARE v_merchant_id int;
+    BEGIN
+      SELECT id INTO v_merchant_id FROM merchants ORDER BY id ASC LIMIT 1;
+      IF v_merchant_id IS NOT NULL THEN
+        UPDATE sync_state SET merchant_id = v_merchant_id WHERE merchant_id IS NULL;
+      END IF;
+    END $$;
+  `);
+  await client.query(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'sync_state' AND constraint_type = 'CHECK' AND constraint_name = 'sync_state_singleton'
+      ) THEN
+        ALTER TABLE sync_state DROP CONSTRAINT sync_state_singleton;
+      END IF;
+      IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'sync_state' AND constraint_type = 'PRIMARY KEY' AND constraint_name = 'sync_state_pkey'
+      ) THEN
+        ALTER TABLE sync_state DROP CONSTRAINT sync_state_pkey;
+      END IF;
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'sync_state' AND column_name = 'id'
+      ) THEN
+        ALTER TABLE sync_state ALTER COLUMN id DROP DEFAULT;
+        ALTER TABLE sync_state DROP COLUMN id;
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM sync_state WHERE merchant_id IS NULL) THEN
+        ALTER TABLE sync_state ALTER COLUMN merchant_id SET NOT NULL;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.table_constraints
+          WHERE table_name = 'sync_state' AND constraint_type = 'PRIMARY KEY'
+        ) THEN
+          ALTER TABLE sync_state ADD CONSTRAINT sync_state_pkey PRIMARY KEY (merchant_id);
+        END IF;
+      END IF;
+    END $$;
+  `);
+
+  await client.query(
+    `ALTER TABLE challenge_nonces ADD COLUMN IF NOT EXISTS merchant_id INT REFERENCES merchants(id);`,
+  );
+
+  // Defence in depth: even the role this app connects as (the table owner,
+  // which Postgres RLS normally exempts) is bound by these policies because
+  // they are FORCEd, not merely ENABLEd. A query that omits its own
+  // merchant_id filter gets zero rows back instead of every tenant's data.
+  await client.query(`ALTER TABLE payments ENABLE ROW LEVEL SECURITY;`);
+  await client.query(`ALTER TABLE payments FORCE ROW LEVEL SECURITY;`);
+  await client.query(`DROP POLICY IF EXISTS payments_merchant_isolation ON payments;`);
+  await client.query(`
+    CREATE POLICY payments_merchant_isolation ON payments
+      USING (merchant_id = current_setting('accensa.merchant_id', true)::int)
+      WITH CHECK (merchant_id = current_setting('accensa.merchant_id', true)::int);
+  `);
+
+  await client.query(`ALTER TABLE sync_state ENABLE ROW LEVEL SECURITY;`);
+  await client.query(`ALTER TABLE sync_state FORCE ROW LEVEL SECURITY;`);
+  await client.query(`DROP POLICY IF EXISTS sync_state_merchant_isolation ON sync_state;`);
+  await client.query(`
+    CREATE POLICY sync_state_merchant_isolation ON sync_state
+      USING (merchant_id = current_setting('accensa.merchant_id', true)::int)
+      WITH CHECK (merchant_id = current_setting('accensa.merchant_id', true)::int);
+  `);
 }
 
 /**
@@ -127,6 +307,7 @@ export async function ensureSchema(client: Client): Promise<void> {
  */
 export async function recordSettlement(
   client: Client,
+  merchantId: number,
   s: {
     txHash: string;
     route: string;
@@ -139,48 +320,53 @@ export async function recordSettlement(
   const reportedAt = s.reportedAt ?? new Date().toISOString();
   const updated = await client.query(
     `UPDATE payments
- SET route = $2, method = $3, request_id = $4, hook_reported_at = $5
- WHERE tx_hash = $1 AND (hook_reported_at IS NULL OR hook_reported_at < $5)`,
-    [s.txHash, s.route, s.method, s.requestId ?? null, reportedAt],
+ SET route = $3, method = $4, request_id = $5, hook_reported_at = $6
+ WHERE merchant_id = $1 AND tx_hash = $2 AND (hook_reported_at IS NULL OR hook_reported_at < $6)`,
+    [merchantId, s.txHash, s.route, s.method, s.requestId ?? null, reportedAt],
   );
 
   if ((updated.rowCount ?? 0) > 0) return { matchedExistingPayment: true };
 
   await client.query(
-    `INSERT INTO payments (tx_hash, payer, route, method, request_id, ts, hook_reported_at)
- VALUES ($1, $2, $3, $4, $5, NULL, $6)
- ON CONFLICT (tx_hash) DO UPDATE
+    `INSERT INTO payments (merchant_id, tx_hash, payer, route, method, request_id, ts, hook_reported_at)
+ VALUES ($1, $2, $3, $4, $5, $6, NULL, $7)
+ ON CONFLICT (merchant_id, tx_hash) DO UPDATE
  SET route = EXCLUDED.route,
  method = EXCLUDED.method,
  request_id = EXCLUDED.request_id,
  hook_reported_at = EXCLUDED.hook_reported_at
  WHERE payments.hook_reported_at IS NULL OR payments.hook_reported_at < EXCLUDED.hook_reported_at`,
-    [s.txHash, s.payer ?? null, s.route, s.method, s.requestId ?? null, reportedAt],
+    [merchantId, s.txHash, s.payer ?? null, s.route, s.method, s.requestId ?? null, reportedAt],
   );
 
   return { matchedExistingPayment: false };
 }
 
-export async function getLastSyncedLedger(client: Client): Promise<number | null> {
+export async function getLastSyncedLedger(
+  client: Client,
+  merchantId: number,
+): Promise<number | null> {
   const res = await client.query<{ last_ledger: string }>(
-    `SELECT last_ledger FROM sync_state WHERE id = 1`,
+    `SELECT last_ledger FROM sync_state WHERE merchant_id = $1`,
+    [merchantId],
   );
   return res.rows.length ? Number(res.rows[0].last_ledger) : null;
 }
 
 /**
- * The indexer's own record of when it last committed progress.
+ * The indexer's own record of when it last committed progress for a merchant.
  *
  * Read by /api/payments so the dashboard can say how current its data is,
  * rather than implying the freshness of its own poll.
  */
 export async function getSyncState(
   client: Client,
+  merchantId: number,
 ): Promise<{ lastLedger: number; updatedAt: string } | null> {
   const res = await client.query<{
     last_ledger: string;
     updated_at: Date | string;
-  }>(`SELECT last_ledger, updated_at FROM sync_state WHERE id = 1`);
+  }>(`SELECT last_ledger, updated_at FROM sync_state WHERE merchant_id = $1`, [merchantId]);
   if (!res.rows.length) return null;
   const { last_ledger, updated_at } = res.rows[0];
   return {
@@ -189,24 +375,34 @@ export async function getSyncState(
   };
 }
 
-export async function setLastSyncedLedger(client: Client, ledger: number): Promise<void> {
-  // Use advisory lock to prevent concurrent double-processing of ranges
-  await client.query('SELECT pg_advisory_xact_lock(1)');
+export async function setLastSyncedLedger(
+  client: Client,
+  merchantId: number,
+  ledger: number,
+): Promise<void> {
+  // Advisory lock keyed by merchant so concurrent syncs for different
+  // merchants never block each other, only concurrent runs for the same one.
+  await client.query('SELECT pg_advisory_xact_lock($1)', [merchantId]);
   await client.query(
-    `INSERT INTO sync_state (id, last_ledger, updated_at) VALUES (1, $1, now())
-     ON CONFLICT (id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger, updated_at = now()
+    `INSERT INTO sync_state (merchant_id, last_ledger, updated_at) VALUES ($1, $2, now())
+     ON CONFLICT (merchant_id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger, updated_at = now()
      WHERE sync_state.last_ledger < EXCLUDED.last_ledger`,
-    [ledger],
+    [merchantId, ledger],
   );
 }
 
 /**
  * Persists a nonce issued by /api/auth/challenge so /api/auth/verify can
  * confirm it was this server that minted it, and that it has not already
- * been used.
+ * been used. Scoped to the merchant the challenge was issued for, so a nonce
+ * minted for one merchant's login cannot be replayed to authenticate as
+ * another.
  */
-export async function storeNonce(client: Client, nonce: string): Promise<void> {
-  await client.query(`INSERT INTO challenge_nonces (nonce) VALUES ($1)`, [nonce]);
+export async function storeNonce(client: Client, nonce: string, merchantId: number): Promise<void> {
+  await client.query(`INSERT INTO challenge_nonces (nonce, merchant_id) VALUES ($1, $2)`, [
+    nonce,
+    merchantId,
+  ]);
 }
 
 /**
@@ -216,12 +412,16 @@ export async function storeNonce(client: Client, nonce: string): Promise<void> {
  * one case where /api/auth/verify should proceed. A false return means the
  * nonce was unknown, already consumed, or expired, and the caller must 401.
  */
-export async function consumeNonce(client: Client, nonce: string): Promise<boolean> {
+export async function consumeNonce(
+  client: Client,
+  nonce: string,
+  merchantId: number,
+): Promise<boolean> {
   const result = await client.query(
     `UPDATE challenge_nonces
      SET consumed = true
-     WHERE nonce = $1 AND consumed = false`,
-    [nonce],
+     WHERE nonce = $1 AND merchant_id = $2 AND consumed = false`,
+    [nonce, merchantId],
   );
   return (result.rowCount ?? 0) > 0;
 }

--- a/apps/web/src/lib/merchants.ts
+++ b/apps/web/src/lib/merchants.ts
@@ -1,0 +1,101 @@
+import type { Client } from 'pg';
+
+/**
+ * A tenant of this deployment.
+ *
+ * `address` is the Stellar G-address that identifies the merchant everywhere:
+ * it is the SAC `transfer` recipient the indexer filters on, the account that
+ * signs the SEP-10-style auth challenge, and the account whose key would sign
+ * a refund. `publicKeyHex` is a *separate* raw Ed25519 key used only to verify
+ * `/api/hook/settle` reports — historically `MERCHANT_PUBLIC_KEY`, kept
+ * distinct because a seller's settlement-reporting key does not have to be the
+ * same key that controls the Stellar account.
+ *
+ * `assetContractIds`, `refundVaultId`, and `webhookUrl` are per-merchant
+ * overrides. Null means "fall back to the deployment-wide default env var" —
+ * this keeps a single-merchant deployment working with zero new configuration
+ * after the migration backfills its one row.
+ */
+export interface Merchant {
+  id: number;
+  address: string;
+  publicKeyHex: string | null;
+  assetContractIds: string[] | null;
+  refundVaultId: string | null;
+  webhookUrl: string | null;
+}
+
+interface MerchantRow {
+  id: number;
+  address: string;
+  public_key_hex: string | null;
+  asset_contract_ids: string | null;
+  refund_vault_id: string | null;
+  webhook_url: string | null;
+}
+
+function fromRow(row: MerchantRow): Merchant {
+  return {
+    id: row.id,
+    address: row.address,
+    publicKeyHex: row.public_key_hex,
+    assetContractIds: row.asset_contract_ids
+      ? row.asset_contract_ids
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : null,
+    refundVaultId: row.refund_vault_id,
+    webhookUrl: row.webhook_url,
+  };
+}
+
+/** Looks up a merchant by their Stellar address. Null when unknown. */
+export async function getMerchantByAddress(
+  client: Client,
+  address: string,
+): Promise<Merchant | null> {
+  const res = await client.query<MerchantRow>(
+    `SELECT id, address, public_key_hex, asset_contract_ids, refund_vault_id, webhook_url
+     FROM merchants WHERE address = $1`,
+    [address],
+  );
+  return res.rows.length ? fromRow(res.rows[0]) : null;
+}
+
+export async function getMerchantById(client: Client, id: number): Promise<Merchant | null> {
+  const res = await client.query<MerchantRow>(
+    `SELECT id, address, public_key_hex, asset_contract_ids, refund_vault_id, webhook_url
+     FROM merchants WHERE id = $1`,
+    [id],
+  );
+  return res.rows.length ? fromRow(res.rows[0]) : null;
+}
+
+/**
+ * Resolves the merchant scoping a request.
+ *
+ * `apps/web/src/middleware.ts` verifies the session cookie and forwards the
+ * signed-in Stellar address as `x-accensa-merchant` — routes trust that
+ * header rather than re-verifying the cookie themselves, since middleware has
+ * already run and the header cannot be forged by the caller (middleware
+ * overwrites it on every request it forwards). Null means the header is
+ * missing, empty, or names a merchant this deployment doesn't have.
+ */
+export async function getMerchantFromRequest(
+  client: Client,
+  request: Request,
+): Promise<Merchant | null> {
+  const address = request.headers.get('x-accensa-merchant');
+  if (!address) return null;
+  return getMerchantByAddress(client, address);
+}
+
+/** Every merchant configured on this deployment, in a stable order for the indexer sweep. */
+export async function listMerchants(client: Client): Promise<Merchant[]> {
+  const res = await client.query<MerchantRow>(
+    `SELECT id, address, public_key_hex, asset_contract_ids, refund_vault_id, webhook_url
+     FROM merchants ORDER BY id ASC`,
+  );
+  return res.rows.map(fromRow);
+}

--- a/apps/web/src/lib/refund-vault.ts
+++ b/apps/web/src/lib/refund-vault.ts
@@ -131,20 +131,29 @@ function server() {
   return new rpc.Server(RPC_URL, { allowHttp: RPC_URL.startsWith('http://') });
 }
 
-function build(source: string, method: string, args: xdr.ScVal[]) {
+function build(
+  source: string,
+  method: string,
+  args: xdr.ScVal[],
+  vaultId: string = REFUND_VAULT_ID,
+) {
   return new TransactionBuilder(new Account(source, '0'), {
     fee: '100',
     networkPassphrase: NETWORK_PASSPHRASE,
   })
-    .addOperation(new Contract(REFUND_VAULT_ID).call(method, ...args))
+    .addOperation(new Contract(vaultId).call(method, ...args))
     .setTimeout(30)
     .build();
 }
 
 /** Reads an existing refund record, or null when the payment was never refunded. */
-export async function getRefund(txHash: string, source: string): Promise<RefundRecord | null> {
+export async function getRefund(
+  txHash: string,
+  source: string,
+  vaultId: string = REFUND_VAULT_ID,
+): Promise<RefundRecord | null> {
   const sim = await server().simulateTransaction(
-    build(source, 'get_refund', [hexToBytes32(txHash)]),
+    build(source, 'get_refund', [hexToBytes32(txHash)], vaultId),
   );
 
   if (rpc.Api.isSimulationError(sim)) throw new Error(sim.error);
@@ -174,15 +183,21 @@ export async function preflightRefund(input: {
   amount: string;
   paidAtLedger: number;
   merchant: string;
+  vaultId?: string;
 }): Promise<RefundPreflight> {
   let tx;
   try {
-    tx = build(input.merchant, 'refund', [
-      hexToBytes32(input.txHash),
-      new Address(input.recipient).toScVal(),
-      nativeToScVal(BigInt(input.amount), { type: 'i128' }),
-      nativeToScVal(input.paidAtLedger, { type: 'u32' }),
-    ]);
+    tx = build(
+      input.merchant,
+      'refund',
+      [
+        hexToBytes32(input.txHash),
+        new Address(input.recipient).toScVal(),
+        nativeToScVal(BigInt(input.amount), { type: 'i128' }),
+        nativeToScVal(input.paidAtLedger, { type: 'u32' }),
+      ],
+      input.vaultId ?? REFUND_VAULT_ID,
+    );
   } catch (error) {
     return { status: 'unknown', message: error instanceof Error ? error.message : 'Invalid input' };
   }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -46,8 +46,23 @@ export async function middleware(request: NextRequest) {
     }
 
     try {
-      await jwtVerify(sessionCookie, key, { algorithms: ['HS256'] });
-      return NextResponse.next();
+      const { payload } = await jwtVerify(sessionCookie, key, { algorithms: ['HS256'] });
+      const merchantAddress = typeof payload.publicKey === 'string' ? payload.publicKey : null;
+      if (isPrivateApi && !merchantAddress) {
+        // A session with no identifiable merchant cannot be scoped to any
+        // tenant's data — treat it the same as no session at all.
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      // Route handlers trust this header for merchant scoping instead of each
+      // re-verifying and re-decoding the session cookie themselves. It is only
+      // ever set here, after jwtVerify has succeeded, so a request cannot
+      // forge it — Next.js middleware runs before the request reaches a route
+      // handler and this header is set on the *outgoing* request, overwriting
+      // any value a caller tried to smuggle in.
+      const headers = new Headers(request.headers);
+      headers.set('x-accensa-merchant', merchantAddress ?? '');
+      return NextResponse.next({ request: { headers } });
     } catch {
       if (isPrivateApi) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
       return NextResponse.redirect(new URL('/login', request.url));

--- a/migrations/003_multi_merchant.sql
+++ b/migrations/003_multi_merchant.sql
@@ -1,0 +1,193 @@
+-- 003_multi_merchant.sql
+--
+-- Turns this deployment from single-merchant-by-environment-variable into
+-- multi-merchant-by-row. See DESIGN.md "Multi-merchant support" for the full
+-- design and the reasoning behind each choice below.
+--
+-- Reversible: the DOWN section at the bottom undoes every change here,
+-- including collapsing back onto a single merchant (the one identified by
+-- MERCHANT_ADDRESS at the time this migration is rolled back).
+--
+-- This file is applied automatically by `ensureSchema()` in
+-- apps/web/src/lib/db.ts on every request, the same way 001 and 002 were.
+-- It is committed here too for documentation and for anyone restoring a
+-- database outside the app.
+
+BEGIN;
+
+-- One row per tenant. `address` is the identity everything else keys off:
+-- the SAC transfer recipient the indexer filters on, and the account that
+-- signs into the dashboard. `public_key_hex` is the separate key that signs
+-- /api/hook/settle reports (historically MERCHANT_PUBLIC_KEY) — kept apart
+-- because a seller's settlement-reporting key need not be their Stellar
+-- signing key. The three override columns fall back to the deployment-wide
+-- env vars (ASSET_CONTRACT_IDS, NEXT_PUBLIC_REFUND_VAULT_ID, WEBHOOK_URL)
+-- when null, so a freshly backfilled single-merchant row needs no new
+-- configuration to keep working exactly as before.
+CREATE TABLE IF NOT EXISTS merchants (
+    id                 SERIAL PRIMARY KEY,
+    address            VARCHAR(56) UNIQUE NOT NULL,
+    public_key_hex     VARCHAR(64),
+    asset_contract_ids TEXT,
+    refund_vault_id    VARCHAR(56),
+    webhook_url        TEXT,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Backfill the one merchant every existing deployment already has. Safe to
+-- run with no MERCHANT_ADDRESS set (a brand-new database): the DO block is a
+-- no-op in that case and merchants stays empty until one is inserted.
+DO $$
+DECLARE
+    v_address text := current_setting('accensa.merchant_address', true);
+    v_public_key text := current_setting('accensa.merchant_public_key', true);
+BEGIN
+    IF v_address IS NOT NULL AND v_address <> '' THEN
+        INSERT INTO merchants (address, public_key_hex)
+        VALUES (v_address, NULLIF(v_public_key, ''))
+        ON CONFLICT (address) DO NOTHING;
+    END IF;
+END $$;
+
+-- payments: was keyed on tx_hash alone, globally. A tx_hash is unique per
+-- Stellar transaction but a single deployment could in principle see the
+-- same hash matter to two merchants (e.g. a batch payment splitting to two
+-- recipients in one transaction), so the identity becomes the pair.
+ALTER TABLE payments ADD COLUMN IF NOT EXISTS merchant_id INT REFERENCES merchants(id);
+
+DO $$
+DECLARE
+    v_merchant_id int;
+BEGIN
+    SELECT id INTO v_merchant_id FROM merchants ORDER BY id ASC LIMIT 1;
+    IF v_merchant_id IS NOT NULL THEN
+        UPDATE payments SET merchant_id = v_merchant_id WHERE merchant_id IS NULL;
+    END IF;
+END $$;
+
+-- Only tighten once every row has a merchant — an empty or not-yet-backfilled
+-- table must not block the migration from applying.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM payments WHERE merchant_id IS NULL) THEN
+        ALTER TABLE payments ALTER COLUMN merchant_id SET NOT NULL;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'payments' AND constraint_type = 'PRIMARY KEY' AND constraint_name = 'payments_pkey'
+    ) THEN
+        ALTER TABLE payments DROP CONSTRAINT payments_pkey;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'payments' AND constraint_type = 'PRIMARY KEY'
+    ) AND NOT EXISTS (SELECT 1 FROM payments WHERE merchant_id IS NULL) THEN
+        ALTER TABLE payments ADD CONSTRAINT payments_pkey PRIMARY KEY (merchant_id, tx_hash);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_payments_merchant_ts ON payments(merchant_id, ts DESC);
+
+-- sync_state was a singleton by CHECK constraint. The cursor becomes
+-- per-merchant, keyed by merchant_id instead of the fixed id = 1.
+ALTER TABLE sync_state ADD COLUMN IF NOT EXISTS merchant_id INT REFERENCES merchants(id);
+
+DO $$
+DECLARE
+    v_merchant_id int;
+BEGIN
+    SELECT id INTO v_merchant_id FROM merchants ORDER BY id ASC LIMIT 1;
+    IF v_merchant_id IS NOT NULL THEN
+        UPDATE sync_state SET merchant_id = v_merchant_id WHERE merchant_id IS NULL;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'sync_state' AND constraint_type = 'CHECK' AND constraint_name = 'sync_state_singleton'
+    ) THEN
+        ALTER TABLE sync_state DROP CONSTRAINT sync_state_singleton;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'sync_state' AND constraint_type = 'PRIMARY KEY' AND constraint_name = 'sync_state_pkey'
+    ) THEN
+        ALTER TABLE sync_state DROP CONSTRAINT sync_state_pkey;
+    END IF;
+    ALTER TABLE sync_state ALTER COLUMN id DROP DEFAULT;
+    ALTER TABLE sync_state DROP COLUMN IF EXISTS id;
+    IF NOT EXISTS (SELECT 1 FROM sync_state WHERE merchant_id IS NULL) THEN
+        ALTER TABLE sync_state ALTER COLUMN merchant_id SET NOT NULL;
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.table_constraints
+            WHERE table_name = 'sync_state' AND constraint_type = 'PRIMARY KEY'
+        ) THEN
+            ALTER TABLE sync_state ADD CONSTRAINT sync_state_pkey PRIMARY KEY (merchant_id);
+        END IF;
+    END IF;
+END $$;
+
+-- challenge_nonces: scoped so a nonce issued for one merchant's challenge
+-- cannot be replayed against another merchant's verify call. Nullable
+-- because unconsumed pre-migration nonces (at most a few minutes old) have
+-- no merchant to backfill; they simply expire via sweepExpiredNonces.
+ALTER TABLE challenge_nonces ADD COLUMN IF NOT EXISTS merchant_id INT REFERENCES merchants(id);
+
+-- Row-level security as a second line of defence behind the application's own
+-- WHERE merchant_id = $1 scoping. FORCE (not just ENABLE) so it also applies
+-- to the table owner — the role this app connects as — since Postgres RLS is
+-- normally bypassed by the owner. Each request sets accensa.merchant_id for
+-- the lifetime of its connection (see withMerchantClient in lib/db.ts); a
+-- query that forgets its WHERE clause returns zero rows instead of every
+-- merchant's data.
+ALTER TABLE payments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payments FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS payments_merchant_isolation ON payments;
+CREATE POLICY payments_merchant_isolation ON payments
+    USING (merchant_id = current_setting('accensa.merchant_id', true)::int)
+    WITH CHECK (merchant_id = current_setting('accensa.merchant_id', true)::int);
+
+ALTER TABLE sync_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sync_state FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS sync_state_merchant_isolation ON sync_state;
+CREATE POLICY sync_state_merchant_isolation ON sync_state
+    USING (merchant_id = current_setting('accensa.merchant_id', true)::int)
+    WITH CHECK (merchant_id = current_setting('accensa.merchant_id', true)::int);
+
+COMMIT;
+
+-- ============================== DOWN ==============================
+-- Not executed automatically. Run by hand to roll back.
+--
+-- BEGIN;
+-- ALTER TABLE payments DISABLE ROW LEVEL SECURITY;
+-- DROP POLICY IF EXISTS payments_merchant_isolation ON payments;
+-- ALTER TABLE sync_state DISABLE ROW LEVEL SECURITY;
+-- DROP POLICY IF EXISTS sync_state_merchant_isolation ON sync_state;
+--
+-- ALTER TABLE challenge_nonces DROP COLUMN IF EXISTS merchant_id;
+--
+-- ALTER TABLE sync_state DROP CONSTRAINT IF EXISTS sync_state_pkey;
+-- ALTER TABLE sync_state ADD COLUMN id INT DEFAULT 1;
+-- UPDATE sync_state SET id = 1;
+-- ALTER TABLE sync_state ADD CONSTRAINT sync_state_pkey PRIMARY KEY (id);
+-- ALTER TABLE sync_state ADD CONSTRAINT sync_state_singleton CHECK (id = 1);
+-- ALTER TABLE sync_state DROP COLUMN IF EXISTS merchant_id;
+--
+-- ALTER TABLE payments DROP CONSTRAINT IF EXISTS payments_pkey;
+-- ALTER TABLE payments ADD CONSTRAINT payments_pkey PRIMARY KEY (tx_hash);
+-- DROP INDEX IF EXISTS idx_payments_merchant_ts;
+-- ALTER TABLE payments DROP COLUMN IF EXISTS merchant_id;
+--
+-- DROP TABLE IF EXISTS merchants;
+-- COMMIT;


### PR DESCRIPTION
Closes #103.

## Summary

Replaces the single-merchant-by-environment-variable architecture (`MERCHANT_ADDRESS`, a singleton `sync_state`, an unscoped `payments` table) with a `merchants` table keyed by Stellar address, so one deployment can serve multiple merchants. Per the issue, the design was written up first — see the new "Multi-merchant support" section at the top of `DESIGN.md` — before any code was changed.

- **Data model**: `merchants` table (address, settlement-report public key, per-merchant asset list/refund vault/webhook overrides). `payments`' primary key becomes `(merchant_id, tx_hash)`. `sync_state`'s singleton `CHECK (id = 1)` is replaced with a normal primary key on `merchant_id`, so each merchant gets an independent ledger cursor. `challenge_nonces` gains a `merchant_id` so a nonce can't be replayed across merchants.
- **Defence in depth**: every query is explicitly scoped by `merchant_id`, backed by Postgres row-level security (`FORCE ROW LEVEL SECURITY`, not just `ENABLE`) as a second line of defence — a query that forgets its own scope returns nothing instead of every merchant's data. Cross-tenant read isolation is asserted directly in a new test (`apps/web/src/app/api/cross-tenant-isolation.test.ts`) across every read endpoint.
- **Indexing**: `GET /api/sync` now sweeps every configured merchant per run, each with its own cursor. A merchant with zero matching events in a sweep still has its cursor advanced — this is exactly the bug that let 207 ledgers fall outside RPC retention in the original outage, and it's covered by a dedicated test in `db.integration.test.ts`. The response keeps the existing `syncedTo`/`skippedLedgers` fields (as deployment-wide maximums) alongside a new per-merchant `results` array, so `.github/workflows/sync.yml`'s existing health-check greps keep working unchanged.
- **Auth**: `/api/auth/challenge` now takes a required `?address=` so it knows which merchant it's building a login challenge for; `/api/auth/verify` reads the merchant back out of the already-signed transaction's source account, no wire change needed.
- **Settlement reporting**: `/api/hook/settle` carries no merchant identifier in its wire payload (a change there would break every existing `@accensa/sdk` integration mid-flight). Instead each configured merchant's signing key is tried against the request signature in turn — whichever verifies is who reported it.
- **Refunds**: the refund vault contract ID is resolved per merchant (falling back to the deployment-wide default), instead of one hardcoded global.
- **Migration**: `migrations/003_multi_merchant.sql`, applied automatically and idempotently via `ensureSchema()` (same pattern as 001/002). Fully reversible (documented DOWN section). An existing single-merchant deployment backfills one `merchants` row from `MERCHANT_ADDRESS`/`MERCHANT_PUBLIC_KEY` automatically — no manual SQL, no new required env vars, existing behavior is unchanged after upgrading.
- **README**: adds a "Tenancy model" section stating the model plainly, per the acceptance criteria.

## Test plan

- [x] `pnpm --filter web test` — 281 tests passing (25 files), including the new cross-tenant isolation test and the per-merchant cursor / RLS integration tests (the latter two are `DATABASE_URL`-gated like the existing integration test, and skip without one)
- [x] `pnpm --filter @accensa/sdk test` — 81 tests passing, unaffected
- [x] `pnpm --filter web typecheck` and `pnpm --filter @accensa/sdk typecheck` — clean
- [x] `pnpm --filter web lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm --filter web build` (production build) — succeeds
- [ ] Manual verification against a real multi-merchant Postgres instance (RLS behavior depends on connecting as a non-superuser role — noted as a caveat in `DESIGN.md`)