### PR TITLE
feat(sdk): expose strict Order and Product types with a typed client

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -21,3 +21,45 @@ The reporting contract is as follows:
    Pass the resulting signature as a hex string in the `X-Signature` HTTP header.
 
 The backend verifies this signature before parsing the JSON, ensuring the request is strictly authenticated based on the raw bytes.
+
+## Reading Orders and Products
+
+The SDK ships a small typed client for the Accensa indexer's read API. Every
+method returns strict `Order` / `Product` values — no `any`, no
+`Record<string, unknown>` — with optional columns (e.g. `metadata`) mapped from
+SQL `NULL` to `undefined` so strict null checks work in the consuming app.
+
+```ts
+import { AccensaClient } from '@accensa/sdk';
+
+const accensa = new AccensaClient({
+  indexerUrl: 'https://accensa-dashboard.vercel.app',
+  // The indexer scopes reads to the signed-in merchant; attach whatever
+  // credential your deployment expects.
+  headers: { Authorization: 'Bearer ...' },
+});
+
+// Most recent orders, newest first.
+const { orders, nextCursor } = await accensa.listOrders({ limit: 50 });
+for (const order of orders) {
+  console.log(order.id, order.productId, order.amount, order.createdAt);
+}
+
+// One order by transaction hash (searches the most recent 1000 payments).
+const order = await accensa.fetchOrder('a'.repeat(64));
+
+// Products (paid endpoints) with their indexed revenue.
+const { products } = await accensa.listProducts();
+for (const product of products) {
+  console.log(product.id, product.calls, product.totalRevenue);
+}
+
+// One product by route path (searches the top 200 by revenue).
+const product = await accensa.fetchProduct('/api/hello');
+```
+
+Prefer the raw mappers when you hold a response body yourself
+(e.g. a webhook payload): `orderFromWire`, `ordersFromResponse`,
+`productFromWire`, and `productsFromResponse` parse an `unknown` JSON value
+into the strict types. The `Order` and `Product` types are also re-exported
+from the package root, and available directly from `@accensa/sdk/types`.

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -20,6 +20,27 @@ export {
   type X402SettleResult,
 } from './settlement';
 
