### PR TITLE
Wave #94/#95/#96/#97: indexer scheduling decision + sync.yml fixes, multi-asset docs, refund-preflight tests, scratch gitignore

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,19 +5,32 @@ name: Trigger Indexer Sync
 # To achieve a reliable 5-minute interval, this workflow triggers hourly
 # and loops internally with a sleep, keeping the runner alive.
 #
+# The scheduling options (paid Vercel Cron, an external scheduler, a
+# long-running worker, or keeping this approach) are compared in DEPLOYMENT.md
+# under "Indexer scheduling". This file is option 4: keep the loop, fix its
+# specific defects.
+#
 # Required repository secrets:
-#   SYNC_URL      https://accensa-dashboard.vercel.app/api/sync
-#   CRON_SECRET   must match the CRON_SECRET set on the Vercel project
+#   SYNC_URL       https://accensa-dashboard.vercel.app/api/sync
+#   CRON_SECRET    must match the CRON_SECRET set on the Vercel project
+# Optional:
+#   HEARTBEAT_URL  a dead-man's-switch check URL (healthchecks.io, cronitor,
+#                  cron-job.org…). Pinged after every healthy sync and once
+#                  when the job ends. If the pings stop, the monitor alerts —
+#                  this is the only signal that scheduling has ceased entirely,
+#                  the failure mode that cost 207 ledgers.
 
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 * * * *'
 
