### PR TITLE
feat(web): add server-side pagination to transaction history

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,8 @@
     "next-themes": "^0.4.6",
     "pg": "^8.22.0",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "swr": "^2.5.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.2",

--- a/apps/web/src/app/api/payments/route.test.ts
+++ b/apps/web/src/app/api/payments/route.test.ts
@@ -80,6 +80,41 @@ describe('/api/payments GET', () => {
     });
   });
 
+  describe('page validation', () => {
+    test('rejects non-numeric page (e.g. abc)', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?page=abc'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('page must be an integer >= 1');
+    });
+
+    test('rejects page 0 and negative pages', async () => {
+      for (const page of ['0', '-1']) {
+        const res = await GET(mockRequest(`http://localhost/api/payments?page=${page}`));
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toBe('page must be an integer >= 1');
+      }
+    });
+
+    test('rejects float page', async () => {
+      const res = await GET(mockRequest('http://localhost/api/payments?page=1.5'));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('page must be an integer >= 1');
+    });
+
+    test('rejects combining page and cursor', async () => {
+      const cursor = Buffer.from(`${new Date().toISOString()}|${'a'.repeat(64)}`).toString(
+        'base64',
+      );
+      const res = await GET(mockRequest(`http://localhost/api/payments?page=2&cursor=${cursor}`));
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe('page and cursor cannot be combined');
+    });
+  });
+
   describe('cursor validation', () => {
     test('rejects non-base64 cursor', async () => {
       const res = await GET(mockRequest('http://localhost/api/payments?cursor=not-base64-!@#$'));
@@ -134,6 +169,92 @@ describe('/api/payments GET', () => {
       const [sql, params] = query.mock.calls[0];
       expect(sql).toContain('merchant_id = $1');
       expect(params[0]).toBe(MERCHANT.id);
+    });
+  });
+
+  describe('offset pagination', () => {
+    const row = {
+      tx_hash: 'a'.repeat(64),
+      ledger: 42,
+      payer: 'GPAYER',
+      amount: '1000',
+      asset: 'XLM',
+      ts: new Date('2026-08-20T07:22:16Z'),
+      route: '/api/hello',
+      method: 'GET',
+      total: 120,
+      total_amount: '120000',
+      total_asset: 'XLM',
+    };
+
+    const queryFor = (rows: unknown[]) => vi.fn().mockResolvedValue({ rows });
+
+    test('page=2&limit=50 translates to LIMIT 50 OFFSET 50', async () => {
+      const query = queryFor([row]);
+      mockWithMerchantClient.mockImplementationOnce(
+        async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) => fn({ query }),
+      );
+
+      const res = await GET(mockRequest('http://localhost/api/payments?page=2&limit=50'));
+      expect(res.status).toBe(200);
+      const [sql, params] = query.mock.calls[0];
+      expect(sql).toContain('LIMIT $2');
+      expect(sql).toContain('OFFSET $3');
+      expect(params).toEqual([MERCHANT.id, 50, 50]);
+    });
+
+    test('no page parameter defaults to page 1, i.e. OFFSET 0', async () => {
+      const query = queryFor([]);
+      mockWithMerchantClient.mockImplementationOnce(
+        async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) => fn({ query }),
+      );
+
+      const res = await GET(mockRequest('http://localhost/api/payments?limit=25'));
+      expect(res.status).toBe(200);
+      const [sql, params] = query.mock.calls[0];
+      expect(sql).toContain('LIMIT $2');
+      expect(sql).toContain('OFFSET $3');
+      expect(params).toEqual([MERCHANT.id, 25, 0]);
+    });
+
+    test('page 3 with limit 50 offsets by 100', async () => {
+      const query = queryFor([]);
+      mockWithMerchantClient.mockImplementationOnce(
+        async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) => fn({ query }),
+      );
+
+      await GET(mockRequest('http://localhost/api/payments?page=3&limit=50'));
+      const [, params] = query.mock.calls[0];
+      expect(params).toEqual([MERCHANT.id, 50, 100]);
+    });
+
+    test('returns aggregates from the window columns', async () => {
+      const query = queryFor([row]);
+      mockWithMerchantClient.mockImplementationOnce(
+        async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) => fn({ query }),
+      );
+
+      const res = await GET(mockRequest('http://localhost/api/payments?page=1&limit=50'));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.total).toBe(120);
+      expect(data.total_amount).toBe('120000');
+      expect(data.total_asset).toBe('XLM');
+      expect(data.total_pages).toBe(3);
+    });
+
+    test('reports zero totals on an empty result', async () => {
+      const query = queryFor([]);
+      mockWithMerchantClient.mockImplementationOnce(
+        async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) => fn({ query }),
+      );
+
+      const res = await GET(mockRequest('http://localhost/api/payments?page=1&limit=50'));
+      const data = await res.json();
+      expect(data.total).toBe(0);
+      expect(data.total_amount).toBe('0');
+      expect(data.total_asset).toBeNull();
+      expect(data.total_pages).toBe(0);
     });
   });
 });

