### PR TITLE
feat: integrate webhook listening for demo merchant (#127)

### DIFF
--- a/apps/demo-merchant/.env.example
+++ b/apps/demo-merchant/.env.example
@@ -1,0 +1,22 @@
+# Port for the demo merchant server.
+PORT=3001
+
+# Stellar address that receives payment.
+MERCHANT_ADDRESS=
+
+# Where to report route attribution. Defaults to http://localhost:3000.
+ACCENSA_URL=http://localhost:3000
+
+# Bearer token for the Accensa /api/hook/settle endpoint.
+# The demo-merchant uses this legacy pattern; the SDK example uses Ed25519
+# signatures instead — see packages/sdk/examples/express-server.
+HOOK_API_KEY=
+
+# Shared secret for verifying inbound webhook signatures from Accensa.
+# Must match the WEBHOOK_SECRET configured in the Accensa deployment.
+# Leave unset to skip signature verification (permissive dev mode).
+WEBHOOK_SECRET=
+
+# Asset to price in. Defaults to native XLM's testnet SAC.
+# Must match an asset the Accensa indexer watches (ASSET_CONTRACT_IDS).
+TOKEN_ADDRESS=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC

--- a/apps/demo-merchant/package.json
+++ b/apps/demo-merchant/package.json
@@ -7,7 +7,7 @@
   },
   "keywords": [],
   "license": "MIT",