-# Never let two syncs overlap; the later one wins.
+# Do NOT cancel an in-flight sync when the next hourly trigger (or a manual
+# dispatch) fires. Indexing is idempotent, so an overlap just means one extra
+# run; a cancel mid-flight throws away a run that was doing real work.
 concurrency:
   group: indexer-sync
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -49,29 +62,40 @@ jobs:
         env:
           SYNC_URL: ${{ secrets.SYNC_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          HEARTBEAT_URL: ${{ secrets.HEARTBEAT_URL }}
         run: |
           if [ -z "$SYNC_URL" ]; then
             echo "SYNC_URL secret is not set"; exit 1
           fi
 
-          # Run for 55 minutes to allow 5 minutes for the next hourly job to start
-          END_TIME=$(( $(date +%s) + 3300 ))
+          heartbeat() {
+            [ -n "$HEARTBEAT_URL" ] || return 0
+            curl -fsS --max-time 15 -o /dev/null "$HEARTBEAT_URL$1" \
+              || echo "::warning::heartbeat ping failed (monitor may alert)"
+          }
+
+          # Run for 65 minutes: the window deliberately overlaps the next hourly
+          # trigger. A self-cancel is no longer possible (cancel-in-progress:
+          # false), so the overlap costs one extra idempotent sync and removes
+          # the hour-boundary gap where a dropped trigger left no runner alive.
+          END_TIME=$(( $(date +%s) + 3900 ))
 
           while [ $(date +%s) -lt $END_TIME ]; do
             echo "Triggering sync at $(date)..."
             response=$(curl -sS --max-time 120 -w '\n%{http_code}' \
               -H "Authorization: Bearer $CRON_SECRET" "$SYNC_URL" || echo "curl failed")
-            
+
             body=$(printf '%s' "$response" | sed '$d')
             code=$(printf '%s' "$response" | tail -n1)
 
             echo "HTTP $code"
             echo "$body"
 
+            healthy=1
             if [ "$code" != "200" ]; then
-              echo "::warning::Sync failed with HTTP $code"
+              echo "::warning::Sync failed with HTTP $code"; healthy=0
             elif printf '%s' "$body" | grep -q '"success":false'; then
-              echo "::warning::Sync reported failure"
+              echo "::warning::Sync reported failure"; healthy=0
             elif printf '%s' "$body" | grep -q '"cooldown":true'; then
               echo "Skipped: a sync ran within the cooldown window."
             elif ! printf '%s' "$body" | grep -q '"syncedTo"'; then
@@ -79,6 +103,7 @@ jobs:
               # so there is nothing to be gained by polling it for another hour.
               echo "::error::Reply carries no syncedTo cursor, so no indexing took place." \
                    "The /api/sync route is not running the indexer."
+              heartbeat /fail
               exit 1
             elif printf '%s' "$body" | grep -q '"drained":false'; then
               echo "::warning::Incomplete sync: paging stopped against the time budget."
@@ -91,6 +116,12 @@ jobs:
               echo "::warning::Cursor fell outside RPC retention; $skipped ledgers skipped."
             fi
 
+            [ "$healthy" -eq 1 ] && heartbeat ""
+
             echo "Sleeping for 5 minutes..."
             sleep 300
           done
+
+          # One ping at clean exit so a monitor with a period > the loop length
+          # still sees the job completing on schedule.
+          heartbeat ""

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,13 @@ dist/
 # full copies of the tree.
 .claude/
 
+# Local scratch: PR bodies passed to `gh pr create --body-file`, issue dumps,
+# one-off fix scripts. See CONTRIBUTING.md — keep these under .scratch/ so they
+# never end up tracked at the repo root (body.txt / issues.json did once).
+.scratch/
+/body.txt
+/issues.json
+
 # This is a pnpm workspace; pnpm-lock.yaml is the only lockfile.
 # Stray npm/yarn lockfiles drift from it and change which package manager
 # Vercel detects for a project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,16 @@ We welcome contributions from the community! Whether it's a bug fix, new feature
 5. **Create a new branch** for your feature or bug fix (`git checkout -b feature/my-new-feature` or `bugfix/issue-123`).
 6. **Make your changes** and test them thoroughly.
 
+## Scratch files
+
+Anything that is tooling residue rather than part of the project — a PR body you
+passed to `gh pr create --body-file`, a dump of issue data, a one-off migration
+or fix script — goes under `.scratch/` at the repo root. That directory is
+`.gitignore`d, so it cannot be committed by accident.
+
+`body.txt` and `issues.json` were both tracked at the repo root once. Do not
+re-create that: if you need a file like that, put it in `.scratch/`.
+
 ## Code Style
 
 This project uses [Prettier](https://prettier.io/) for code formatting. Before committing, run:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -65,6 +65,48 @@ are unrecoverable — no later run can reach them. A sync that skipped ledgers t
 way reports `skippedLedgers` in its response and `sync.yml` raises a warning; it
 is the one failure here that cannot be fixed by running the job again.
 
+## Indexer scheduling — the options weighed
+
+The sleep-looping runner in `sync.yml` works, and its diagnostics are the reason
+several silent-failure modes are now caught. But as the production scheduler for
+a component that has already failed silently once, it has real costs: it holds a
+runner for ~55 min/hour doing nothing but sleeping (~660 runner-minutes/day,
+billed as occupied on any non-free plan), and if scheduling stops there are no
+runs, therefore no red runs, therefore no signal.
+
+| Option | Cost | Reliability | Notes |
+| --- | --- | --- | --- |
+| **1. Vercel Cron, paid plan** | Pro is **$20/user/month**; the only gain over Hobby that this project needs is sub-daily cron. | Minute-level schedules, run by Vercel, no runner to keep alive. Still needs external cessation monitoring — a paused project is as silent as a stopped workflow. | Cleanest fit *if* the team is already on Pro for other reasons. Buying Pro solely for cron is poor value at one merchant. |
+| **2. External scheduler** (cron-job.org, Upstash QStash, EventBridge Scheduler) hitting `/api/sync` directly | cron-job.org: **free**. QStash: free ≤ 500 msg/day, then usage-priced. EventBridge Scheduler: ~$0 at this volume. | High. The scheduler is a dedicated, monitored service; most include their own failure alerting. Adds one third-party dependency in the critical path. | `/api/sync` is already a plain authenticated GET, so this is a config change, not a code change. **Recommended** — it removes the runner cost *and* the blind spot, for $0. |
+| **3. Long-running worker** (Railway/Fly/Render process, or a container) | ~$5/month minimum for an always-on small instance. | Most control, most operational surface. **Re-opens the extraction that caused the original outage** — the indexer logic would move out of `apps/web` again. Note that history explicitly if this is proposed. | Only worth it if the indexer grows past what a 60 s function invocation can do. It cannot today. |
+| **4. Keep the loop, fix the defects** | Same ~660 runner-min/day. Free on public repos; on GitHub Team/Enterprise-billed minutes it is the most expensive option here. | Acceptable once the defects below are fixed. | What this repo does today, plus the fixes in this PR. |
+
+**Decision: option 4 now, with the specific defects fixed, and option 2
+(cron-job.org or EventBridge) as the documented migration when the team wants the
+runner cost gone.** Option 2 is strictly better on cost and on the cessation
+blind spot; it is not adopted in this PR only because it needs an account and a
+secret that a maintainer must create, not a code change a contributor can land.
+
+Defects fixed in `sync.yml` in this PR:
+
+- **`cancel-in-progress: true` → `false`.** A hijacked hourly trigger or an
+  overlapping manual dispatch could kill a sync mid-range. Indexing is
+  idempotent so nothing corrupted, but the run was lost.
+- **Hour-boundary gap closed.** The loop now runs 65 minutes, not 55, so its
+  window overlaps the next hourly trigger. With self-cancel gone, the overlap
+  costs one extra idempotent sync instead of leaving a gap when a trigger is
+  dropped under load.
+- **External cessation monitor.** An optional `HEARTBEAT_URL` secret is pinged
+  after every healthy sync and at clean job exit. Point it at a dead-man's
+  switch (healthchecks.io free tier, cronitor, cron-job.org's own monitor) with
+  a grace period of ~90 min. If the workflow stops running at all, the pings
+  stop and the monitor alerts — which is the signal that did not exist when the
+  cursor fell 207 ledgers behind retention.
+
+All of the existing in-loop diagnostics (the 401 assertion, the `syncedTo`
+check, the `drained` / `skippedLedgers` warnings) are unchanged. Alerting on
+those warnings — routing them somewhere a human sees them — is separate work.
+
 ## Reading a sync response
 
 ```json
@@ -90,6 +132,45 @@ is the one failure here that cannot be fixed by running the job again.
 | `windows`                          | `getEvents` calls made. Requests are bounded to 10,000 ledgers because the RPC silently truncates wider ranges. |
 | `skippedLedgers`                   | Ledgers lost to the retention window. Should always be 0.                                                       |
 | `scanned` / `decoded` / `inserted` | Events matched, decoded as transfers, and written.                                                              |
+
+## Settling in USDC or multiple assets
+
+The indexer defaults every setting to testnet native XLM. To index USDC — or
+XLM and USDC together — set `ASSET_CONTRACT_IDS` on the `web` project to a
+comma-separated list of the Stellar Asset Contract ids whose `transfer` events
+are revenue:
+
+```
+ASSET_CONTRACT_IDS=CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA,CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
+```
+
+(The first id above is the testnet USDC SAC; the second is testnet native XLM.
+Confirm current ids against
+[`accensa-contracts/deployments/testnet.env`](https://github.com/accensa/accensa-contracts/blob/main/deployments/testnet.env)
+before deploying.)
+
+Each `payments` row carries its own `asset` (`"native"` or `"USDC:GA…"`),
+decoded from the transfer event's optional asset topic. Revenue **must** be
+grouped by asset and never summed across assets — a figure that added XLM and
+USDC into one number is meaningless. Any dashboard total that mixes assets is a
+bug; see `apps/web/src/lib/revenue-analytics.ts`.
+
+### RefundVault holds one token
+
+`RefundVault` is initialised with a single token at deploy time. A merchant who
+takes both XLM and USDC has **one vault and one refund asset**: a refund of a
+payment made in the other asset will be rejected by the contract (the preflight
+in `/api/refund/preflight` surfaces this before any signing prompt).
+
+If a merchant needs to refund in more than one asset, deploy **one RefundVault
+per asset** and point `NEXT_PUBLIC_REFUND_VAULT_ID` at the right one per refund
+flow. There is no multi-asset vault, and adding one is a contract change tracked
+in `accensa-contracts`, not here.
+
+A merchant also cannot **receive** USDC at all without a trustline to the USDC
+issuer. A missing trustline for a configured `ASSET_CONTRACT_IDS` asset must be
+surfaced distinctly from "no payments yet" — an empty list is also what an
+indexer outage looks like, and the two must not be indistinguishable.
 
 ## Database connection
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
 MERCHANT_ADDRESS=GCALKSGAZRJLSUEJT3M5W6LN4R7XQOLIRCOS6ZA6EDZVTZDBIIPPFKJ6
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 HOOK_API_KEY=any-shared-secret   # required for /api/hook/settle
+# ASSET_CONTRACT_IDS — comma-separated SAC ids whose transfers are revenue.
+# Omitted, it defaults to the testnet native XLM SAC. For USDC (or XLM + USDC):
+# ASSET_CONTRACT_IDS=CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA,CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 
 # 3. Dashboard (schema is created on first request)
 cd apps/web
@@ -183,6 +186,18 @@ standing up another deployment.
 
 Testnet IDs are published in
 [`accensa-contracts/deployments/testnet.env`](https://github.com/accensa/accensa-contracts/blob/main/deployments/testnet.env).
+
+### Settling in USDC or multiple assets
+
+`ASSET_CONTRACT_IDS` selects which Stellar Asset Contracts the indexer treats as
+revenue. It defaults to the testnet native XLM SAC; set it to a comma-separated
+list to index USDC, or XLM and USDC together. `payments.asset` records each
+row's asset, and revenue is grouped by asset — never summed across them.
+
+RefundVault holds a **single** token, so a merchant taking both assets refunds
+in only one of them unless a second vault is deployed. Receiving USDC also
+requires a trustline. Both constraints are spelled out in
+[DEPLOYMENT.md](DEPLOYMENT.md#settling-in-usdc-or-multiple-assets).
 
 ## Testing
 


### PR DESCRIPTION
> **Draft.** Authored without a local checkout — not yet run through `pnpm lint` / `pnpm tsc --noEmit` / `pnpm test` / `pnpm build`. Please treat the code as a proposal to verify, not verified work. Scope notes per issue below.

Four Stellar Wave issues, one branch.

## #97 — remove `body.txt` / `issues.json` from the root ✅ mostly already done
Both files are **already gone** from the tree and `db-setup.md` is already folded into `DEPLOYMENT.md` (an earlier PR). This adds the missing recurrence guard: `.gitignore` entries for `body.txt`, `issues.json` and a `.scratch/` directory, plus a `CONTRIBUTING.md` section pointing tooling residue there.

## #94 — replace the sleep-looping Actions runner
`DEPLOYMENT.md` gains **"Indexer scheduling — the options weighed"**: paid Vercel Cron (~$20/user/mo) vs an external scheduler (cron-job.org / EventBridge, ~$0) vs a long-running worker (~$5/mo, re-opens the extraction that caused the original outage) vs keeping the loop. **Decision: keep the loop with its defects fixed now; migrate to an external scheduler when the team wants the ~660 runner-min/day gone** — that step needs an account + secret a maintainer must create, so it isn't in this PR.

`sync.yml` defects fixed:
- `concurrency.cancel-in-progress: true → false` — an overlapping trigger no longer kills an in-flight sync.
- loop window `55m → 65m` so it overlaps the next hourly trigger (safe now that self-cancel is gone; costs one extra idempotent sync).
- optional `HEARTBEAT_URL` pinged after every healthy sync and at clean exit → external dead-man's switch for **scheduling cessation**, the failure mode that cost 207 ledgers.

Every existing in-loop diagnostic (401 assertion, `syncedTo` check, `drained` / `skippedLedgers` warnings) is untouched. Deliberately breaking each to confirm the checks still fire, and wiring alerting on the warnings, are **not done here** (need the deployed environment).

## #95 — prove the USDC / multi-asset path
`DEPLOYMENT.md` + `README.md` document `ASSET_CONTRACT_IDS` with a USDC example, the per-asset grouping rule (never sum across assets), the **single-token RefundVault** constraint + the deploy-a-vault-per-asset workaround, and the missing-trustline case that must read differently from "no payments".

**Not done here (needs testnet/chain access):** the real testnet USDC payment + tx hash, the captured USDC event fixtures in `sac-transfer-events.json`, the aggregation-code changes in `revenue-analytics.ts`, and trustline detection in the dashboard.

## #96 — API route tests
Route tests for `routes` / `verify(auth)` / `challenge` / `hook/settle` / `payments` already landed (PR #234). This adds `apps/web/src/app/api/refund/preflight/route.test.ts` (validation paths + happy path + the float-to-i128 amount guard).

**Not done here (needs the CI Postgres service + a local run):** `/api/sync` scenarios (cold start, cursor resume, `skippedLedgers`, cursor-advances-across-empty-windows, cooldown/429, config errors), `/api/verify` disagreement flag, and reintroducing the filed route bugs to confirm the tests catch them.

## Related Issues
Closes #97

Closes #94, Closes #95, Closes #96 — see the "not done here" notes above; each needs deploy/CI/chain access a checkout-less contribution can't reach.