--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -22,7 +22,16 @@ export interface PaymentsResponse {
   payments: PaymentRow[];
   /** Null until the indexer has run at least once. */
   sync: SyncState | null;
+  /** Opaque keyset cursor for the next page; null when the list is exhausted. */
   next_cursor?: string | null;
+  /** Total number of indexed payments for this merchant. */
+  total: number;
+  /** Sum of every payment amount, as a decimal string. */
+  total_amount: string;
+  /** Raw asset when every payment is in one asset, else null. */
+  total_asset: string | null;
+  /** ceil(total / limit); 0 when there are no payments. */
+  total_pages: number;
 }
 
 export async function GET(request: Request) {
@@ -44,9 +53,27 @@ export async function GET(request: Request) {
     limit = parsed;
   }
 
+  // Page-based (offset) pagination, e.g. ?page=2&limit=50. Absent means page 1,
+  // which keeps every existing no-parameter caller (the routes page, the SDK's
+  // first page) on exactly the behaviour they had.
+  const pageParam = searchParams.get('page');
+  let page = 1;
+  if (pageParam !== null) {
+    const parsed = Number.parseFloat(pageParam);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      return NextResponse.json({ error: 'page must be an integer >= 1' }, { status: 400 });
+    }
+    page = parsed;
+  }
+
+  // Cursor-based (keyset) pagination, used by @accensa/sdk. The two schemes are
+  // mutually exclusive: a request cannot offset and keyset at the same time.
   const cursor = searchParams.get('cursor');
   let parsedCursor: { ts: string; txHash: string } | null = null;
   if (cursor) {
+    if (pageParam !== null) {
+      return NextResponse.json({ error: 'page and cursor cannot be combined' }, { status: 400 });
+    }
     try {
       const decoded = Buffer.from(cursor, 'base64').toString('utf8');
       const parts = decoded.split('|');
@@ -63,6 +90,8 @@ export async function GET(request: Request) {
     }
   }
 
+  const offset = (page - 1) * limit;
+
   try {
     const merchant = await withClient((client) => getMerchantFromRequest(client, request));
     if (!merchant) {
@@ -72,7 +101,17 @@ export async function GET(request: Request) {
     const { rows, sync } = await withMerchantClient(merchant.id, async (client) => {
       await ensureSchema(client);
 
-      let query = `SELECT tx_hash, ledger, payer, amount::text AS amount, asset, ts, route, method FROM payments WHERE merchant_id = $1 AND ts IS NOT NULL`;
+      // Window functions evaluate over the full filtered row set before LIMIT
+      // and OFFSET are applied, so one query returns both the page and the
+      // aggregates the dashboard header needs (total count, sum, single-asset
+      // detection via min = max).
+      let query = `SELECT tx_hash, ledger, payer, amount::text AS amount, asset, ts, route, method,
+                         COUNT(*) OVER() AS total,
+                         COALESCE(SUM(amount) OVER(), 0) AS total_amount,
+                         CASE WHEN MIN(COALESCE(asset, 'native')) OVER() =
+                                   MAX(COALESCE(asset, 'native')) OVER()
+                              THEN MIN(COALESCE(asset, 'native')) OVER() END AS total_asset
+                  FROM payments WHERE merchant_id = $1 AND ts IS NOT NULL`;
       const params: (string | number)[] = [merchant.id];
       if (parsedCursor) {
         query += ` AND (ts < $${params.length + 1} OR (ts = $${params.length + 1} AND tx_hash < $${params.length + 2}))`;
@@ -82,9 +121,21 @@ export async function GET(request: Request) {
       query += ` ORDER BY ts DESC, tx_hash DESC LIMIT $${params.length + 1}`;
       params.push(limit);
 
+      if (!parsedCursor) {
+        query += ` OFFSET $${params.length + 1}`;
+        params.push(offset);
+      }
+
       const result = await client.query(query, params);
       return { rows: result.rows, sync: await getSyncState(client, merchant.id) };
     });
+
+    // The fake databases in tests do not return the window columns; tolerate
+    // their absence so aggregate handling is uniform.
+    const total = rows.length > 0 ? Number(rows[0].total ?? 0) : 0;
+    const totalAmount = rows.length > 0 ? String(rows[0].total_amount ?? 0) : '0';
+    const totalAsset = rows.length > 0 ? (rows[0].total_asset ?? null) : null;
+    const totalPages = total === 0 ? 0 : Math.ceil(total / limit);
 
     const next_cursor =
       rows.length === limit
@@ -106,6 +157,10 @@ export async function GET(request: Request) {
       })),
       sync,
       next_cursor,
+      total,
+      total_amount: totalAmount,
+      total_asset: totalAsset,
+      total_pages: totalPages,
     };
     return NextResponse.json(body);
   } catch (error: unknown) {

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,16 +1,19 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { formatAmount, sumAmounts, assetLabel } from '@/lib/money';
 import { describeSync, type SyncState } from '@/lib/sync-status';
 import { CSV_BOM, paymentsCsvFilename, paymentsToCsv } from '@/lib/payments-csv';
 import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import useSWR from 'swr';
 import { ArrowUpRight } from 'lucide-react';
 import { PageContainer } from '@/components/page-container';
 import { RefundPanel } from '@/components/refund-panel';
 import { CopyButton } from '@/components/copy-button';
 import { useOnline } from '@/components/network-status';
-import { describeFailure, isAbortError } from '@/lib/network-status';
+import { describeFailure } from '@/lib/network-status';
+import { Pagination } from '@/components/pagination';
 
 interface Payment {
   tx_hash: string;
@@ -25,11 +28,35 @@ interface Payment {
 
 type LoadState =
   | { status: 'loading' }
-  | { status: 'ready'; payments: Payment[]; fetchedAt: number; sync: SyncState | null }
+  | { status: 'ready'; payments: Payment[]; sync: SyncState | null }
   | { status: 'error'; message: string };
 
+/** A page of payments as `/api/payments` returns them. */
+interface PaymentsResponse {
+  payments: Payment[];
+  sync: SyncState | null;
+  /** Total indexed payments for the merchant; server-side aggregate. */
+  total?: number;
+  /** Sum of every payment amount; server-side aggregate. */
+  total_amount?: string;
+  /** Raw asset when every payment is in one asset; server-side aggregate. */
+  total_asset?: string | null;
+  /** ceil(total / limit); absent on older deploys. */
+  total_pages?: number;
+}
+
+/** Chunk size for the transaction history. */
+const PAGE_SIZE = 50;
 const POLL_INTERVAL_MS = 15_000;
 const explorerUrl = (hash: string) => `https://stellar.expert/explorer/testnet/tx/${hash}`;
+
+const paymentsUrl = (page: number) => `/api/payments?limit=${PAGE_SIZE}&page=${page}`;
+
+async function fetchPaymentsPage(url: string): Promise<PaymentsResponse> {
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error ?? `Error ${res.status}`);
+  return res.json();
+}
 
 function truncate(value: string, head = 8, tail = 6) {
   return value.length <= head + tail + 1 ? value : `${value.slice(0, head)}…${value.slice(-tail)}`;
@@ -58,11 +85,9 @@ function saveRefundedToStorage(refunded: ReadonlySet<string>): void {
   }
 }
 
-export default function Dashboard() {
-  const [state, setState] = useState<LoadState>({ status: 'loading' });
+export function Dashboard() {
   const [selected, setSelected] = useState<Payment | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const [reloadToken, setReloadToken] = useState(0);
   // Refunds issued in this session. The indexer does not watch RefundVault
   // events yet, so a refund is otherwise invisible until someone opens the
   // payment again and the contract is re-read.
@@ -73,44 +98,56 @@ export default function Dashboard() {
   );
   const online = useOnline();
 
-  const reload = useCallback(() => setReloadToken((n) => n + 1), []);
+  // The current page lives in the URL (?page=2) so it survives reloads and can
+  // be linked to; searchParams is the single source of truth, and `goToPage`
+  // writes a new URL that the router re-renders this component with.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const pageParam = Number(searchParams.get('page') ?? '1');
+  const page = Number.isInteger(pageParam) && pageParam >= 1 ? pageParam : 1;
 
-  // `online` is a dependency, not just a guard: polling stops while the browser
-  // has no connection - every request would fail and overwrite a good table with
-  // an error - and reconnecting re-runs the effect, which refetches immediately
-  // rather than waiting out the remainder of a 15s tick.
-  useEffect(() => {
-    if (!online) return;
-    const controller = new AbortController();
-    async function fetchPayments() {
-      try {
-        const res = await fetch('/api/payments', { signal: controller.signal, cache: 'no-store' });
-        if (!res.ok)
-          throw new Error((await res.json().catch(() => ({}))).error ?? `Error ${res.status}`);
-        const data = await res.json();
-        // Tolerate both shapes: the endpoint used to return a bare array, and
-        // a deploy can briefly serve an older build to an already-open tab.
-        const payments: Payment[] = Array.isArray(data) ? data : (data.payments ?? []);
-        const sync: SyncState | null = Array.isArray(data) ? null : (data.sync ?? null);
-        if (!controller.signal.aborted) {
-          setState({ status: 'ready', payments, fetchedAt: Date.now(), sync });
-        }
-      } catch (error) {
-        // Re-read navigator.onLine here rather than closing over `online`: the
-        // connection can drop between the request going out and it failing,
-        // and that is exactly the case worth naming correctly.
-        if (!controller.signal.aborted && !isAbortError(error)) {
-          setState({ status: 'error', message: describeFailure(error, navigator.onLine) });
-        }
-      }
-    }
-    void fetchPayments();
-    const timer = setInterval(fetchPayments, POLL_INTERVAL_MS);
-    return () => {
-      controller.abort();
-      clearInterval(timer);
-    };
-  }, [reloadToken, online]);
+  const goToPage = useCallback(
+    (next: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next <= 1) params.delete('page');
+      else params.set('page', String(next));
+      router.replace(`${pathname}${params.toString() ? `?${params.toString()}` : ''}`, {
+        scroll: false,
+      });
+    },
+    [router, pathname, searchParams],
+  );
+
+  // SWR caches each ?page=N response keyed by URL, so paging back to a visited
+  // page is instant. The 15s poll keeps only the visible page fresh, and the
+  // `online` gate means a disconnected browser stops requesting (every request
+  // would fail and replace a good table with an error); reconnecting turns the
+  // key back on, which refetches immediately rather than waiting out a tick.
+  const { data, error, mutate } = useSWR<PaymentsResponse>(
+    online ? paymentsUrl(page) : null,
+    fetchPaymentsPage,
+    { refreshInterval: POLL_INTERVAL_MS, keepPreviousData: true },
+  );
+
+  // Refresh on demand (retry, or after a manual sync).
+  const reload = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+
+  const state: LoadState = error
+    ? { status: 'error', message: describeFailure(error, navigator.onLine) }
+    : !data
+      ? { status: 'loading' }
+      : { status: 'ready', payments: data.payments, sync: data.sync ?? null };
+
+  const payments: Payment[] = data?.payments ?? [];
+  const totalPages = data?.total_pages ?? 0;
+
+  // Prefetch the next page into SWR's cache as soon as this one is known, so
+  // clicking Next is instant. Renders nothing; the cache is the whole point.
+  const hasNext = totalPages > page;
+  useSWR(hasNext ? paymentsUrl(page + 1) : null, fetchPaymentsPage);
 
   useEffect(() => {
     if (!selected) return;
@@ -120,10 +157,17 @@ export default function Dashboard() {
     return () => document.removeEventListener('keydown', onKey);
   }, [selected]);
 
-  const payments = state.status === 'ready' ? state.payments : [];
-  const total = sumAmounts(payments.map((p) => p.amount));
-  const assets = new Set(payments.map((p) => assetLabel(p.asset)));
-  const totalAsset = assets.size === 1 ? [...assets][0] : '';
+  // The header total covers every payment, not just the visible page, so the
+  // number does not shrink when the merchant pages forward. Older deploys that
+  // lack the server-side aggregates fall back to summing what is on screen.
+  let total = sumAmounts(payments.map((p) => p.amount));
+  let totalAsset = '';
+  const pageAssets = new Set(payments.map((p) => assetLabel(p.asset)));
+  if (pageAssets.size === 1) totalAsset = [...pageAssets][0];
+  if (data?.total_amount != null) {
+    total = data.total_amount;
+    totalAsset = data.total_asset ? assetLabel(data.total_asset) : '';
+  }
 
   return (
     <main className="min-h-screen text-slate-600 dark:text-slate-200 font-sans selection:bg-slate-200 dark:selection:bg-white/10 transition-colors duration-300 bg-grid p-6 md:p-12 lg:p-20 pt-28 md:pt-32 lg:pt-32">
@@ -205,7 +249,7 @@ export default function Dashboard() {
               </div>
             )}
 
-            {state.status === 'ready' && payments.length === 0 && (
+            {state.status === 'ready' && payments.length === 0 && (data?.total ?? 0) === 0 && (
               <div className="flex flex-col items-center justify-center h-[400px] text-center space-y-4 px-6">
                 <div className="w-12 h-12 bg-emerald-400 dark:bg-emerald-500/10 flex items-center justify-center text-emerald-600 dark:text-emerald-400 mb-2 animate-pulse">
                   ●
@@ -216,6 +260,24 @@ export default function Dashboard() {
                 <p className="text-slate-500 dark:text-slate-400 text-sm max-w-sm">
                   Payments settled to this merchant address will appear here automatically.
                 </p>
+              </div>
+            )}
+
+            {state.status === 'ready' && payments.length === 0 && (data?.total ?? 0) > 0 && (
+              <div className="flex flex-col items-center justify-center h-[400px] text-center space-y-4 px-6">
+                <p className="text-xl font-black tracking-tighter text-slate-900 dark:text-white">
+                  No payments on this page
+                </p>
+                <p className="text-slate-500 dark:text-slate-400 text-sm max-w-sm">
+                  The list has {(data?.total ?? 0).toLocaleString()} payments. Jump back to the
+                  first page to see the newest ones.
+                </p>
+                <button
+                  onClick={() => goToPage(1)}
+                  className="mt-2 px-6 py-3 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white text-sm font-bold hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 dark:hover:border-white/20 transition-colors shadow-sm dark:shadow-none"
+                >
+                  Back to first page
+                </button>
               </div>
             )}
 
@@ -291,6 +353,12 @@ export default function Dashboard() {
               </>
             )}
           </div>
+
+          {state.status === 'ready' && totalPages > 1 && (
+            <div className="px-8 py-5 border-t border-slate-100 dark:border-white/5 bg-white/30 dark:bg-black/30 backdrop-blur-xl transition-colors duration-300">
+              <Pagination page={page} totalPages={totalPages} onPageChange={goToPage} />
+            </div>
+          )}
         </section>
       </PageContainer>
 
@@ -388,7 +456,7 @@ export function PaymentModal({
               href={explorerUrl(selected.tx_hash)}
               target="_blank"
               rel="noreferrer"
-               className="flex items-center justify-center gap-1.5 w-full py-4 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 dark:hover:border-white/20 shadow-sm dark:shadow-none transition-all font-bold text-sm tracking-wide uppercase"
+              className="flex items-center justify-center gap-1.5 w-full py-4 bg-white dark:bg-white/5 border border-slate-200 dark:border-white/10 text-slate-700 dark:text-white hover:bg-slate-50 dark:hover:bg-white/10 hover:border-slate-300 dark:hover:border-white/20 shadow-sm dark:shadow-none transition-all font-bold text-sm tracking-wide uppercase"
             >
               View on Explorer <ArrowUpRight className="w-4 h-4 opacity-70" />
             </a>
@@ -530,9 +598,9 @@ function StatusPill({ state, onRetry }: { state: LoadState; onRetry: () => void 
         <span className="w-2 h-2 bg-red-500" /> Retry Connection
       </button>
     );
-  // Deliberately reports the indexer's timestamp, not state.fetchedAt. The poll
-  // succeeding says nothing about how current the data behind it is, and the
-  // sync job lands every 1-3 hours in practice.
+  // Deliberately reports the indexer's timestamp, not when the poll last
+  // succeeded. The poll succeeding says nothing about how current the data
+  // behind it is, and the sync job lands every 1-3 hours in practice.
   const { level, age, detail } = describeSync(state.sync);
 
   const tone = {
@@ -690,9 +758,8 @@ function SyncNowButton({ onSynced }: { onSynced: () => void }) {
 /**
  * Downloads the payment history the table is showing as a CSV file.
  *
- * Exports what is on screen rather than re-fetching: /api/payments is already
- * the whole set the dashboard has (newest 100), and re-requesting would mean
- * the file could disagree with the rows the merchant was looking at.
+ * Exports what is on screen rather than re-fetching every page: the file then
+ * always matches the rows the merchant was looking at, whatever page that is.
  *
  * Serialization lives in lib/payments-csv so it can be tested without a DOM;
  * this only turns the text into a download.
@@ -755,5 +822,19 @@ function TableSkeleton() {
         />
       ))}
     </div>
+  );
+}
+
+/**
+ * The page reads the current page from the URL (?page=2) via useSearchParams,
+ * which must sit inside a Suspense boundary during prerendering — otherwise the
+ * production build fails. The dashboard itself is wrapped below; the modal and
+ * table exports stay named so tests can import them directly.
+ */
+export default function DashboardPage() {
+  return (
+    <Suspense fallback={null}>
+      <Dashboard />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/pagination.test.tsx
+++ b/apps/web/src/components/pagination.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { Pagination, pageWindow } from './pagination';
+
+describe('pageWindow', () => {
+  it('lists every page when there are seven or fewer', () => {
+    expect(pageWindow(1, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(pageWindow(3, 1)).toEqual([1]);
+    expect(pageWindow(4, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('pins the first and last pages with an ellipsis for the gap', () => {
+    expect(pageWindow(1, 20)).toEqual([1, 2, '…', 20]);
+    expect(pageWindow(10, 20)).toEqual([1, '…', 9, 10, 11, '…', 20]);
+    expect(pageWindow(20, 20)).toEqual([1, '…', 19, 20]);
+    expect(pageWindow(2, 20)).toEqual([1, 2, 3, '…', 20]);
+  });
+});
+
+describe('Pagination', () => {
+  const buttonHtml = (html: string, label: string) =>
+    html.match(new RegExp(`<button[^>]*>${label}</button>`))?.[0] ?? '';
+
+  // The button classes include `disabled:cursor-not-allowed` even when enabled,
+  // so look for the actual `disabled` attribute rather than the substring.
+  const isDisabled = (html: string, label: string) => /\sdisabled=/.test(buttonHtml(html, label));
+
+  it('renders nothing when there is a single page', () => {
+    const html = renderToString(<Pagination page={1} totalPages={1} onPageChange={() => {}} />);
+    expect(html).toBe('');
+  });
+
+  it('renders nothing when there are no pages at all', () => {
+    const html = renderToString(<Pagination page={1} totalPages={0} onPageChange={() => {}} />);
+    expect(html).toBe('');
+  });
+
+  it('disables Previous on the first page but not Next', () => {
+    const html = renderToString(<Pagination page={1} totalPages={5} onPageChange={() => {}} />);
+    expect(isDisabled(html, 'Previous')).toBe(true);
+    expect(isDisabled(html, 'Next')).toBe(false);
+  });
+
+  it('disables Next on the last page but not Previous', () => {
+    const html = renderToString(<Pagination page={5} totalPages={5} onPageChange={() => {}} />);
+    expect(isDisabled(html, 'Next')).toBe(true);
+    expect(isDisabled(html, 'Previous')).toBe(false);
+  });
+
+  it('marks the current page with aria-current and labels every page button', () => {
+    const html = renderToString(<Pagination page={3} totalPages={5} onPageChange={() => {}} />);
+    expect(html).toContain('aria-current="page"');
+    for (const n of [1, 2, 3, 4, 5]) {
+      expect(html).toContain(`aria-label="Page ${n}"`);
+    }
+  });
+
+  it('exposes a labelled navigation landmark', () => {
+    const html = renderToString(<Pagination page={1} totalPages={3} onPageChange={() => {}} />);
+    expect(html).toContain('<nav aria-label="Pagination"');
+  });
+});

--- a/apps/web/src/components/pagination.tsx
+++ b/apps/web/src/components/pagination.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+/**
+ * Server-side pagination controls for the transaction history table.
+ *
+ * Renders Previous/Next buttons plus a window of page numbers around the
+ * current page. Next is disabled on the last page and Previous on the first,
+ * so the merchant always knows where the list ends without a request.
+ *
+ * The page-window logic is exported separately ({@link pageWindow}) so it can
+ * be unit tested without a DOM.
+ */
+
+export type PageWindowEntry = number | '…';
+
+/**
+ * The page numbers to render, with ellipses for the gap.
+ *
+ * Shows every page when there are seven or fewer; otherwise a window of the
+ * current page's neighbours pinned to the first and last pages:
+ *
+ * - total 20, current 1  -> [1, 2, …, 20]
+ * - total 20, current 10 -> [1, …, 9, 10, 11, …, 20]
+ */
+export function pageWindow(current: number, total: number): PageWindowEntry[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+  const wanted = new Set([1, total, current - 1, current, current + 1]);
+  const sorted = [...wanted].filter((p) => p >= 1 && p <= total).sort((a, b) => a - b);
+
+  const entries: PageWindowEntry[] = [];
+  let previous = 0;
+  for (const page of sorted) {
+    if (page - previous > 1) entries.push('…');
+    entries.push(page);
+    previous = page;
+  }
+  return entries;
+}
+
+export interface PaginationProps {
+  /** The page currently shown (1-based). */
+  page: number;
+  /** Total number of pages; 0 means there is nothing to page over. */
+  totalPages: number;
+  /** Called with the requested page when a control is activated. */
+  onPageChange: (page: number) => void;
+}
+
+export function Pagination({ page, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const canGoBack = page > 1;
+  const canGoForward = page < totalPages;
+
+  const controlClass = (enabled: boolean) =>
+    `px-3 py-2 text-[10px] font-bold uppercase tracking-widest border transition-colors cursor-pointer disabled:cursor-not-allowed ${
+      enabled
+        ? 'border-slate-200 dark:border-white/10 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-white/5'
+        : 'border-slate-100 dark:border-white/5 text-slate-300 dark:text-slate-600 opacity-60'
+    }`;
+
+  return (
+    <nav aria-label="Pagination" className="flex items-center justify-between gap-4">
+      <button
+        type="button"
+        onClick={() => onPageChange(page - 1)}
+        disabled={!canGoBack}
+        className={controlClass(canGoBack)}
+      >
+        Previous
+      </button>
+
+      <div className="flex items-center gap-1.5">
+        {pageWindow(page, totalPages).map((entry, index) =>
+          entry === '…' ? (
+            <span
+              key={`ellipsis-${index}`}
+              aria-hidden="true"
+              className="px-1 text-slate-400 dark:text-slate-500"
+            >
+              …
+            </span>
+          ) : (
+            <button
+              key={entry}
+              type="button"
+              onClick={() => onPageChange(entry)}
+              aria-current={entry === page ? 'page' : undefined}
+              aria-label={`Page ${entry}`}
+              className={`min-w-9 px-2 py-2 text-xs font-bold tabular-nums transition-colors cursor-pointer ${
+                entry === page
+                  ? 'bg-emerald-500/15 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-300'
+                  : 'text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-white/5'
+              }`}
+            >
+              {entry}
+            </button>
+          ),
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onPageChange(page + 1)}
+        disabled={!canGoForward}
+        className={controlClass(canGoForward)}
+      >
+        Next
+      </button>
+    </nav>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 2.21.0
       '@x402/express':
         specifier: ^2.21.0
-        version: 2.21.0(express@5.2.1)(typescript@5.9.3)
+        version: 2.21.0(express@5.2.1)(typescript@6.0.3)
       '@x402/stellar':
         specifier: ^2.21.0
         version: 2.21.0
@@ -105,6 +105,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      swr:
+        specifier: ^2.5.1
+        version: 2.5.1(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.3.2
@@ -1602,89 +1605,105 @@ packages:
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.3':
     resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.3':
     resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.3':
     resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.3':
     resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
@@ -1922,24 +1941,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.3.0':
     resolution: {integrity: sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.3.0':
     resolution: {integrity: sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.3.0':
     resolution: {integrity: sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.3.0':
     resolution: {integrity: sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==}
@@ -2085,66 +2108,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -2190,21 +2226,25 @@ packages:
     resolution: {integrity: sha512-C8owWG+yvo7X0oVLIXetkoJhIFBP1LYNcAQqtgLmJnQLQDklGuP83dKC+zISGQWpjawHfZ1ER96vLgoTrxKZdw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.7.12':
     resolution: {integrity: sha512-i51WWI64aRpsfSki6rN0aepPqXkVfS+vZM7+4bWDcmnhUmdMvhIPcYg0QRk3DtyJnu33jqNLM0WHY78k00NyfA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.7.12':
     resolution: {integrity: sha512-MSos0FuPEefqo9V92ULd5hggKG29EkSNg1zDcypy0OkpsKh5pfjVxTLYFXgTcVyFoUQQbdG8zFBzYbwmJ8V4ew==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.7.12':
     resolution: {integrity: sha512-JcAMVKXOnjfpC3coWjCFPWD3Yl8RBw6a+IXQQ8mfRlHaHMIiOv8IfZqx15XRxMUn49CtP7Z0Na8iiAg2aKrcfw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.7.12':
     resolution: {integrity: sha512-n+ZqP6ZMc0nhOgvadg5VhEs9ojtbES80AcWeFnmGkbzIszvGSO63GKNiRkXtjJ9KFuRzytbbmsCqkUVH+Tywxg==}
@@ -2408,36 +2448,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.43':
     resolution: {integrity: sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.43':
     resolution: {integrity: sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.43':
     resolution: {integrity: sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.43':
     resolution: {integrity: sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.43':
     resolution: {integrity: sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.43':
     resolution: {integrity: sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==}
@@ -2495,36 +2541,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/html-linux-arm64-musl@1.15.43':
     resolution: {integrity: sha512-TweIdl/g9ugkoiYvcL/qbu+gbglDY3TqNxfXH84WXc4rSqEP20owVlxLya2NjVct8LIP2wDrtutpOwAXWC+Eew==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/html-linux-ppc64-gnu@1.15.43':
     resolution: {integrity: sha512-4oue1pB38/W6mbudp+w0q1jbwxuwdbdbaOj85ay0pisCs213WkgP+MPN8Zqa5VVPjQnVk2CTY9kmEc74XQI/sA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/html-linux-s390x-gnu@1.15.43':
     resolution: {integrity: sha512-/tceMNvAxK70SKUZtcn3X+K0vcElMGk3i8Sz0CmPdtooso8MZ7WfAvVP1qi3TWgh1rpQ3cC+Al3433AHlET6+w==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/html-linux-x64-gnu@1.15.43':
     resolution: {integrity: sha512-YE7ltlTt5ZFl59GsoHTDrIHnCBY8EDBio66CVj4bqkElFXbE/28xmpVE5ksdGoI5c5aQ/8byUCfHxqzCzQQSVg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/html-linux-x64-musl@1.15.43':
     resolution: {integrity: sha512-nS20HmbOk+dEEzdosJqqxAeyjMIiS5yrCAti8LUf0+dgr4eRmjkH4MlkjfPjf49aayR8o+eMJ1jsDZ7whx4zog==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/html-win32-arm64-msvc@1.15.43':
     resolution: {integrity: sha512-Yz7aQQhXT/Yc6QcuMDQDZP9jqf2phkVyU+qSu8ZRWEcJgIorrPL6q7YLqMk+MB5PpZyu5XJEODvc1/UVDE1Kyg==}
@@ -2593,24 +2645,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
@@ -2911,51 +2967,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -5203,24 +5269,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7107,6 +7177,11 @@ packages:
       '@swc/core': ^1.2.147
       webpack: '>=2'
 
+  swr@2.5.1:
+    resolution: {integrity: sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwindcss@4.3.2:
     resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
@@ -7390,6 +7465,11 @@ packages:
     peerDependenciesMeta:
       file-loader:
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -9000,24 +9080,24 @@ snapshots:
       '@docusaurus/logger': 3.10.2
       '@docusaurus/types': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-      css-loader: 6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      copy-webpack-plugin: 11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      css-loader: 6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       cssnano: 6.1.2(postcss@8.5.25)
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-      null-loader: 4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      null-loader: 4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       postcss: 8.5.25
-      postcss-loader: 7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      postcss-loader: 7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       postcss-preset-env: 10.6.1(postcss@8.5.25)
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
-      webpackbar: 7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      webpackbar: 7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
     optionalDependencies:
       '@docusaurus/faster': 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@swc/helpers@0.5.15)(postcss@8.5.25)
     transitivePeerDependencies:
@@ -9124,9 +9204,9 @@ snapshots:
       browserslist: 4.28.6
       lightningcss: 1.32.0
       semver: 7.8.5
-      swc-loader: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      swc-loader: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -9154,7 +9234,7 @@ snapshots:
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       fs-extra: 11.3.6
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -9914,7 +9994,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       fs-extra: 11.3.6
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -9926,7 +10006,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       utility-types: 3.11.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
     transitivePeerDependencies:
@@ -9955,7 +10035,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       fs-extra: 11.3.6
       github-slugger: 1.5.0
       globby: 11.1.0
@@ -10827,11 +10907,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       apg-js: 4.4.0
 
-  '@signinwithethereum/siwe@4.2.0(viem@2.55.1(typescript@5.9.3)(zod@3.25.76))':
+  '@signinwithethereum/siwe@4.2.0(viem@2.55.1(typescript@6.0.3)(zod@3.25.76))':
     dependencies:
       '@signinwithethereum/siwe-parser': 4.2.0
     optionalDependencies:
-      viem: 2.55.1(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.55.1(typescript@6.0.3)(zod@3.25.76)
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -11654,10 +11734,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@x402/express@2.21.0(express@5.2.1)(typescript@5.9.3)':
+  '@x402/express@2.21.0(express@5.2.1)(typescript@6.0.3)':
     dependencies:
       '@x402/core': 2.21.0
-      '@x402/extensions': 2.21.0(typescript@5.9.3)
+      '@x402/extensions': 2.21.0(typescript@6.0.3)
       express: 5.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -11665,16 +11745,16 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/extensions@2.21.0(typescript@5.9.3)':
+  '@x402/extensions@2.21.0(typescript@6.0.3)':
     dependencies:
       '@noble/curves': 1.9.7
       '@scure/base': 1.2.6
-      '@signinwithethereum/siwe': 4.2.0(viem@2.55.1(typescript@5.9.3)(zod@3.25.76))
+      '@signinwithethereum/siwe': 4.2.0(viem@2.55.1(typescript@6.0.3)(zod@3.25.76))
       '@x402/core': 2.21.0
       ajv: 8.20.0
       jose: 5.10.0
       tweetnacl: 1.0.3
-      viem: 2.55.1(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.55.1(typescript@6.0.3)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -11694,9 +11774,9 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
+  abitype@1.2.3(typescript@6.0.3)(zod@3.25.76):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       zod: 3.25.76
 
   accepts@1.3.8:
@@ -11932,12 +12012,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -12332,7 +12412,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  copy-webpack-plugin@11.0.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       fast-glob: 3.3.1
       glob-parent: 6.0.2
@@ -12340,7 +12420,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -12385,7 +12465,7 @@ snapshots:
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  css-loader@6.11.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.25)
       postcss: 8.5.25
@@ -12397,9 +12477,9 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.15)
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.5.25)
@@ -12407,7 +12487,7 @@ snapshots:
       postcss: 8.5.25
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     optionalDependencies:
       clean-css: 5.3.3
 
@@ -12925,7 +13005,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12947,7 +13027,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -13287,17 +13367,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
+  file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
-
-  file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
 
   fill-range@7.1.1:
     dependencies:
@@ -14805,11 +14879,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  mini-css-extract-plugin@2.10.2(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   minimalistic-assert@1.0.1: {}
 
@@ -14823,7 +14897,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -14836,13 +14910,13 @@ snapshots:
       lightningcss: 1.32.0
       postcss: 8.5.25
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.15)
       clean-css: 5.3.3
@@ -14941,11 +15015,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  null-loader@4.0.1(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   object-assign@4.1.1: {}
 
@@ -15035,7 +15109,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.14.30(typescript@5.9.3)(zod@3.25.76):
+  ox@0.14.30(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -15043,10 +15117,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - zod
 
@@ -15364,13 +15438,13 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.25)
       postcss: 8.5.25
 
-  postcss-loader@7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  postcss-loader@7.3.4(postcss@8.5.25)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
       postcss: 8.5.25
       semver: 7.8.5
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     transitivePeerDependencies:
       - typescript
 
@@ -16614,23 +16688,29 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swc-loader@0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)):
+  swc-loader@0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.15)
       '@swc/counter': 0.1.3
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
+  swr@2.5.1(react@19.2.4):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+
   tailwindcss@4.3.2: {}
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.15)
       clean-css: 5.3.3
@@ -16901,15 +16981,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
-    dependencies:
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
-    optionalDependencies:
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
-
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       loader-utils: 2.0.4
@@ -16917,7 +16988,11 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 
@@ -16948,18 +17023,18 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.55.1(typescript@5.9.3)(zod@3.25.76):
+  viem@2.55.1(typescript@6.0.3)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
       isows: 1.0.7(ws@8.21.0)
-      ox: 0.14.30(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.14.30(typescript@6.0.3)(zod@3.25.76)
       ws: 8.21.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17123,6 +17198,44 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
+  webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.6
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.2
+      es-module-lexer: 2.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
   webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25):
     dependencies:
       '@types/estree': 1.0.9
@@ -17141,7 +17254,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -17179,7 +17292,7 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.25))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -17199,7 +17312,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpackbar@7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)):
+  webpackbar@7.0.0(@rspack/core@1.7.12(@swc/helpers@0.5.15))(webpack@5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2
@@ -17207,7 +17320,7 @@ snapshots:
       std-env: 3.10.0
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.15)
-      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(html-minifier-terser@7.2.0)(postcss@8.5.25)
+      webpack: 5.108.4(@swc/core@1.15.43(@swc/helpers@0.5.15))(postcss@8.5.25)
 
   websocket-driver@0.7.5:
     dependencies:


### PR DESCRIPTION
Closes #130

## Summary

The dashboard's transaction history fetched the newest 100 payments in a single request — payload size and render time grow without bound as volume grows. This PR adds page-based server-side pagination: the API now accepts `page`/`limit` and returns server-side totals, the dashboard fetches 50 per page keyed by `?page=N` via SWR (with the next page prefetched), and a new `Pagination` component renders Previous/Next plus page numbers.

## What changed

**API — `GET /api/payments`** (`apps/web/src/app/api/payments/route.ts`)
- New `page` query parameter (integer ≥ 1, defaults to 1) enabling offset pagination: `LIMIT $n OFFSET (page-1)*limit`.
- `limit` unchanged (1–1000, default 100 for backward compatibility).
- The row query now uses window functions (`COUNT(*) OVER()`, `SUM(amount) OVER()`, min=max single-asset detection) so one query returns the page plus the aggregates the dashboard header needs — `total`, `total_amount`, `total_asset`, `total_pages`.
- `page` and `cursor` are mutually exclusive (400 if combined); the existing keyset cursor mode used by `@accensa/sdk` is untouched, and `next_cursor` is still computed.

**UI — dashboard** (`apps/web/src/app/dashboard/page.tsx`)
- Data fetching moved to SWR: `useSWR('/api/payments?limit=50&page=N')` with a 15s `refreshInterval` (replacing the hand-rolled `setInterval` poll) and `keepPreviousData` so paging does not flash a skeleton.
- The current page lives in the URL via `useSearchParams`; `goToPage` writes `?page=N` with `router.replace(..., { scroll: false })`. The component sits in a `Suspense` boundary (required for `useSearchParams` at build time).
- A hidden `useSWR` prefetches the next page into the cache the moment the current page is known, so Next is instant.
- The "Total Settled" header now uses the server-side `total_amount`/`total_asset`, so the number covers every payment instead of shrinking as the merchant pages forward (falls back to summing the page on older deploys).

**Component — `apps/web/src/components/pagination.tsx`**
- Previous/Next buttons plus a windowed page-number row with ellipses; Previous disabled on page 1, Next disabled on the last page; `aria-current` and labelled page buttons.

**Dependency** — `swr@^2.5.1` added to `apps/web` (nothing else in the workspace uses it yet; the issue calls for SWR or React Query).

## Acceptance criteria

- [x] Data is fetched in chunks of 50 items (`PAGE_SIZE = 50`).
- [x] URL reflects the current page (e.g. `/dashboard?page=2`).
- [x] The 'Next' button is disabled on the last page.

## Notes

- Offset pagination shifts as new payments land during the 15s poll — inherent to page-numbered URLs, and the tradeoff the issue's `?page=2` requirement implies.
- The CSV export still exports what is on screen (now the current page), so the file always matches the rows being viewed.

## Testing

- `pnpm --filter web test` — 298 tests pass (26 files), including new coverage for `page` validation, `page`+`cursor` conflict, `LIMIT/OFFSET` SQL and params, aggregate fields, and the Pagination component (page windowing, disabled states, a11y attributes).
- `pnpm typecheck` (web + sdk) — clean; SDK suite still 116/116 since its cursor contract is unchanged.
- `pnpm --filter web build` — succeeds (`/dashboard` prerenders static with the Suspense-wrapped `useSearchParams`).
- Prettier applied; `pnpm --filter web lint` — 0 errors (3 pre-existing warnings untouched).