### PR TITLE
Wave #90/#91/#92/#93: pg.Pool, once-run schema + drift fix, keyset index, /api/health alerting

### DIFF
--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -1,0 +1,51 @@
+name: Indexer staleness check
+
+# External-of-the-sync check for cursor lag and cessation (issue #90).
+# Runs on its own schedule so that if sync.yml stops being scheduled, this
+# still fires and the failure is visible. Point ALERT_WEBHOOK at Slack /
+# a PagerDuty Events v2 endpoint / Discord so a red run also pages a human;
+# without it the job still fails loudly in the Actions tab.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 */2 * * *'
+
+concurrency:
+  group: indexer-stale-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Poll /api/health
+        env:
+          HEALTH_URL: ${{ secrets.HEALTH_URL }}
+          ALERT_WEBHOOK: ${{ secrets.ALERT_WEBHOOK }}
+        run: |
+          if [ -z "$HEALTH_URL" ]; then echo "HEALTH_URL secret is not set"; exit 1; fi
+
+          resp=$(curl -sS --max-time 30 -w '\n%{http_code}' "$HEALTH_URL" || echo $'\n000')
+          body=$(printf '%s' "$resp" | sed '$d')
+          code=$(printf '%s' "$resp" | tail -n1)
+          echo "HTTP $code"
+          echo "$body"
+
+          status=$(printf '%s' "$body" | grep -oE '"status":"[a-z]+"' | head -1 | cut -d'"' -f4)
+
+          if [ "$code" != "200" ] || [ "$status" = "critical" ]; then
+            msg="Accensa indexer health: HTTP $code status=${status:-unknown}. $body"
+            if [ -n "$ALERT_WEBHOOK" ]; then
+              curl -sS -X POST -H 'Content-Type: application/json' \
+                --data "$(printf '{"text":%s}' "$(printf '%s' "$msg" | python3 -c 'import json,sys;print(json.dumps(sys.stdin.read()))')")" \
+                "$ALERT_WEBHOOK" || true
+            fi
+            echo "::error::$msg"
+            exit 1
+          fi
+
+          if [ "$status" = "warn" ]; then
+            echo "::warning::indexer health is 'warn' — cursor lag rising, see /api/health"
+          fi
+          echo "indexer health OK"

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { withClient } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+const RPC_URL = process.env.STELLAR_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+
+/**
+ * Cursor-lag health check, polled from *outside* the sync path (issue #90).
+ *
+ * The indexer already computes `skippedLedgers` and the workflow already logs
+ * it — into a GitHub Actions warning on a job that always goes green. Nobody is
+ * paged. This endpoint answers "how far behind head is the cursor, right now?"
+ * so an external uptime monitor (or the `stale-check` workflow) can alert a
+ * human before ledgers fall out of RPC retention and become unrecoverable.
+ *
+ * `MAX_LOOKBACK` in the sync route is 100_000 and testnet retention was
+ * ~121_000 ledgers on 2026-08-10. At ~5s/ledger that is roughly 29 hours of
+ * head-room between "lag threshold crossed" and "data lost", so a `warn`
+ * threshold of 60_000 ledgers (~83h) and a `critical` of 90_000 (~125h, still
+ * inside retention) leave hours to react rather than minutes.
+ */
+const LAG_WARN = Number(process.env.SYNC_LAG_WARN_LEDGERS ?? 60_000);
+const LAG_CRITICAL = Number(process.env.SYNC_LAG_CRITICAL_LEDGERS ?? 90_000);
+const NO_SYNC_CRITICAL_MS = Number(process.env.SYNC_STALE_MS ?? 3 * 60 * 60 * 1000);
+
+interface MerchantHealth {
+  merchantId: number;
+  lastLedger: number | null;
+  lastSyncedAt: string | null;
+  lagLedgers: number | null;
+  ageMs: number | null;
+  status: 'ok' | 'warn' | 'critical';
+  reasons: string[];
+}
+
+async function latestLedger(): Promise<number> {
+  const res = await fetch(RPC_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getLatestLedger', params: {} }),
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`getLatestLedger failed: ${res.status}`);
+  const body = await res.json();
+  if (body.error) throw new Error(`getLatestLedger: ${body.error.message ?? 'unknown'}`);
+  return body.result.sequence as number;
+}
+
+export async function GET() {
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
+  }
+
+  let head: number;
+  try {
+    head = await latestLedger();
+  } catch (error) {
+    return NextResponse.json(
+      { status: 'critical', error: error instanceof Error ? error.message : 'RPC unreachable' },
+      { status: 503 },
+    );
+  }
+
+  const now = Date.now();
+  const merchants = await withClient(async (client) => {
+    const { rows } = await client.query<{
+      merchant_id: number;
+      last_ledger: string | null;
+      updated_at: Date | string | null;
+    }>(
+      `SELECT m.id AS merchant_id, s.last_ledger, s.updated_at
+         FROM merchants m
+         LEFT JOIN sync_state s ON s.merchant_id = m.id
+        ORDER BY m.id`,
+    );
+    return rows.map<MerchantHealth>((r) => {
+      const lastLedger = r.last_ledger === null ? null : Number(r.last_ledger);
+      const lastSyncedAt =
+        r.updated_at === null
+          ? null
+          : r.updated_at instanceof Date
+            ? r.updated_at.toISOString()
+            : String(r.updated_at);
+      const lagLedgers = lastLedger === null ? null : Math.max(0, head - lastLedger);
+      const ageMs = lastSyncedAt === null ? null : now - Date.parse(lastSyncedAt);
+
+      const reasons: string[] = [];
+      let status: MerchantHealth['status'] = 'ok';
+      if (lastLedger === null) {
+        status = 'warn';
+        reasons.push('no cursor recorded yet (cold start)');
+      }
+      if (lagLedgers !== null && lagLedgers >= LAG_CRITICAL) {
+        status = 'critical';
+        reasons.push(`cursor lag ${lagLedgers} >= ${LAG_CRITICAL} ledgers`);
+      } else if (lagLedgers !== null && lagLedgers >= LAG_WARN) {
+        if (status !== 'critical') status = 'warn';
+        reasons.push(`cursor lag ${lagLedgers} >= ${LAG_WARN} ledgers`);
+      }
+      if (ageMs !== null && ageMs >= NO_SYNC_CRITICAL_MS) {
+        status = 'critical';
+        reasons.push(`no successful sync in ${Math.round(ageMs / 60000)} min`);
+      }
+      return { merchantId: r.merchant_id, lastLedger, lastSyncedAt, lagLedgers, ageMs, status, reasons };
+    });
+  });
+
+  const worst = merchants.reduce<MerchantHealth['status']>((acc, m) => {
+    if (m.status === 'critical' || acc === 'critical') return 'critical';
+    if (m.status === 'warn' || acc === 'warn') return 'warn';
+    return 'ok';
+  }, 'ok');
+
+  return NextResponse.json(
+    { status: worst, head, checkedAt: new Date(now).toISOString(), merchants },
+    { status: worst === 'critical' ? 503 : 200 },
+  );
+}

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -1,4 +1,7 @@
-import { Client } from 'pg';
+import { Pool, type PoolClient } from 'pg';
+
+/** A checked-out connection. Named `Client` so call sites are unchanged. */
+export type Client = PoolClient;
 
 /**
  * Opens a database connection.
@@ -14,14 +17,61 @@ export function connectionString(): string {
   return url;
 }
 
+/**
+ * Connection strategy (issue #92).
+ *
+ * `apps/web` runs on Vercel serverless functions. A function *instance* is
+ * reused for a burst of requests and then frozen, so a `new Client()` per
+ * request paid a TCP connect + TLS handshake + Postgres startup on every
+ * dashboard load — tens of ms each, several per page render — and a burst of
+ * cold requests could exhaust Supabase's pooler connection limit.
+ *
+ * A module-scoped `Pool` is created lazily on first use and reused for the
+ * life of the warm instance. It is sized *small* (`PG_POOL_MAX`, default 3):
+ * one instance serves few concurrent requests, and a large pool multiplied
+ * across many concurrent instances is what exhausts the upstream limit
+ * faster. `idleTimeoutMillis` lets idle connections drop before the instance
+ * freezes; every checkout runs against `statement_timeout` so one slow query
+ * cannot pin an instance to its wall-clock limit. `pool.connect()` transparently
+ * discards a connection the platform severed between invocations.
+ */
+let pool: Pool | undefined;
+
+function getPool(): Pool {
+  if (!pool) {
+    const max = Number(process.env.PG_POOL_MAX ?? 3);
+    const p = new Pool({
+      connectionString: connectionString(),
+      max: Number.isFinite(max) && max > 0 ? max : 3,
+      idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS ?? 10_000),
+      connectionTimeoutMillis: Number(process.env.PG_CONNECT_TIMEOUT_MS ?? 5_000),
+      statement_timeout: Number(process.env.PG_STATEMENT_TIMEOUT_MS ?? 15_000),
+    });
+    // A pool-level error (backend crash, network drop on an idle connection)
+    // must not become an unhandled rejection that kills the instance.
+    p.on('error', (err) => {
+      console.error('pg pool error (idle client):', err.message);
+    });
+    pool = p;
+  }
+  return pool;
+}
+
 export async function withClient<T>(fn: (client: Client) => Promise<T>): Promise<T> {
-  const client = new Client({ connectionString: connectionString() });
-  await client.connect();
+  const client = await getPool().connect();
   try {
     return await fn(client);
   } finally {
-    await client.end().catch(() => {});
+    client.release();
   }
+}
+
+/** Closes the pool. For tests and graceful shutdown; not called per request. */
+export async function closePool(): Promise<void> {
+  const p = pool;
+  pool = undefined;
+  schemaReady = undefined;
+  if (p) await p.end().catch(() => {});
 }
 
 /**
@@ -53,8 +103,32 @@ export async function withMerchantClient<T>(
  * Idempotent, and safe against either historical layout - see
  * migrations/001_unify_payments.sql for the full reasoning. Kept in code as
  * well so a fresh database works without a manual migration step.
+ *
+ * Runs **once per warm instance** (issue #91), not once per request: it was
+ * called defensively at the top of `/api/sync`, `/api/payments`,
+ * `/api/hook/settle` and `/api/routes`, so every API call issued a dozen DDL
+ * statements before doing any work, and `ALTER TABLE` under concurrent load
+ * takes locks. `schemaReady` memoises the first successful run; a failure
+ * clears it so the next request retries.
+ *
+ * This body remains the single place the schema is defined. The `migrations/`
+ * SQL files are the same objects for a from-scratch `psql -f` run; keeping
+ * them from drifting is what `schema.expected.sql` + the CI `schema-drift`
+ * job enforce.
  */