-  "description": "Example x402 seller reporting route attribution to Accensa",
+  "description": "Example x402 seller with webhook listener and real-time SSE updates",
   "dependencies": {
     "@x402/core": "^2.21.0",
     "@x402/express": "^2.21.0",

--- a/apps/demo-merchant/server.js
+++ b/apps/demo-merchant/server.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import {
   paymentMiddlewareFromHTTPServer,
   x402ResourceServer,
@@ -13,6 +14,10 @@ const PORT = process.env.PORT || 3001;
 // Where to report route attribution. Point this at your Accensa deployment.
 const ACCENSA_URL = process.env.ACCENSA_URL || 'http://localhost:3000';
 const HOOK_API_KEY = process.env.HOOK_API_KEY;
+
+// Shared secret for verifying inbound webhook signatures from Accensa.
+// Must match the WEBHOOK_SECRET configured in the Accensa deployment.
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET;
 
 const NETWORK = 'stellar:testnet';
 
@@ -38,7 +43,63 @@ function routeFromResourceUrl(url) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Webhook signature verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify the HMAC-SHA256 signature that the Accensa indexer attaches to
+ * outbound webhooks. Returns true when:
+ *   - WEBHOOK_SECRET is configured, and the signature matches, OR
+ *   - WEBHOOK_SECRET is not configured (permissive mode for local dev).
+ *
+ * Timing-safe comparison prevents side-channel leakage of the expected MAC.
+ */
+function verifyWebhookSignature(rawBody, signatureHeader) {
+  if (!WEBHOOK_SECRET) return true;
+  if (!signatureHeader) return false;
+
+  const expected = createHmac('sha256', WEBHOOK_SECRET).update(rawBody).digest('hex');
+
+  try {
+    const a = Buffer.from(expected, 'hex');
+    const b = Buffer.from(signatureHeader, 'hex');
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SSE (Server-Sent Events) — real-time push to the frontend
+// ---------------------------------------------------------------------------
+
+/** Registered SSE clients (one per browser tab). */
+const sseClients = new Set();
+
+function addSseClient(res) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+    'Access-Control-Allow-Origin': '*',
+  });
+  res.write(':\n\n'); // comment to flush the connection
+  sseClients.add(res);
+  return () => sseClients.delete(res);
+}
+
+function broadcastEvent(event, data) {
+  for (const client of sseClients) {
+    client.write(`event: ${event}\n`);
+    client.write(`data: ${JSON.stringify(data)}\n\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 1. Create the resource server and point it to the public facilitator
+// ---------------------------------------------------------------------------
 const resourceServer = new x402ResourceServer([
   new HTTPFacilitatorClient({ url: 'https://www.x402.org/facilitator' }),
 ]);
@@ -47,6 +108,7 @@ const resourceServer = new x402ResourceServer([
 // implementation to build and verify payment requirements locally.
 resourceServer.register(NETWORK, new ExactStellarScheme());
 
+// ---------------------------------------------------------------------------
 // 2. Path B: report the route that was paid for.
 //
 // The ledger records the transfer but not the route — a SAC transfer event has
@@ -56,6 +118,7 @@ resourceServer.register(NETWORK, new ExactStellarScheme());
 // Note what is *not* here: no fallback hash. If x402 reports a settlement
 // without a transaction, there is nothing to attribute and we send nothing. A
 // row whose tx_hash never appears on chain is worse than a missing row.
+// ---------------------------------------------------------------------------
 resourceServer.onAfterSettle(async (ctx) => {
   if (!ctx.result.success) {
     console.error('❌ Settlement failed:', ctx.result.errorReason);
@@ -107,7 +170,9 @@ resourceServer.onAfterSettle(async (ctx) => {
   }
 });
 
+// ---------------------------------------------------------------------------
 // 3. Configure the routes
+// ---------------------------------------------------------------------------
 const routesConfig = {
   '/api/hello': {
     accepts: {
@@ -121,19 +186,253 @@ const routesConfig = {
 
 const httpServer = new x402HTTPResourceServer(resourceServer, routesConfig);
 
-// 4. Apply the middleware
+// 4. Apply the x402 payment middleware
 app.use(paymentMiddlewareFromHTTPServer(httpServer));
 
-// 5. Protected route
-app.get('/api/hello', (req, res) => {
+// Parse JSON bodies for the webhook endpoint (skip for x402 payment handshake
+// paths which have their own content type).
+app.use('/api/webhooks', express.json());
+
+// ---------------------------------------------------------------------------
+// 5. Routes — payment-gated
+// ---------------------------------------------------------------------------
+
+app.get('/api/hello', (_req, res) => {
   res.json({
     message: 'Payment verified!',
     data: 'This is the premium Accensa content.',
   });
 });
 
+// ---------------------------------------------------------------------------
+// 6. Routes — inbound webhook from Accensa
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/webhooks/accensa
+ *
+ * Receives payment-notifications from the Accensa indexer. The indexer signs
+ * the JSON body with HMAC-SHA256 using a shared WEBHOOK_SECRET; the signature
+ * arrives in the X-Webhook-Signature header.
+ *
+ * On success the event is broadcast to all connected SSE clients so the
+ * frontend can update in real time.
+ */
+app.post('/api/webhooks/accensa', (req, res) => {
+  const rawBody = JSON.stringify(req.body);
+  const signature = req.headers['x-webhook-signature'];
+
+  if (!verifyWebhookSignature(rawBody, signature)) {
+    console.warn('⚠️  Webhook signature verification failed — rejecting');
+    return res.status(401).json({ error: 'Invalid signature' });
+  }
+
+  const payment = req.body;
+  console.log('🔔 Webhook received:', payment.tx_hash ?? payment.id ?? 'unknown');
+
+  // Broadcast to every connected SSE client
+  broadcastEvent('payment', {
+    type: 'payment',
+    txHash: payment.tx_hash,
+    ledger: payment.ledger,
+    payer: payment.payer,
+    amount: payment.amount,
+    asset: payment.asset,
+    route: payment.route,
+    ts: payment.ts,
+    receivedAt: new Date().toISOString(),
+  });
+
+  res.status(200).json({ ok: true });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Routes — SSE stream for the frontend
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/events
+ *
+ * Server-Sent Events endpoint. The browser opens a persistent connection here
+ * and receives real-time updates whenever the Accensa indexer pushes a
+ * webhook. The connection stays open until the client disconnects.
+ */
+app.get('/api/events', (req, res) => {
+  const removeClient = addSseClient(res);
+  console.log(`📡 SSE client connected (${sseClients.size} total)`);
+
+  req.on('close', () => {
+    removeClient();
+    console.log(`📡 SSE client disconnected (${sseClients.size} total)`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Frontend — minimal demo page
+// ---------------------------------------------------------------------------
+
+app.get('/', (_req, res) => {
+  res.type('html').send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Accensa Demo Merchant</title>
+<style>
+  :root {
+    --bg: #0a0a0a; --surface: #141414; --border: #262626;
+    --text: #e5e5e5; --muted: #a3a3a3; --accent: #22c55e;
+    --accent-dim: #16a34a;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: system-ui, -apple-system, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
+  .container { max-width: 640px; margin: 0 auto; padding: 3rem 1.5rem; }
+  h1 { font-size: 1.75rem; font-weight: 600; margin-bottom: .25rem; }
+  .subtitle { color: var(--muted); margin-bottom: 2rem; font-size: .95rem; }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: .75rem; padding: 1.5rem; margin-bottom: 1.5rem; }
+  .card h2 { font-size: 1rem; font-weight: 500; margin-bottom: .75rem; color: var(--muted); }
+  .status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: .5rem; vertical-align: middle; }
+  .status-dot.connected { background: var(--accent); }
+  .status-dot.disconnected { background: #ef4444; }
+  .pay-btn {
+    display: inline-flex; align-items: center; gap: .5rem;
+    background: var(--accent); color: #000; border: none; border-radius: .5rem;
+    padding: .75rem 1.5rem; font-size: 1rem; font-weight: 600; cursor: pointer;
+    transition: background .15s;
+  }
+  .pay-btn:hover { background: var(--accent-dim); }
+  .pay-btn:disabled { opacity: .5; cursor: not-allowed; }
+  .event-list { list-style: none; }
+  .event-list li {
+    padding: .75rem 0; border-bottom: 1px solid var(--border);
+    font-size: .875rem; line-height: 1.5;
+  }
+  .event-list li:last-child { border-bottom: none; }
+  .event-list .tx { font-family: monospace; color: var(--accent); word-break: break-all; }
+  .event-list .time { color: var(--muted); font-size: .8rem; }
+  .empty { color: var(--muted); font-size: .875rem; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>Accensa Demo Merchant</h1>
+  <p class="subtitle">x402 payment-gated endpoint with real-time webhook updates</p>
+
+  <div class="card">
+    <h2>Webhook Connection</h2>
+    <p id="conn-status">
+      <span class="status-dot disconnected" id="dot"></span>
+      <span id="conn-text">Connecting&hellip;</span>
+    </p>
+  </div>
+
+  <div class="card">
+    <h2>Premium Endpoint</h2>
+    <button class="pay-btn" id="pay-btn" onclick="callHello()">
+      Pay &amp; Call /api/hello
+    </button>
+    <p id="pay-result" style="margin-top:.75rem;font-size:.875rem;"></p>
+  </div>
+
+  <div class="card">
+    <h2>Payment Events (via SSE)</h2>
+    <ul class="event-list" id="events">
+      <li class="empty">No events yet. Pay to trigger one.</li>
+    </ul>
+  </div>
+</div>
+
+<script>
+const dot = document.getElementById('dot');
+const connText = document.getElementById('conn-text');
+const eventsList = document.getElementById('events');
+const payBtn = document.getElementById('pay-btn');
+const payResult = document.getElementById('pay-result');
+let hasEvents = false;
+
+// ---- SSE ----
+function connectSSE() {
+  const es = new EventSource('/api/events');
+  es.onopen = () => {
+    dot.className = 'status-dot connected';
+    connText.textContent = 'Connected';
+  };
+  es.onerror = () => {
+    dot.className = 'status-dot disconnected';
+    connText.textContent = 'Reconnecting\u2026';
+  };
+  es.addEventListener('payment', (e) => {
+    const data = JSON.parse(e.data);
+    addEvent(data);
+    showToast(data);
+  });
+}
+
+function addEvent(data) {
+  if (!hasEvents) { eventsList.innerHTML = ''; hasEvents = true; }
+  const li = document.createElement('li');
+  const ts = data.receivedAt ? new Date(data.receivedAt).toLocaleTimeString() : '';
+  const amount = data.amount ? \` (\${data.amount})\` : '';
+  li.innerHTML =
+    \`<span class="tx">\${data.txHash ?? 'unknown'}</span>\` +
+    \`\${amount}<br><span class="time">\${ts}</span>\`;
+  eventsList.prepend(li);
+}
+
+// ---- Toast ----
+function showToast(data) {
+  const toast = document.createElement('div');
+  toast.textContent = 'Payment Successful!';
+  Object.assign(toast.style, {
+    position: 'fixed', bottom: '1.5rem', right: '1.5rem',
+    background: '#16a34a', color: '#fff', padding: '.75rem 1.25rem',
+    borderRadius: '.5rem', fontWeight: '600', fontSize: '.95rem',
+    boxShadow: '0 4px 12px rgba(0,0,0,.4)',
+    zIndex: '9999', opacity: '0', transition: 'opacity .3s',
+  });
+  document.body.appendChild(toast);
+  requestAnimationFrame(() => toast.style.opacity = '1');
+  setTimeout(() => {
+    toast.style.opacity = '0';
+    setTimeout(() => toast.remove(), 300);
+  }, 4000);
+}
+
+// ---- Pay button (calls the x402-gated endpoint) ----
+async function callHello() {
+  payBtn.disabled = true;
+  payBtn.textContent = 'Paying\u2026';
+  payResult.textContent = '';
+  try {
+    const res = await fetch('/api/hello');
+    const json = await res.json();
+    payResult.textContent = JSON.stringify(json);
+  } catch (err) {
+    payResult.textContent = 'Error: ' + err.message;
+  } finally {
+    payBtn.disabled = false;
+    payBtn.textContent = 'Pay & Call /api/hello';
+  }
+}
+
+connectSSE();
+</script>
+</body>
+</html>`);
+});
+
+// ---------------------------------------------------------------------------
+// 9. Start
+// ---------------------------------------------------------------------------
+
 app.listen(PORT, () => {
   console.log(`Demo merchant server running on port ${PORT}`);
+  console.log(`Dashboard: http://localhost:${PORT}/`);
   console.log(`Protected route: http://localhost:${PORT}/api/hello`);
   console.log(`Reporting attribution to: ${ACCENSA_URL}/api/hook/settle`);
+  console.log(`Webhook endpoint: POST http://localhost:${PORT}/api/webhooks/accensa`);
+  console.log(`SSE stream: GET http://localhost:${PORT}/api/events`);
+  if (!WEBHOOK_SECRET) {
+    console.warn('⚠️  WEBHOOK_SECRET is not set — webhook signature verification is disabled');
+  }
 });

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -11,6 +11,7 @@ import {
 import { listMerchants, getMerchantFromRequest, type Merchant } from '@/lib/merchants';
 import { sweepLedgerRange, EVENTS_PAGE_LIMIT, type EventPage } from '@/lib/event-pager';
 import { cooldownRemaining } from '@/lib/sync-status';
+import { createHmac } from 'node:crypto';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -214,6 +215,14 @@ async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
         );
         if (res.rowCount && res.rowCount > 0 && webhookUrl) {
           const payment = res.rows[0];
+          const body = JSON.stringify(payment);
+          const webhookSecret = process.env.WEBHOOK_SECRET;
+          const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+          if (webhookSecret) {
+            headers['X-Webhook-Signature'] = createHmac('sha256', webhookSecret)
+              .update(body)
+              .digest('hex');
+          }
           const timeoutMs = 2000;
           for (let i = 0; i < 3; i++) {
             try {
@@ -221,8 +230,8 @@ async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
               const id = setTimeout(() => controller.abort(), timeoutMs);
               const webhookRes = await fetch(webhookUrl, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payment),
+                headers,
+                body,
                 signal: controller.signal,
               });
               clearTimeout(id);


### PR DESCRIPTION
## Summary

Integrates real-time webhook listening into the `apps/demo-merchant` app so the demo can show live payment notifications without manual refresh.

Closes #127

---

## What changed

### 1. HMAC-SHA256 webhook signatures (sender side)
**`apps/web/src/app/api/sync/route.ts`**

When the Accensa indexer discovers a new payment and dispatches an outbound webhook to the merchant's `webhookUrl`, it now signs the JSON body with HMAC-SHA256 and attaches the signature in an `X-Webhook-Signature` header.

- Signing is enabled when `WEBHOOK_SECRET` is configured in the Accensa deployment
- The body bytes are computed once, reused for the HMAC and the fetch call
- When `WEBHOOK_SECRET` is unset, the header is simply omitted — existing integrations that don't verify signatures continue to work unchanged

### 2. Inbound webhook endpoint
**`apps/demo-merchant/server.js` — `POST /api/webhooks/accensa`**

A new Express route that:
- Parses the JSON body via `express.json()` (scoped to `/api/webhooks`)
- Validates the `X-Webhook-Signature` header using timing-safe HMAC-SHA256 comparison
- In permissive mode (no `WEBHOOK_SECRET` set) the check is skipped for local dev
- On success, broadcasts the payment data to all connected SSE clients

### 3. Server-Sent Events stream
**`apps/demo-merchant/server.js` — `GET /api/events`**

An SSE endpoint that holds connections open and pushes `payment` events whenever the webhook fires. Clients register on connect and are removed on disconnect, with connection count logging.

### 4. Frontend dashboard
**`apps/demo-merchant/server.js` — `GET /`**

A self-contained HTML page (inline, no build step required) that:
- Connects to `/api/events` via `EventSource` and shows connection status with a green/red indicator
- Displays a **"Payment Successful!"** toast notification (fixed-position, auto-dismissing) when a payment event arrives
- Lists payment events in reverse chronological order with tx hash, amount, and timestamp
- Has a "Pay & Call /api/hello" button to trigger the x402-gated endpoint

### 5. Configuration
**`apps/demo-merchant/.env.example`** — Documents all environment variables including the new `WEBHOOK_SECRET`.

---

## Architecture

```
Accensa Indexer                          Demo Merchant
┌──────────────┐                         ┌──────────────────────┐
│ sync/route   │  POST webhookUrl        │ /api/webhooks/accensa│
│              │ ──────────────────────►  │  verify HMAC sig     │
│ HMAC-SHA256  │  X-Webhook-Signature: … │  broadcast to SSE    │
│ (if secret)  │                         │         │            │
└──────────────┘                         │         ▼            │
                                         │  GET /api/events     │
                                         │         │            │
                                         │         ▼            │
                                         │  Browser EventSource │
                                         │  → toast notification│
                                         └──────────────────────┘
```

---

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Demo app can receive POST requests to `/api/webhooks/accensa` | ✅ |
| Payload signature validation is implemented | ✅ HMAC-SHA256 with timing-safe comparison |
| Frontend updates automatically when payment clears | ✅ SSE push → EventSource → toast |
| `Payment Successful` toast notification displayed | ✅ |

---

## Testing

1. Copy `apps/demo-merchant/.env.example` → `.env` and configure `WEBHOOK_SECRET`
2. Set the same `WEBHOOK_SECRET` in the Accensa deployment's environment
3. Start the demo merchant: `node apps/demo-merchant/server.js`
4. Open `http://localhost:3001/` — verify SSE shows "Connected"
5. Trigger a payment through x402 — the webhook arrives, toast appears, event is listed
6. Tamper with the `X-Webhook-Signature` header → 401 rejected