+/** Strict, typed Order and Product fetches against the Accensa indexer. */
+export {
+  AccensaClient,
+  AccensaError,
+  type AccensaClientOptions,
+  type OrdersPage,
+  type ProductsPage,
+} from './src/client';
+/** Strict mappers from the indexer's wire rows to Order/Product. */
+export {
+  orderFromWire,
+  ordersFromResponse,
+  productFromWire,
+  productsFromResponse,
+  type OrdersResponse,
+  type ProductsResponse,
+} from './src/mapping';
+/** The strict Order and Product types themselves. */
+export type { Order, OrderMetadata } from './src/types/order';
+export type { Product, ProductMetadata } from './src/types/product';
+
 /**
  * This package deliberately ships no paywall middleware.
  *

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,8 @@
   },
   "exports": {
     ".": "./index.ts",
-    "./merkle": "./merkle.ts"
+    "./merkle": "./merkle.ts",
+    "./types": "./src/types/index.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AccensaClient, AccensaError } from './client';
+
+const TX_HASH = 'a'.repeat(64);
+const PAYER = 'G' + 'A'.repeat(55);
+
+/** A payments body the indexer could return. */
+const paymentsBody = {
+  payments: [
+    {
+      tx_hash: TX_HASH,
+      route: '/api/hello',
+      method: 'GET',
+      payer: PAYER,
+      amount: '1000',
+      asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      ledger: 42,
+      ts: '2026-08-20T07:22:16Z',
+    },
+    {
+      tx_hash: 'b'.repeat(64),
+      route: '/api/quote/:id',
+      method: 'POST',
+      payer: PAYER,
+      amount: '2500',
+      asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      ledger: 43,
+      ts: '2026-08-21T07:22:16Z',
+    },
+  ],
+  next_cursor: 'bmV4dC1wYWdl',
+};
+
+const routesBody = {
+  routes: [
+    { route: '/api/hello', method: 'GET', total_revenue: '1000', calls: 1 },
+    { route: '/api/quote/:id', method: 'POST', total_revenue: '2500', calls: 1 },
+  ],
+  truncated: false,
+};
+
+/** A fetch mock that serves one canned JSON body for any request. */
+const jsonFetch = (body: unknown) =>
+  vi.fn<typeof fetch>(
+    async () =>
+      new globalThis.Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  );
+
+const client = (fetchImpl: typeof fetch) =>
+  new AccensaClient({ indexerUrl: 'https://accensa.test', fetchImpl });
+
+describe('AccensaClient.listOrders', () => {
+  it('GETs /api/payments and returns strict Order values', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    const page = await client(fetchImpl).listOrders();
+
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://accensa.test/api/payments');
+    expect(page.orders).toHaveLength(2);
+    expect(page.orders[0]).toMatchObject({ id: TX_HASH, productId: '/api/hello', amount: '1000' });
+    expect(page.nextCursor).toBe('bmV4dC1wYWdl');
+  });
+
+  it('forwards limit and cursor as query parameters', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    await client(fetchImpl).listOrders({ limit: 25, cursor: 'bmV4dC1wYWdl' });
+
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://accensa.test/api/payments?limit=25&cursor=bmV4dC1wYWdl',
+    );
+  });
+
+  it('does not append a query string when no options are given', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    await client(fetchImpl).listOrders();
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://accensa.test/api/payments');
+  });
+});
+
+describe('AccensaClient.fetchOrder', () => {
+  it('finds an order by transaction hash', async () => {
+    const order = await client(jsonFetch(paymentsBody)).fetchOrder(TX_HASH);
+    expect(order?.id).toBe(TX_HASH);
+  });
+
+  it('returns null when the hash is not in the fetched window', async () => {
+    const order = await client(jsonFetch(paymentsBody)).fetchOrder('c'.repeat(64));
+    expect(order).toBeNull();
+  });
+
+  it('defaults to the API-maximum page size and allows overriding it', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    await client(fetchImpl).fetchOrder(TX_HASH);
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('limit=1000');
+
+    await client(fetchImpl).fetchOrder(TX_HASH, { limit: 50 });
+    expect(String(fetchImpl.mock.calls[1][0])).toContain('limit=50');
+  });
+});
+
+describe('AccensaClient.listProducts', () => {
+  it('GETs /api/routes and returns strict Product values', async () => {
+    const fetchImpl = jsonFetch(routesBody);
+    const page = await client(fetchImpl).listProducts();
+
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://accensa.test/api/routes');
+    expect(page.products).toHaveLength(2);
+    expect(page.products[0]).toMatchObject({
+      id: '/api/hello',
+      totalRevenue: '1000',
+      calls: 1,
+    });
+    expect(page.truncated).toBe(false);
+  });
+
+  it('forwards limit, from, and to as query parameters', async () => {
+    const fetchImpl = jsonFetch(routesBody);
+    await client(fetchImpl).listProducts({
+      limit: 10,
+      from: '2026-08-01T00:00:00Z',
+      to: '2026-08-31T00:00:00Z',
+    });
+
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://accensa.test/api/routes?limit=10&from=2026-08-01T00%3A00%3A00Z&to=2026-08-31T00%3A00%3A00Z',
+    );
+  });
+});
+
+describe('AccensaClient.fetchProduct', () => {
+  it('finds a product by route path', async () => {
+    const product = await client(jsonFetch(routesBody)).fetchProduct('/api/hello');
+    expect(product?.id).toBe('/api/hello');
+  });
+
+  it('returns null when the route is not in the fetched window', async () => {
+    const product = await client(jsonFetch(routesBody)).fetchProduct('/api/missing');
+    expect(product).toBeNull();
+  });
+});
+
+describe('AccensaClient — request plumbing', () => {
+  it('strips a trailing slash from indexerUrl', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    const c = new AccensaClient({ indexerUrl: 'https://accensa.test/', fetchImpl });
+    await c.listOrders();
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://accensa.test/api/payments');
+  });
+
+  it('sends the configured headers on every request', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    const c = new AccensaClient({
+      indexerUrl: 'https://accensa.test',
+      headers: { Authorization: 'Bearer secret' },
+      fetchImpl,
+    });
+    await c.listOrders();
+    expect(fetchImpl.mock.calls[0][1]?.headers).toEqual({ Authorization: 'Bearer secret' });
+  });
+
+  it('throws AccensaError with the status on a non-2xx response', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new globalThis.Response(null, { status: 401 }),
+    );
+
+    await expect(client(fetchImpl).listOrders()).rejects.toBeInstanceOf(AccensaError);
+    await expect(client(fetchImpl).listOrders()).rejects.toMatchObject({ status: 401 });
+  });
+
+  it('throws a clear error when a malformed row comes back', async () => {
+    const fetchImpl = jsonFetch({ payments: [{ amount: '1000' }] });
+    await expect(client(fetchImpl).listOrders()).rejects.toThrow(/row at index 0/);
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,0 +1,150 @@
+/**
+ * Typed client for the Accensa indexer's read API.
+ *
+ * Every method returns strict {@link Order} / {@link Product} values produced
+ * by the mappers in `./mapping`, so consuming the SDK gives full autocomplete
+ * on the fields and strict null checks on the optional ones — no `any`, no
+ * `Record<string, unknown>` escaping to the caller.
+ *
+ * The client talks to the same endpoints the dashboard's widgets use
+ * (`GET /api/payments` for orders, `GET /api/routes` for products). Both are
+ * scoped to the authenticated merchant, so a caller must attach whatever
+ * credential the deployment expects (session cookie, API key, …) via
+ * {@link AccensaClientOptions.headers}.
+ */
+
+import { ordersFromResponse, productsFromResponse } from './mapping';
+import type { Order } from './types/order';
+import type { Product } from './types/product';
+
+export interface AccensaClientOptions {
+  /** Base URL of your Accensa deployment, e.g. https://accensa-dashboard.vercel.app */
+  indexerUrl: string;
+  /**
+   * Headers added to every request. The indexer's read endpoints are scoped to
+   * the signed-in merchant, so pass whatever that requires (session cookie,
+   * API key, …).
+   */
+  headers?: Record<string, string>;
+  /** Injected in tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/** A page of {@link Order}s as `/api/payments` returns them. */
+export interface OrdersPage {
+  orders: Order[];
+  /** Opaque cursor for the next page; null when the list is exhausted. */
+  nextCursor: string | null;
+}
+
+/** A page of {@link Product}s as `/api/routes` returns them. */
+export interface ProductsPage {
+  products: Product[];
+  /** Whether more product groups exist than the limit (rolled into "(other)"). */
+  truncated: boolean;
+}
+
+/** Thrown when the indexer responds with a non-2xx status. */
+export class AccensaError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'AccensaError';
+    this.status = status;
+  }
+}
+
+export class AccensaClient {
+  private readonly indexerUrl: string;
+  private readonly headers: Record<string, string>;
+  private readonly fetchImpl?: typeof fetch;
+
+  constructor(opts: AccensaClientOptions) {
+    this.indexerUrl = opts.indexerUrl.replace(/\/$/, '');
+    this.headers = opts.headers ?? {};
+    this.fetchImpl = opts.fetchImpl;
+  }
+
+  /**
+   * Fetches the most recent orders, newest first.
+   *
+   * Mirrors `/api/payments`: `limit` (default 100, max 1000) and an opaque
+   * `cursor` from a previous page's `nextCursor`.
+   */
+  async listOrders(opts: { limit?: number; cursor?: string } = {}): Promise<OrdersPage> {
+    const params = new URLSearchParams();
+    if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+    if (opts.cursor !== undefined) params.set('cursor', opts.cursor);
+
+    const body = await this.getJson(`/api/payments${queryString(params)}`);
+    return ordersFromResponse(body);
+  }
+
+  /**
+   * Looks up one order by its Stellar transaction hash.
+   *
+   * The indexer exposes no lookup-by-hash endpoint, so this searches the most
+   * recent `limit` indexed payments (default 1000, the API maximum). Returns
+   * null when the order is not in that window.
+   */
+  async fetchOrder(orderId: string, opts: { limit?: number } = {}): Promise<Order | null> {
+    const page = await this.listOrders({ limit: opts.limit ?? 1000 });
+    return page.orders.find((order) => order.id === orderId) ?? null;
+  }
+
+  /**
+   * Fetches the merchant's products (paid endpoints) with their indexed
+   * revenue, most revenue first.
+   *
+   * Mirrors `/api/routes`: `limit` (default 50, max 200) and an optional
+   * `from`/`to` ISO-8601 window (defaults to the last 30 days server-side).
+   */
+  async listProducts(
+    opts: { limit?: number; from?: string; to?: string } = {},
+  ): Promise<ProductsPage> {
+    const params = new URLSearchParams();
+    if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+    if (opts.from !== undefined) params.set('from', opts.from);
+    if (opts.to !== undefined) params.set('to', opts.to);
+
+    const body = await this.getJson(`/api/routes${queryString(params)}`);
+    return productsFromResponse(body);
+  }
+
+  /**
+   * Looks up one product by its route path (e.g. `/api/hello`).
+   *
+   * The indexer exposes no lookup-by-route endpoint, so this searches the
+   * top `limit` products by revenue (default 200, the API maximum). Returns
+   * null when the product is not in that window.
+   */
+  async fetchProduct(productId: string, opts: { limit?: number } = {}): Promise<Product | null> {
+    const page = await this.listProducts({ limit: opts.limit ?? 200 });
+    return page.products.find((product) => product.id === productId) ?? null;
+  }
+
+  private async getJson(path: string): Promise<unknown> {
+    const doFetch = this.fetchImpl ?? globalThis.fetch;
+    if (typeof doFetch !== 'function') {
+      throw new AccensaError('No fetch implementation available');
+    }
+
+    const response = await doFetch(`${this.indexerUrl}${path}`, {
+      method: 'GET',
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new AccensaError(`Accensa returned ${response.status} for ${path}`, response.status);
+    }
+
+    const body: unknown = await response.json();
+    return body;
+  }
+}
+
+function queryString(params: URLSearchParams): string {
+  const text = params.toString();
+  return text === '' ? '' : `?${text}`;
+}

--- a/packages/sdk/src/mapping.test.ts
+++ b/packages/sdk/src/mapping.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  orderFromWire,
+  ordersFromResponse,
+  productFromWire,
+  productsFromResponse,
+} from './mapping';
+
+describe('orderFromWire', () => {
+  it('maps a full payment row onto a strict Order', () => {
+    const order = orderFromWire({
+      tx_hash: 'a'.repeat(64),
+      route: '/api/hello',
+      method: 'GET',
+      payer: 'G' + 'A'.repeat(55),
+      amount: '1000',
+      asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      ledger: 42,
+      ts: '2026-08-20T07:22:16Z',
+      metadata: { tier: 'premium' },
+    });
+
+    expect(order).toEqual({
+      id: 'a'.repeat(64),
+      productId: '/api/hello',
+      method: 'GET',
+      payer: 'G' + 'A'.repeat(55),
+      amount: '1000',
+      asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      ledger: 42,
+      createdAt: '2026-08-20T07:22:16Z',
+      metadata: { tier: 'premium' },
+    });
+  });
+
+  it('normalises null optional columns to undefined, never null', () => {
+    const order = orderFromWire({
+      tx_hash: 'a'.repeat(64),
+      route: null,
+      method: null,
+      payer: null,
+      asset: null,
+      ledger: null,
+      ts: '2026-08-20T07:22:16Z',
+      amount: '1000',
+      metadata: null,
+    });
+
+    expect(order).toEqual({
+      id: 'a'.repeat(64),
+      amount: '1000',
+      createdAt: '2026-08-20T07:22:16Z',
+      productId: undefined,
+      asset: undefined,
+      payer: undefined,
+      method: undefined,
+      ledger: undefined,
+      metadata: undefined,
+    });
+    // Strict null checks: optional fields are `undefined`, not `null`.
+    expect(order?.metadata).toBeUndefined();
+    expect(order?.productId).toBeUndefined();
+  });
+
+  it('returns null for a row missing a required field', () => {
+    expect(orderFromWire({ tx_hash: 'a'.repeat(64), ts: '2026-08-20T07:22:16Z' })).toBeNull();
+    expect(orderFromWire({ tx_hash: 'a'.repeat(64), amount: '1000' })).toBeNull();
+    expect(orderFromWire({ amount: '1000', ts: '2026-08-20T07:22:16Z' })).toBeNull();
+  });
+
+  it('returns null for anything that is not a record', () => {
+    expect(orderFromWire(null)).toBeNull();
+    expect(orderFromWire('tx_hash')).toBeNull();
+    expect(orderFromWire(['not', 'a', 'row'])).toBeNull();
+    expect(orderFromWire(undefined)).toBeNull();
+  });
+});
+
+describe('ordersFromResponse', () => {
+  it('parses the payments envelope into orders and the next cursor', () => {
+    const { orders, nextCursor } = ordersFromResponse({
+      payments: [
+        {
+          tx_hash: 'a'.repeat(64),
+          amount: '1000',
+          ts: '2026-08-20T07:22:16Z',
+          route: '/api/hello',
+        },
+      ],
+      next_cursor: 'c2VsbGluZy1jYW5k',
+    });
+
+    expect(orders).toHaveLength(1);
+    expect(orders[0]).toMatchObject({ id: 'a'.repeat(64), productId: '/api/hello' });
+    expect(nextCursor).toBe('c2VsbGluZy1jYW5k');
+  });
+
+  it('treats a missing next_cursor as an exhausted list', () => {
+    const { nextCursor } = ordersFromResponse({ payments: [] });
+    expect(nextCursor).toBeNull();
+  });
+
+  it('throws on a malformed row rather than dropping it', () => {
+    expect(() =>
+      ordersFromResponse({
+        payments: [
+          { tx_hash: 'a'.repeat(64), amount: '1000', ts: '2026-08-20T07:22:16Z' },
+          { amount: '1000', ts: '2026-08-20T07:22:16Z' }, // no tx_hash
+        ],
+      }),
+    ).toThrow(/row at index 1/);
+  });
+
+  it('throws when the body is not a payments envelope', () => {
+    expect(() => ordersFromResponse({ payments: 'nope' })).toThrow(/payments/);
+    expect(() => ordersFromResponse([])).toThrow(/payments/);
+    expect(() => ordersFromResponse(null)).toThrow(/payments/);
+  });
+});
+
+describe('productFromWire', () => {
+  it('maps a route aggregate onto a strict Product', () => {
+    const product = productFromWire({
+      route: '/api/hello',
+      method: 'GET',
+      total_revenue: '5000',
+      calls: 5,
+      metadata: { tier: 'premium' },
+    });
+
+    expect(product).toEqual({
+      id: '/api/hello',
+      method: 'GET',
+      totalRevenue: '5000',
+      calls: 5,
+      metadata: { tier: 'premium' },
+    });
+  });
+
+  it('normalises a null method to undefined', () => {
+    const product = productFromWire({
+      route: '/api/hello',
+      method: null,
+      total_revenue: '5000',
+      calls: 5,
+    });
+    expect(product?.method).toBeUndefined();
+    expect(product).toEqual({
+      id: '/api/hello',
+      method: undefined,
+      totalRevenue: '5000',
+      calls: 5,
+      metadata: undefined,
+    });
+  });
+
+  it('returns null when a required field is missing or mistyped', () => {
+    expect(productFromWire({ route: '/api/hello', total_revenue: '5000' })).toBeNull(); // no calls
+    expect(productFromWire({ route: '/api/hello', calls: 5 })).toBeNull(); // no revenue
+    expect(productFromWire({ total_revenue: '5000', calls: 5 })).toBeNull(); // no route
+    expect(productFromWire({ route: '/api/hello', total_revenue: '5000', calls: '5' })).toBeNull(); // calls as string
+  });
+});
+
+describe('productsFromResponse', () => {
+  it('parses the routes envelope into products and the truncation flag', () => {
+    const { products, truncated } = productsFromResponse({
+      routes: [{ route: '/api/hello', total_revenue: '5000', calls: 5 }],
+      truncated: true,
+    });
+
+    expect(products).toHaveLength(1);
+    expect(products[0]).toMatchObject({ id: '/api/hello', calls: 5 });
+    expect(truncated).toBe(true);
+  });
+
+  it('defaults truncated to false when absent', () => {
+    const { truncated } = productsFromResponse({ routes: [] });
+    expect(truncated).toBe(false);
+  });
+
+  it('throws on a malformed row', () => {
+    expect(() =>
+      productsFromResponse({
+        routes: [{ route: '/api/hello', calls: 5 }],
+      }),
+    ).toThrow(/row at index 0/);
+  });
+
+  it('throws when the body is not a routes envelope', () => {
+    expect(() => productsFromResponse({ routes: 'nope' })).toThrow(/routes/);
+    expect(() => productsFromResponse(null)).toThrow(/routes/);
+  });
+});

--- a/packages/sdk/src/mapping.ts
+++ b/packages/sdk/src/mapping.ts
@@ -1,0 +1,161 @@
+/**
+ * Strict mappers from the indexer's wire rows to the SDK's Order/Product types.
+ *
+ * The indexer publishes payment rows decoded from Soroban `transfer` XDR events,
+ * and route aggregates derived from them (see `apps/web/src/app/api/payments`
+ * and `/api/routes`). These mappers close the last gap: a JSON response — typed
+ * as `unknown` until here — becomes a fully typed `Order` or `Product`, with
+ * `null` optional columns normalised to `undefined` so consumers get real strict
+ * null checks instead of `Record<string, unknown>`.
+ *
+ * The single-row mappers (`orderFromWire`, `productFromWire`) return `null` for
+ * anything unreadable, matching the defensive style of `parseSettlementHeader`.
+ * The response mappers (`ordersFromResponse`, `productsFromResponse`) are
+ * strict: one malformed row throws rather than being silently dropped, because
+ * a page that silently loses rows would mislead a merchant about their ledger.
+ */
+
+import type { Order, OrderMetadata } from './types/order';
+import type { Product, ProductMetadata } from './types/product';
+
+/** True for plain objects — the only thing the mappers accept as a row. */
+export function isWireRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Reads a string column, treating missing, null, and empty as undefined. */
+export function wireString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function wireMetadata(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  return isWireRecord(record.metadata) ? (record.metadata as Record<string, unknown>) : undefined;
+}
+
+/**
+ * Maps one payment row to a strict {@link Order}.
+ *
+ * Accepts the snake-cased shape `/api/payments` publishes (`tx_hash`, `route`,
+ * `amount`, `asset`, `payer`, `method`, `ledger`, `ts`, `metadata`). Returns
+ * null when the row is not a record or lacks a required field (`tx_hash`,
+ * `amount`, `ts`).
+ */
+export function orderFromWire(raw: unknown): Order | null {
+  if (!isWireRecord(raw)) return null;
+
+  const id = wireString(raw, 'tx_hash');
+  const amount = wireString(raw, 'amount');
+  const createdAt = wireString(raw, 'ts');
+  if (!id || !amount || !createdAt) return null;
+
+  const ledger = raw.ledger;
+  const metadata = wireMetadata(raw) as OrderMetadata | undefined;
+
+  return {
+    id,
+    amount,
+    createdAt,
+    productId: wireString(raw, 'route'),
+    asset: wireString(raw, 'asset'),
+    payer: wireString(raw, 'payer'),
+    method: wireString(raw, 'method'),
+    ledger: typeof ledger === 'number' ? ledger : undefined,
+    metadata,
+  };
+}
+
+/** The result of parsing a `/api/payments` response body. */
+export interface OrdersResponse {
+  orders: Order[];
+  /** Opaque cursor for the next page; null when the list is exhausted. */
+  nextCursor: string | null;
+}
+
+/**
+ * Maps a `/api/payments` response body to a strict `{ orders, nextCursor }`.
+ *
+ * Accepts either the envelope (`{ payments: [...], next_cursor }`) or a bare
+ * array of payment rows. Throws on a malformed row — a payment that cannot be
+ * mapped is a contract violation worth surfacing, not a row to silently drop.
+ */
+export function ordersFromResponse(raw: unknown): OrdersResponse {
+  if (!isWireRecord(raw)) {
+    throw new Error('ordersFromResponse: expected an object with a "payments" array');
+  }
+  const rows = Array.isArray(raw.payments) ? raw.payments : null;
+  if (rows === null) {
+    throw new Error('ordersFromResponse: expected a "payments" array');
+  }
+
+  const orders: Order[] = rows.map((row, index) => {
+    const order = orderFromWire(row);
+    if (!order) {
+      throw new Error(
+        `ordersFromResponse: row at index ${index} is missing a required field ` +
+          '(tx_hash, amount, ts)',
+      );
+    }
+    return order;
+  });
+
+  const nextCursor = wireString(raw, 'next_cursor') ?? null;
+  return { orders, nextCursor };
+}
+
+/**
+ * Maps one route-aggregate row to a strict {@link Product}.
+ *
+ * Accepts the snake-cased shape `/api/routes` publishes (`route`, `method`,
+ * `total_revenue`, `calls`, `metadata`). Returns null when the row is not a
+ * record or lacks a required field (`route`, `total_revenue`, `calls`).
+ */
+export function productFromWire(raw: unknown): Product | null {
+  if (!isWireRecord(raw)) return null;
+
+  const id = wireString(raw, 'route');
+  const totalRevenue = wireString(raw, 'total_revenue');
+  if (!id || !totalRevenue || typeof raw.calls !== 'number') return null;
+
+  const metadata = wireMetadata(raw) as ProductMetadata | undefined;
+
+  return {
+    id,
+    totalRevenue,
+    calls: raw.calls,
+    method: wireString(raw, 'method'),
+    metadata,
+  };
+}
+
+/** The result of parsing a `/api/routes` response body. */
+export interface ProductsResponse {
+  products: Product[];
+  /** Whether more product groups exist than the limit (rolled into "(other)"). */
+  truncated: boolean;
+}
+
+/**
+ * Maps a `/api/routes` response body to a strict `{ products, truncated }`.
+ *
+ * Throws on a malformed row, mirroring {@link ordersFromResponse}.
+ */
+export function productsFromResponse(raw: unknown): ProductsResponse {
+  if (!isWireRecord(raw) || !Array.isArray(raw.routes)) {
+    throw new Error('productsFromResponse: expected an object with a "routes" array');
+  }
+
+  const products: Product[] = raw.routes.map((row, index) => {
+    const product = productFromWire(row);
+    if (!product) {
+      throw new Error(
+        `productsFromResponse: row at index ${index} is missing a required field ` +
+          '(route, total_revenue, calls)',
+      );
+    }
+    return product;
+  });
+
+  const truncated = typeof raw.truncated === 'boolean' ? raw.truncated : false;
+  return { products, truncated };
+}

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -1,0 +1,2 @@
+export type { Order, OrderMetadata } from './order';
+export type { Product, ProductMetadata } from './product';

--- a/packages/sdk/src/types/order.ts
+++ b/packages/sdk/src/types/order.ts
@@ -1,0 +1,43 @@
+/**
+ * Strict types for an Accensa order.
+ *
+ * An order is one indexed payment for a merchant's product — a single settled
+ * Stellar Asset Contract transfer that the indexer decoded from Soroban `transfer`
+ * XDR and recorded in the merchant's payment ledger. The SDK's order fetchers
+ * (`AccensaClient.listOrders` / `fetchOrder`) map the indexer's wire rows into
+ * this shape, so consumers never see `Record<string, unknown>`.
+ *
+ * Every column that can be absent on the wire is declared optional (`?`), and
+ * the mappers normalise SQL `NULL` to `undefined` — `metadata` is `undefined`
+ * unless the deployment actually publishes it, never `null` and never `any`.
+ */
+
+/** Free-form metadata a deployment may attach to an order. Strictly optional. */
+export type OrderMetadata = Record<string, unknown>;
+
+export interface Order {
+  /** The Stellar transaction hash that paid for this order. */
+  id: string;
+  /**
+   * The product purchased — the paid route (e.g. `/api/hello`).
+   * Absent until the merchant reports route attribution for the transfer.
+   */
+  productId?: string;
+  /**
+   * Amount paid, as a decimal string. Money crosses this boundary as a string,
+   * never a float, matching the NUMERIC column the indexer writes.
+   */
+  amount: string;
+  /** The asset that settled (Stellar Asset Contract id, e.g. the native XLM SAC). */
+  asset?: string;
+  /** Stellar address of the payer. */
+  payer?: string;
+  /** HTTP method of the paid request. */
+  method?: string;
+  /** Ledger sequence the transfer was observed on. */
+  ledger?: number;
+  /** ISO-8601 timestamp of the payment. */
+  createdAt: string;
+  /** Optional deployment-supplied metadata. `null` on the wire maps to `undefined`. */
+  metadata?: OrderMetadata;
+}

--- a/packages/sdk/src/types/product.ts
+++ b/packages/sdk/src/types/product.ts
@@ -1,0 +1,30 @@
+/**
+ * Strict types for an Accensa product.
+ *
+ * A product is one of a merchant's sellable x402 endpoints. The indexer does not
+ * hold the merchant's price configuration — that lives in the seller's own
+ * `routesConfig` — so what it can publish (and what the SDK fetches) is the
+ * endpoint identity plus the aggregated revenue the ledger actually shows:
+ * how many times the product was paid for and for how much, within a reporting
+ * window.
+ *
+ * As with {@link Order}, optional columns are declared `?` and mapped from SQL
+ * `NULL` to `undefined`, so consumers get strict null checks rather than a
+ * `Record<string, unknown>`.
+ */
+
+/** Free-form metadata a deployment may attach to a product. Strictly optional. */
+export type ProductMetadata = Record<string, unknown>;
+
+export interface Product {
+  /** The paid endpoint this product represents (e.g. `/api/hello`). */
+  id: string;
+  /** HTTP method attributed to the endpoint. Absent when never reported. */
+  method?: string;
+  /** How many times the product was purchased within the reporting window. */
+  calls: number;
+  /** Total revenue within the window, as a decimal string — never a float. */
+  totalRevenue: string;
+  /** Optional deployment-supplied metadata. `null` on the wire maps to `undefined`. */
+  metadata?: ProductMetadata;
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -9,6 +9,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["*.ts"],
+  "include": ["*.ts", "src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.d.ts", "examples"]
 }


### PR DESCRIPTION
## Summary

The SDK previously had no typed surface for reading a merchant's orders and products — consumers had to type indexer API responses themselves, falling back on `any` or `Record<string, unknown>`, which defeats TypeScript in the consuming apps. This PR ports the Order/Product shapes to strict TS types in `packages/sdk/src/types`, adds strict mappers from the indexer's wire rows (themselves decoded from Soroban `transfer` XDR) into those types, and ships a small `AccensaClient` whose `fetchOrder` / `listOrders` / `fetchProduct` / `listProducts` methods all return the strict types.

Closes #126

---

## What changed

### 1. Strict types — `packages/sdk/src/types/`
- **`order.ts`** — `Order` interface: `id` (tx hash), `productId?` (route), `amount` (decimal string, never a float), `asset?`, `payer?`, `method?`, `ledger?`, `createdAt`, and `metadata?`.
- **`product.ts`** — `Product` interface: `id` (route path), `method?`, `calls`, `totalRevenue` (decimal string), and `metadata?`.
- Every column that can be absent on the wire is declared optional (`?`) with strict null checks: `metadata` is `undefined` unless a deployment actually publishes it — never `null`, never `any`.
- Available from the package root and via the new `@accensa/sdk/types` subpath export.

### 2. Strict mappers — `packages/sdk/src/mapping.ts`
- `orderFromWire` / `ordersFromResponse` and `productFromWire` / `productsFromResponse` map the snake-cased JSON the indexer publishes (`/api/payments`, `/api/routes`) into `Order` / `Product`.
- SQL `NULL` optional columns are normalised to `undefined`, and amounts stay strings throughout.
- Single-row mappers return `null` for unreadable input (matching the defensive style of `parseSettlementHeader`); the response mappers throw on a malformed row rather than silently dropping it from a page.

### 3. Typed client — `packages/sdk/src/client.ts`
- `AccensaClient` with:
  - `listOrders({ limit, cursor })` → `OrdersPage` (`orders`, `nextCursor`) — mirrors `GET /api/payments`.
  - `fetchOrder(txHash)` → `Order | null` — searches the most recent 1000 indexed payments (the API max), documented, since no lookup-by-hash endpoint exists yet.
  - `listProducts({ limit, from, to })` → `ProductsPage` (`products`, `truncated`) — mirrors `GET /api/routes`.
  - `fetchProduct(route)` → `Product | null` — searches the top 200 products by revenue, documented.
- `AccensaError` with the HTTP status is thrown for non-2xx responses; `headers` lets callers attach whatever credential the deployment requires (the read endpoints are scoped to the signed-in merchant).

### 4. Wiring
- `index.ts` re-exports the client, mappers, and types.
- `package.json` adds the `./types` export; `tsconfig.json` includes `src/**/*.ts`.

### 5. Tests & docs
- `src/mapping.test.ts` — full-row mapping, `null → undefined` normalisation, required-field validation, malformed-row rejection (15 tests).
- `src/client.test.ts` — endpoints, query params, header passing, trailing-slash handling, `AccensaError` on 401, `fetchOrder`/`fetchProduct` lookups (14 tests).
- `README.md` — short "Reading Orders and Products" section with usage.

---

## Design notes

- **What an "order" is here**: one indexed payment — a settled Stellar Asset Contract transfer the indexer decoded from Soroban XDR and recorded in the merchant's ledger. The dashboard's "Recent Orders" widget reads exactly this data (`/api/payments`).
- **What a "product" is here**: one of the merchant's sellable x402 endpoints, as the indexer sees it — identity plus aggregated `calls` / `totalRevenue` within the reporting window. Price configuration lives in the seller's own `routesConfig`, which the indexer does not hold, so the SDK types what the API can actually return rather than inventing fields.
- **Why optional fields are `undefined`, not `null`**: strict null checks (`metadata?: …`) are the acceptance criterion. Mappers convert SQL `NULL` to `undefined`, so a consumer never has to handle both.
- **Why amounts are strings**: the indexer writes money as `NUMERIC` and serves it as text (`amount::text`); the SDK preserves that invariant so money never crosses this boundary as a float.

---

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Consuming the SDK provides full autocomplete for Order and Product fields | ✅ `Order`/`Product` exported from the root and `@accensa/sdk/types`, used as the return types of every client method |
| Strict null checks are enforced on optional fields (e.g. `metadata`) | ✅ optional fields declared `?`, mappers normalise `null → undefined` |
| SDK builds without TS errors | ✅ `pnpm typecheck` passes for web and SDK |

## Testing

- `pnpm --filter @accensa/sdk test` — 6 files, 110 tests passed (29 new).
- `pnpm typecheck` — web and SDK both clean.
- `pnpm exec prettier --check packages/sdk` — clean.