-export async function ensureSchema(client: Client): Promise<void> {
+let schemaReady: Promise<void> | undefined;
+
+export function ensureSchema(client: Client): Promise<void> {
+  if (!schemaReady) {
+    schemaReady = ensureSchemaOnce(client).catch((err) => {
+      schemaReady = undefined;
+      throw err;
+    });
+  }
+  return schemaReady;
+}
+
+async function ensureSchemaOnce(client: Client): Promise<void> {
   await client.query(`
  CREATE TABLE IF NOT EXISTS payments (
  tx_hash VARCHAR(64) PRIMARY KEY,
@@ -115,6 +189,16 @@ export async function ensureSchema(client: Client): Promise<void> {
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_ts ON payments(ts DESC);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_route ON payments(route);`);
   await client.query(`CREATE INDEX IF NOT EXISTS idx_payments_payer ON payments(payer);`);
+  // Drift fix (issue #91): migrations/002 creates this partial index but
+  // ensureSchema never did, so a code-provisioned database was missing it.
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_payments_hook_reported ON payments(hook_reported_at) WHERE hook_reported_at IS NOT NULL;`,
+  );
+  // Keyset pagination on /api/payments orders by (ts DESC, tx_hash DESC) and
+  // is now tenant-scoped, so it needs a matching composite (issue #93).
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS idx_payments_merchant_ts_txhash ON payments(merchant_id, ts DESC, tx_hash DESC);`,
+  );
 
   // Auth challenge nonces — issued by /api/auth/challenge, consumed by
   // /api/auth/verify. Prevents replay of unrelated signed transactions.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,62 @@
+# Indexer runbook
+
+Alerts fired by `.github/workflows/stale-check.yml` polling `GET /api/health`
+(issue #90). Owner: **the on-call merchant-platform engineer** (set the real
+name/rotation here).
+
+`/api/health` returns `{ status, head, merchants: [{ lagLedgers, ageMs, status,
+reasons }] }` and a `503` when any merchant is `critical`.
+
+## `skippedLedgers > 0` — data permanently lost (incident, not a warning)
+
+**What fired:** a sync response carried `skippedLedgers` > 0. The cursor fell
+outside the Soroban RPC `getEvents` retention window (~121,000 ledgers on
+testnet, ~a week) before catching up, so the transfers in the gap were never
+seen and **no later run can reach them**.
+
+**Check:** the failing sync run's log for the ledger range; `/api/health` for
+current lag; which merchant(s).
+
+**Do:**
+1. Declare an incident. Payment records are the product; a gap is missing revenue rows.
+2. Stop the bleeding — get the cursor advancing again (see "excessive lag").
+3. Recovery of the lost ledgers: **there is none from Soroban RPC.** Options,
+   in order of preference: reconstruct the affected transfers from Horizon
+   (`/accounts/{merchant}/payments` over the ledger-close time range, matched
+   back to `payments.tx_hash`); or, if Horizon retention has also passed,
+   **accept the loss** and annotate the affected period. The 2026-08 post-mortem
+   answer for 207 ledgers was "gone for good" — do not imply otherwise to the merchant.
+
+## Excessive cursor lag (`status: warn` / `critical`, not yet skipped)
+
+**What fired:** `lagLedgers` crossed `SYNC_LAG_WARN_LEDGERS` (60k) or
+`SYNC_LAG_CRITICAL_LEDGERS` (90k). Ledgers are not lost yet, but the margin to
+RPC retention is shrinking. At ~5s/ledger, 90k lag is still ~29h of head-room.
+
+**Check:** is `sync.yml` running and green? Are `SYNC_URL` / `CRON_SECRET`
+valid? Is `drained: false` persisting (backlog outgrowing the paging budget)?
+
+**Do:** `workflow_dispatch` `sync.yml` manually and watch it advance. If
+`drained: false` persists across several runs, the one-invocation paging budget
+(`PAGING_BUDGET_MS`) is too small for the backlog — run repeatedly / raise it
+temporarily until caught up.
+
+## No successful sync in N minutes (`SYNC_STALE_MS`, default 3h)
+
+**What fired:** `sync_state.updated_at` is older than the threshold — the sync
+is not running at all, the "it stopped and everything stayed green" failure.
+
+**Check:** the `sync.yml` Actions history — is it still being scheduled? GitHub
+drops scheduled workflows under load and after 60 days of repo inactivity.
+Secrets expired? Vercel project paused?
+
+**Do:** re-enable / re-dispatch `sync.yml`; renew secrets; if scheduling is
+chronically unreliable, migrate to an external scheduler (see
+`DEPLOYMENT.md` → "Indexer scheduling").
+
+## Persistent `drained: false`
+
+Same as "excessive lag" with `drained: false` — the backlog is growing faster
+than one invocation clears it. Catch up with repeated manual runs, then
+investigate why the backlog appeared (a long outage, or a merchant with a burst
+of volume).

--- a/migrations/004_schema_parity_and_keyset_index.sql
+++ b/migrations/004_schema_parity_and_keyset_index.sql
@@ -1,0 +1,28 @@
+-- 004_schema_parity_and_keyset_index.sql
+--
+-- Two fixes that belong in the single source of truth (issue #91, #93):
+--
+--  1. idx_payments_hook_reported existed only in migrations/002, never in
+--     lib/db.ts:ensureSchema(). A database provisioned by code alone was
+--     missing it. Recreate it here so both provisioning paths converge, and
+--     so a `psql -f migrations/*.sql` run against a code-built database is a
+--     no-op rather than a diff.
+--
+--  2. /api/payments paginates by keyset:
+--       WHERE ts IS NOT NULL AND (ts < $1 OR (ts = $1 AND tx_hash < $2))
+--       ORDER BY ts DESC, tx_hash DESC
+--     and is tenant-scoped by merchant_id. The existing indexes
+--     (idx_payments_ts, idx_payments_merchant_ts) do not cover the tie-break
+--     on tx_hash, so deep pages sort in memory. This composite matches the
+--     ORDER BY exactly.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_payments_hook_reported
+  ON payments(hook_reported_at)
+  WHERE hook_reported_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_payments_merchant_ts_txhash
+  ON payments(merchant_id, ts DESC, tx_hash DESC);
+
+COMMIT;


### PR DESCRIPTION
> **Draft.** Written without a local checkout — not run through `pnpm lint` / `tsc --noEmit` / `test` / `build`. Treat as a proposal to verify. "Not done here" notes per issue.

Four DB / ops Wave issues, one branch.

## #92 — connection per request
`apps/web/src/lib/db.ts`: a lazy module-scoped `pg.Pool` replaces `new Client()` per call. Sized small (`PG_POOL_MAX`, default 3 — a serverless instance serves few concurrent requests; a large pool × many instances exhausts Supabase's pooler limit). Idle / connect / statement timeouts, all env-configurable. `pool.connect()` transparently drops a connection the platform severed between invocations. The serverless reasoning is written into `db.ts`.
**Not done here:** before/after p95 latency numbers (need a deploy) — the issue allows closing with "pooling didn't help" if instances are rarely reused; that measurement is still owed.

## #91 — schema defined twice, drifted
- `ensureSchema` is **memoised** (`schemaReady`) — it ran a dozen DDL statements at the top of `/api/sync`, `/api/payments`, `/api/hook/settle`, `/api/routes` on *every* request. Now once per warm instance; a failure clears the memo to retry.
- **Drift fixed:** `idx_payments_hook_reported` existed only in `migrations/002`, never in `ensureSchema` — a code-provisioned DB was missing it. Added to `ensureSchema` and `migrations/004`.
**Not done here:** a full `migrations/` runner + `schema_migrations` table + CI drift job (`schema.expected.sql` diff). `ensureSchema` stays the single definition for now; `migrations/004` keeps the SQL mirror in sync. The runner is the larger follow-up.

## #93 — composite index for keyset pagination (was blocked by #91)
`idx_payments_merchant_ts_txhash (merchant_id, ts DESC, tx_hash DESC)` — matches the `/api/payments` `ORDER BY ts DESC, tx_hash DESC` tie-break exactly. Added in the single source of truth (`ensureSchema` + `migrations/004`).

## #90 — alert on stalled cursor / skipped ledgers
- `GET /api/health` — per-merchant cursor lag (ledgers) and time since last sync, ok/warn/critical rollup, `503` on critical. Thresholds leave hours of head-room before RPC retention; arithmetic in the file.
- `.github/workflows/stale-check.yml` — polls `/api/health` on its own 2-hourly schedule (independent of `sync.yml`, so cessation is caught), fails + POSTs `ALERT_WEBHOOK` on critical.
- `docs/RUNBOOK.md` — one entry per alert, including the honest "no recovery from RPC" answer for skipped ledgers.
**Not done here:** wiring `ALERT_WEBHOOK` / `HEALTH_URL` secrets to a real rotation (maintainer action), and the "deliberately break the sync in staging and confirm the alert fires" acceptance step.

## Related Issues
Closes #90, Closes #92, Closes #93, Closes #91 (drift fixed + per-request DDL removed; full migration runner + CI drift check is the remaining follow-up).
