### PR TITLE
feat: webhook signatures, batched indexer inserts, multi-route demo, and agent payer

### DIFF
--- a/apps/demo-merchant/README.md
+++ b/apps/demo-merchant/README.md
@@ -1,0 +1,126 @@
+# Accensa Demo Merchant
+
+A working example of the seller side of Accensa: an x402 payment-gated Express
+server that reports route attribution to an Accensa deployment, plus the buyer
+side in [`agent.js`](agent.js) so a reviewer can watch the whole protocol from
+both ends.
+
+## Routes
+
+| Route                 | Price      | Demonstrates                                                                            |
+| --------------------- | ---------- | --------------------------------------------------------------------------------------- |
+| `/api/hello`          | 0.0001 XLM | Cheap, frequent call — the everyday payment                                             |
+| `/api/insights/daily` | 0.0025 XLM | A mid price, different in magnitude from `/api/hello`                                   |
+| `/api/analytics/full` | 0.1 XLM    | Expensive, rare call — a third, much larger price                                       |
+| `/api/free`           | free       | The free/paid boundary: not in the x402 route config, so the middleware lets it through |
+
+Amounts are priced in stroops (1 XLM = 10,000,000 stroops) against the native
+XLM Stellar Asset Contract on testnet. The prices are deliberately far apart so
+the dashboard's per-route revenue attribution — grouping, sorting, filtering,
+per-route totals, and the CSV export's stroop decimal handling — is exercised
+against genuinely different numbers, not one value repeated.
+
+`/api/free` is the only route **not** configured in `routesConfig`: the x402
+middleware intercepts only configured routes, so this one answers without any
+payment handshake.
+
+## What each file is for
+
+- `server.js` — the seller. x402 middleware in front of three priced routes,
+  an SSE stream, and a webhook listener for the Accensa indexer.
+- `lib/x402-payer.js` — the stock x402 client wired up (official
+  `x402Client`/`x402HTTPClient` + the Stellar `ExactStellarScheme`); shared by
+  the agent and driver scripts.
+- `agent.js` — the buyer. Pays a route end to end (402 → sign → retry →
+  resource → settlement), prints every protocol step, and ends by printing a
+  receipt in the form the dashboard's `/verify` page accepts.
+- `drive.js` — pays a realistic mix across every route in one command, so
+  anyone can populate a dashboard with plausible per-route data.
+
+## Prerequisites
+
+- Node.js 20+.
+- A **funded testnet payer**: a Stellar testnet account with XLM. Its secret
+  key goes in `STELLAR_PRIVATE_KEY` (see below).
+- The demo merchant needs `MERCHANT_ADDRESS` set to the address that should
+  receive the paid XLM — otherwise it falls back to a placeholder address that
+  cannot be paid.
+
+## Funding a testnet payer, start to finish
+
+1. **Create a keypair.** The fastest way is Stellar Lab:
+   <https://lab.stellar.org/account/create>. Save the **secret key** (`S...`)
+   and the **public address** (`G...`). You only need the secret key for the
+   scripts; the public address is handy for checking your balance.
+2. **Fund it with testnet XLM.** Open
+   <https://lab.stellar.org/account/fund>, paste the public address, and click
+   "Get testnet XLM". The Stellar friendbot funds the account immediately; a
+   few hundred testnet XLM is more than enough for every demo here.
+3. **Put the secret key in an `.env` file** in this directory:
+
+   ```env
+   STELLAR_PRIVATE_KEY=S...
+   MERCHANT_URL=http://localhost:3001
+   # STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+   ```
+
+   `dotenv` is already a dependency, so both scripts pick this up. Never commit
+   a real secret key.
+
+4. **Verify the account is funded** (optional): paste the public address into
+   the Stellar testnet explorer, or run `node agent.js` and check it gets past
+   the signing step.
+
+That is the whole setup — no trustlines are needed because the demo prices are
+paid in native XLM.
+
+## Running the seller
+
+```bash
+MERCHANT_ADDRESS=G... node server.js
+```
+
+The server listens on port 3001 (override with `PORT`). Point `ACCENSA_URL` at
+your Accensa deployment if you want the merchant to report route attribution;
+`HOOK_API_KEY` and `WEBHOOK_SECRET` are required for the dashboard to accept
+reports and for the merchant to accept indexer webhooks (see the root README).
+
+## Paying as the agent (buyer side)
+
+With the merchant running, open a second terminal:
+
+```bash
+node agent.js
+```
+
+This pays `/api/hello` and `/api/insights/daily` (override with `ROUTES`), and
+prints:
+
+1. The initial `GET` and the `402 Payment Required` response.
+2. The payment option(s) the server declared.
+3. The signed payment payload the stock client built.
+4. The retry with the payment header.
+5. The settlement: success and the on-chain transaction hash.
+6. A receipt in the form `/verify` accepts — `batchId`, `leaf`, and `proof` —
+   built over the payments this run actually made.
+
+Paste those three values into the dashboard's `/verify` page. The local Merkle
+check recomputes the batch root from the proof; the on-chain check needs the
+batch to be anchored, which is tracked separately (accensa-app issue #15).
+
+## Populating the dashboard in one command
+
+```bash
+node drive.js
+```
+
+This makes a realistic mix of calls — five cheap, two mid, one expensive, and
+three free — so the dashboard's route column shows several distinct values and
+per-route totals differ.
+
+## Notes
+
+- The demo intentionally has **no product, cart, or order model**: it exists to
+  exercise x402 route attribution, not to become a store.
+- There is **no mock or simulated login** anywhere in this app — real SEP-10
+  wallet authentication guards the dashboard, and nothing here touches it.

--- a/apps/demo-merchant/agent.js
+++ b/apps/demo-merchant/agent.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * The other half of the demo — an agent that pays.
+ *
+ * `server.js` is the seller: it puts x402 payment middleware in front of its
+ * routes and waits. This script is the buyer: it walks one of those routes
+ * through the whole protocol — plain request, 402 Payment Required, signed
+ * payment payload, retry, resource, settlement — printing each step so a
+ * reader can follow what the protocol did. It uses the stock x402 client
+ * (`x402Client` + `x402HTTPClient`) rather than a hand-rolled payer.
+ *
+ * It then ends with something usable: a receipt in exactly the form the
+ * dashboard's `/verify` page accepts (batchId, leaf, proof), built over the
+ * payments this run actually made. The proof is a real sorted-pair Merkle
+ * proof, so the receipt is genuinely verifiable with `@accensa/sdk`'s
+ * `verifyReceipt`. Whether the containing batch is anchored on-chain is a
+ * separate step (accensa-app issue #15); until then the on-chain half of
+ * `/verify` will report the batch as unknown while the local half still
+ * recomputes the root from the proof.
+ *
+ * Setup (see README.md for the full walkthrough):
+ *   1. Fund a testnet payer and put its secret key in STELLAR_PRIVATE_KEY.
+ *   2. Start the demo merchant (node server.js) with MERCHANT_ADDRESS set.
+ *   3. Run this script:  node agent.js
+ *
+ * Environment:
+ *   STELLAR_PRIVATE_KEY  payer's Ed25519 secret key (required)
+ *   MERCHANT_URL         defaults to http://localhost:3001
+ *   ROUTES               comma-separated routes to pay; defaults to
+ *                        /api/hello,/api/insights/daily — two different prices,
+ *                        so the receipt batch has more than one leaf and the
+ *                        proof is non-empty (the /verify form requires at
+ *                        least one sibling hash).
+ *   STELLAR_RPC_URL      Soroban RPC; defaults to the testnet endpoint.
+ */
+import { createHash } from 'node:crypto';
+import 'dotenv/config';
+import { createPayer, payForResource } from './lib/x402-payer.js';
+
+const MERCHANT_URL = (process.env.MERCHANT_URL ?? 'http://localhost:3001').replace(/\/$/, '');
+const ROUTES = (process.env.ROUTES ?? '/api/hello,/api/insights/daily')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const RPC_URL = process.env.STELLAR_RPC_URL;
+
+const PRIVATE_KEY = process.env.STELLAR_PRIVATE_KEY;
+if (!PRIVATE_KEY) {
+  console.error('❌ STELLAR_PRIVATE_KEY is not set. Fund a testnet payer first — see README.md.');
+  process.exit(1);
+}
+
+/**
+ * A receipt leaf in the Accensa convention: the SHA-256 of a receipt label
+ * string (payment hash + metadata), matching the leaves the ReceiptAnchor
+ * contract anchors and `@accensa/sdk`'s verifyReceipt expects.
+ */
+function receiptLeaf(txHash, amount, route) {
+  return createHash('sha256').update(`accensa:receipt:${txHash}:${amount}:${route}`).digest('hex');
+}
+
+/** Combines two nodes smaller-hash-first, exactly like the SDK/contract. */
+function combine(a, b) {
+  const aBuf = Buffer.from(a, 'hex');
+  const bBuf = Buffer.from(b, 'hex');
+  const [lo, hi] = Buffer.compare(aBuf, bBuf) <= 0 ? [aBuf, bBuf] : [bBuf, aBuf];
+  return createHash('sha256')
+    .update(Buffer.concat([lo, hi]))
+    .digest('hex');
+}
+
+/**
+ * Builds a sorted-pair Merkle batch over the given leaves and returns the
+ * membership proof for the leaf at `index` (leaf-to-root order), mirroring the
+ * conformance convention in packages/sdk/merkle-vectors.json.
+ */
+function proofFor(leaves, index) {
+  let level = leaves.slice();
+  const proof = [];
+  let i = index;
+  while (level.length > 1) {
+    const sibling = i % 2 === 0 ? i + 1 : i - 1;
+    if (sibling < level.length) proof.push(level[sibling]);
+    const next = [];
+    for (let j = 0; j < level.length; j += 2) {
+      next.push(j + 1 < level.length ? combine(level[j], level[j + 1]) : level[j]);
+    }
+    level = next;
+    i = Math.floor(i / 2);
+  }
+  return proof;
+}
+
+async function main() {
+  console.log(`Agent payer: ${process.env.STELLAR_PRIVATE_KEY ? 'configured' : 'missing'}`);
+  console.log(`Target merchant: ${MERCHANT_URL}`);
+  console.log(`Routes to pay: ${ROUTES.join(', ')}`);
+  console.log('');
+
+  const { client, httpClient } = createPayer(PRIVATE_KEY, RPC_URL);
+  const payments = [];
+
+  for (const route of ROUTES) {
+    const url = `${MERCHANT_URL}${route}`;
+    console.log(`━━━ Paying ${route} ━━━`);
+    const result = await payForResource(client, httpClient, url, (step, detail) => {
+      console.log(`  ${step}`);
+      if (detail !== undefined) console.log(`      ${JSON.stringify(detail)}`);
+    });
+
+    if (!result.paid) {
+      console.log(`  (not an x402-gated route — status ${result.status})`);
+      console.log(`  ${result.body}`);
+      console.log('');
+      continue;
+    }
+
+    if (result.status !== 200 || !result.settlement?.success) {
+      console.error(`❌ Payment for ${route} did not settle:`);
+      console.error(`   status=${result.status}`);
+      console.error(`   settlement=${JSON.stringify(result.settlement)}`);
+      console.error(`   body=${result.body}`);
+      process.exit(1);
+    }
+
+    const txHash = result.settlement.transaction;
+    const amount = result.settlement.amount ?? result.paymentRequired?.accepts?.[0]?.amount ?? '?';
+    payments.push({ route, txHash, amount, body: result.body });
+    console.log(`✅ Got the resource: ${result.body}`);
+    console.log('');
+  }
+
+  if (payments.length === 0) {
+    console.error('No payments were made; nothing to show.');
+    process.exit(1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Receipt — in exactly the form /verify accepts: batchId, leaf, proof.
+  // -------------------------------------------------------------------------
+  console.log('━━━ Receipt ━━━');
+  const leaves = payments.map((p) => receiptLeaf(p.txHash, p.amount, p.route));
+  console.log(
+    `Built a ${payments.length}-leaf batch over this run's payments (sorted-pair SHA-256).`,
+  );
+
+  // Print a receipt for the first payment; the batch root and every leaf are
+  // also printed so the reader can paste the receipt into /verify.
+  const target = 0;
+  const proof = proofFor(leaves, target);
+  const batchRoot = batchRootFor(leaves);
+
+  const p = payments[target];
+  console.log('');
+  console.log(`Receipt for ${p.route} (tx ${p.txHash}):`);
+  console.log(`  batchId: 1`);
+  console.log(`  leaf:    ${leaves[target]}`);
+  console.log(`  proof:   ${proof.join(' ')}`);
+  console.log(`  root:    ${batchRoot}`);
+  console.log('');
+  console.log('Paste the batchId, leaf and proof into the dashboard /verify page.');
+  console.log('The local Merkle check recomputes this exact root from the proof;');
+  console.log('the on-chain check needs the batch anchored (accensa-app issue #15).');
+}
+
+/** Root of a sorted-pair Merkle batch (promoted odd nodes, SDK convention). */
+function batchRootFor(leaves) {
+  let level = leaves.slice();
+  while (level.length > 1) {
+    const next = [];
+    for (let j = 0; j < level.length; j += 2) {
+      next.push(j + 1 < level.length ? combine(level[j], level[j + 1]) : level[j]);
+    }
+    level = next;
+  }
+  return level[0];
+}
+
+main().catch((error) => {
+  console.error('Agent failed:', error.message);
+  process.exit(1);
+});

--- a/apps/demo-merchant/drive.js
+++ b/apps/demo-merchant/drive.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Populates the dashboard with a realistic mix of payments in one command.
+ *
+ * The demo merchant serves several routes at deliberately different prices.
+ * This driver hits each of them the way a real agent would — the cheap route
+ * often, the mid route occasionally, the expensive route rarely — plus the
+ * free route, so a reviewer who opens the dashboard sees more than one value
+ * in the route column and per-route totals that actually differ.
+ *
+ * Setup (see README.md for the full walkthrough):
+ *   1. Fund a testnet payer and put its secret key in STELLAR_PRIVATE_KEY.
+ *   2. Start the demo merchant (node server.js) with MERCHANT_ADDRESS set.
+ *   3. Point ACCENSA_URL at your Accensa deployment so the merchant's
+ *      settlement reports land in the dashboard (the merchant reads it from
+ *      its own ACCENSA_URL env var).
+ *   4. Run this script:  node drive.js
+ *
+ * Environment:
+ *   STELLAR_PRIVATE_KEY  payer's Ed25519 secret key (required)
+ *   MERCHANT_URL         defaults to http://localhost:3001
+ *   STELLAR_RPC_URL      Soroban RPC; defaults to the testnet endpoint.
+ */
+import 'dotenv/config';
+import { createPayer, payForResource } from './lib/x402-payer.js';
+
+const MERCHANT_URL = (process.env.MERCHANT_URL ?? 'http://localhost:3001').replace(/\/$/, '');
+const RPC_URL = process.env.STELLAR_RPC_URL;
+
+const PRIVATE_KEY = process.env.STELLAR_PRIVATE_KEY;
+if (!PRIVATE_KEY) {
+  console.error('❌ STELLAR_PRIVATE_KEY is not set. Fund a testnet payer first — see README.md.');
+  process.exit(1);
+}
+
+/**
+ * The mix this driver makes. Cheap and frequent, expensive and rare — a
+ * realistic call pattern, and one that gives the dashboard's per-route
+ * attribution and totals something to differ over.
+ */
+const MIX = [
+  { route: '/api/hello', count: 5 },
+  { route: '/api/insights/daily', count: 2 },
+  { route: '/api/analytics/full', count: 1 },
+  { route: '/api/free', count: 3 },
+];
+
+async function main() {
+  console.log(`Driving ${MERCHANT_URL} with:`);
+  for (const { route, count } of MIX) {
+    console.log(`  ${count}× ${route}`);
+  }
+  console.log('');
+
+  const { client, httpClient } = createPayer(PRIVATE_KEY, RPC_URL);
+  const summary = [];
+
+  for (const { route, count } of MIX) {
+    const url = `${MERCHANT_URL}${route}`;
+    let ok = 0;
+    for (let i = 0; i < count; i++) {
+      try {
+        const result = await payForResource(client, httpClient, url);
+        // Free route: 200 with no settlement. Paid routes: 200 + success.
+        const settled = result.paid
+          ? result.status === 200 && result.settlement?.success
+          : result.status === 200;
+        if (settled) ok++;
+        else console.error(`  ⚠️  ${route} call ${i + 1} returned ${result.status}`);
+      } catch (error) {
+        console.error(`  ⚠️  ${route} call ${i + 1} failed: ${error.message}`);
+      }
+    }
+    summary.push({ route, attempted: count, ok });
+    console.log(`  ${route}: ${ok}/${count} calls succeeded`);
+  }
+
+  const failed = summary.some((s) => s.ok < s.attempted);
+  console.log('');
+  console.log('Done. Refresh the Accensa dashboard to see per-route revenue.');
+  if (failed) {
+    console.warn('Some calls failed — check that the merchant is running with MERCHANT_ADDRESS');
+    console.warn('set and a funded payer is configured (see README.md).');
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('Driver failed:', error.message);
+  process.exit(1);
+});

--- a/apps/demo-merchant/lib/x402-payer.js
+++ b/apps/demo-merchant/lib/x402-payer.js
@@ -1,0 +1,108 @@
+import { x402Client, x402HTTPClient } from '@x402/core/client';
+import { createEd25519Signer, getNetworkPassphrase } from '@x402/stellar';
+import { ExactStellarScheme } from '@x402/stellar/exact/client';
+import { Transaction, TransactionBuilder } from '@stellar/stellar-sdk';
+
+export const NETWORK = 'stellar:testnet';
+export const DEFAULT_RPC_URL = 'https://soroban-testnet.stellar.org';
+
+/**
+ * Builds a payer from the stock x402 client — no bespoke payer here.
+ *
+ * The whole point of the x402 conformance story is that unmodified clients
+ * work, so the demo inherits that property: `x402Client` + `x402HTTPClient`
+ * are the official client classes, and the Stellar `ExactStellarScheme` does
+ * the signing. This demo only wires them together.
+ *
+ * @param {string} privateKey Ed25519 secret key (S... seed) of the payer.
+ * @param {string} [rpcUrl] Soroban RPC URL; defaults to the testnet endpoint.
+ */
+export function createPayer(privateKey, rpcUrl = DEFAULT_RPC_URL) {
+  const signer = createEd25519Signer(privateKey, NETWORK);
+  const client = new x402Client().register(
+    'stellar:*',
+    new ExactStellarScheme(signer, rpcUrl ? { url: rpcUrl } : undefined),
+  );
+  const httpClient = new x402HTTPClient(client);
+  return { client, httpClient, signer };
+}
+
+/**
+ * Pays one x402-protected resource end to end and returns everything a caller
+ * needs to report or verify the payment.
+ *
+ * Steps, in protocol order:
+ *   1. GET the resource with no payment headers → the server answers 402 with
+ *      a `PaymentRequired` declaration.
+ *   2. The stock client selects an acceptable payment requirement and builds a
+ *      signed payment payload.
+ *   3. The payload is encoded into the `payment-signature` request header.
+ *   4. The original request is retried with that header → 200 with the
+ *      resource, plus a settlement response header.
+ *
+ * @param {import('@x402/core/client').x402Client} client
+ * @param {import('@x402/core/client').x402HTTPClient} httpClient
+ * @param {string} url Absolute URL of the resource to pay for.
+ * @param {(step: string, detail?: unknown) => void} [log] Step logger; defaults
+ *   to silent so the driver script can print its own summary.
+ */
+export async function payForResource(client, httpClient, url, log = () => {}) {
+  // Step 1 — ask without paying.
+  const firstTry = await fetch(url);
+  log(`1. GET ${url} → ${firstTry.status}`);
+  if (firstTry.status !== 402) {
+    // Not an x402-gated route (the demo's free route), or already paid.
+    const body = await firstTry.text();
+    return { status: firstTry.status, body, paymentRequired: null, settlement: null, paid: false };
+  }
+
+  const paymentRequired = httpClient.getPaymentRequiredResponse((name) =>
+    firstTry.headers.get(name),
+  );
+  log(`2. 402 Payment Required — ${paymentRequired.accepts.length} option(s)`);
+
+  // Step 2 — build and sign the payment payload with the stock client.
+  let paymentPayload = await client.createPaymentPayload(paymentRequired);
+  log(`3. Signed payment payload for ${paymentPayload.accepted?.network ?? NETWORK}`);
+
+  // Step 3 — fee adjustment. The testnet facilitator rejects transactions
+  // whose fee exceeds 1 stroop, so the transaction is rebuilt with that fee.
+  // This matches the documented x402 Stellar quickstart.
+  const networkPassphrase = getNetworkPassphrase(NETWORK);
+  const tx = new Transaction(paymentPayload.payload.transaction, networkPassphrase);
+  const sorobanData = tx.toEnvelope().v1()?.tx()?.ext()?.sorobanData();
+  if (sorobanData) {
+    paymentPayload = {
+      ...paymentPayload,
+      payload: {
+        ...paymentPayload.payload,
+        transaction: TransactionBuilder.cloneFrom(tx, {
+          fee: '1',
+          sorobanData,
+          networkPassphrase,
+        })
+          .build()
+          .toXDR(),
+      },
+    };
+  }
+
+  // Step 4 — retry with the payment header.
+  const paymentHeaders = httpClient.encodePaymentSignatureHeader(paymentPayload);
+  log(`4. Retrying with payment-signature header`);
+  const paidResponse = await fetch(url, { method: 'GET', headers: paymentHeaders });
+  const body = await paidResponse.text();
+  const settlement = httpClient.getPaymentSettleResponse((name) => paidResponse.headers.get(name));
+  log(`5. GET ${url} → ${paidResponse.status}`);
+  if (settlement) {
+    log(`6. Settlement: success=${settlement.success} tx=${settlement.transaction}`);
+  }
+
+  return {
+    status: paidResponse.status,
+    body,
+    paymentRequired,
+    settlement,
+    paid: true,
+  };
+}

--- a/apps/demo-merchant/package.json
+++ b/apps/demo-merchant/package.json
@@ -3,12 +3,16 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
+    "agent": "node agent.js",
+    "drive": "node drive.js",
     "test": "echo \"demo-merchant is an example server; no tests\""
   },
   "keywords": [],
   "license": "MIT",
   "description": "Example x402 seller with webhook listener and real-time SSE updates",
   "dependencies": {
+    "@stellar/stellar-sdk": "^16.0.1",
     "@x402/core": "^2.21.0",
     "@x402/express": "^2.21.0",
     "@x402/stellar": "^2.21.0",

--- a/apps/demo-merchant/server.js
+++ b/apps/demo-merchant/server.js
@@ -172,17 +172,48 @@ resourceServer.onAfterSettle(async (ctx) => {
 
 // ---------------------------------------------------------------------------
 // 3. Configure the routes
+//
+// Several priced routes at deliberately different magnitudes, so the dashboard
+// has real per-route attribution to show: grouping, sorting and filtering by
+// route, per-route totals, and the CSV export's stroop decimal handling all
+// get exercised against genuinely different prices. Amounts are in stroops
+// (1 XLM = 10,000,000 stroops).
 // ---------------------------------------------------------------------------
 const routesConfig = {
+  // Cheap and frequent — the "everyday" call. 0.0001 XLM.
   '/api/hello': {
     accepts: {
       scheme: 'exact',
-      price: { asset: XLM_SAC, amount: '1000' }, // 1000 stroops = 0.0001 XLM
+      price: { asset: XLM_SAC, amount: '1000' }, // 1000 stroops
+      network: NETWORK,
+      payTo: process.env.MERCHANT_ADDRESS || 'GAQW...REPLACE_WITH_REAL_ADDRESS',
+    },
+  },
+  // Mid price — 0.0025 XLM. A different magnitude from /api/hello so per-route
+  // totals differ by more than call count.
+  '/api/insights/daily': {
+    accepts: {
+      scheme: 'exact',
+      price: { asset: XLM_SAC, amount: '25000' }, // 25,000 stroops
+      network: NETWORK,
+      payTo: process.env.MERCHANT_ADDRESS || 'GAQW...REPLACE_WITH_REAL_ADDRESS',
+    },
+  },
+  // Expensive and rare — 0.1 XLM. A third, much larger magnitude so decimal
+  // handling and totals are exercised at a genuinely different scale.
+  '/api/analytics/full': {
+    accepts: {
+      scheme: 'exact',
+      price: { asset: XLM_SAC, amount: '1000000' }, // 1,000,000 stroops
       network: NETWORK,
       payTo: process.env.MERCHANT_ADDRESS || 'GAQW...REPLACE_WITH_REAL_ADDRESS',
     },
   },
 };
+
+// /api/free is deliberately NOT in routesConfig: the x402 middleware only
+// intercepts configured routes, so this route passes straight through — the
+// free/paid boundary is visible in one server.
 
 const httpServer = new x402HTTPResourceServer(resourceServer, routesConfig);
 
@@ -201,6 +232,39 @@ app.get('/api/hello', (_req, res) => {
   res.json({
     message: 'Payment verified!',
     data: 'This is the premium Accensa content.',
+    route: '/api/hello',
+    price: '0.0001 XLM',
+  });
+});
+
+app.get('/api/insights/daily', (_req, res) => {
+  res.json({
+    message: 'Payment verified!',
+    data: 'Your daily insights digest.',
+    route: '/api/insights/daily',
+    price: '0.0025 XLM',
+  });
+});
+
+app.get('/api/analytics/full', (_req, res) => {
+  res.json({
+    message: 'Payment verified!',
+    data: 'The full analytics report, exported.',
+    route: '/api/analytics/full',
+    price: '0.1 XLM',
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5b. Route — free (no payment required)
+// ---------------------------------------------------------------------------
+
+app.get('/api/free', (_req, res) => {
+  res.json({
+    message: 'No payment needed!',
+    data: 'Public content, served without an x402 gate.',
+    route: '/api/free',
+    price: 'free',
   });
 });
 
@@ -327,10 +391,25 @@ app.get('/', (_req, res) => {
   </div>
 
   <div class="card">
-    <h2>Premium Endpoint</h2>
-    <button class="pay-btn" id="pay-btn" onclick="callHello()">
-      Pay &amp; Call /api/hello
-    </button>
+    <h2>Paid Endpoints</h2>
+    <p style="margin-bottom:1rem;font-size:.875rem;color:var(--muted);">
+      Each route costs a different amount, so the dashboard can show per-route
+      attribution.
+    </p>
+    <div style="display:flex;flex-direction:column;gap:.75rem;">
+      <button class="pay-btn" id="pay-btn-hello" onclick="callRoute('/api/hello')">
+        Pay &amp; Call /api/hello &mdash; 0.0001 XLM
+      </button>
+      <button class="pay-btn" id="pay-btn-insights" onclick="callRoute('/api/insights/daily')">
+        Pay &amp; Call /api/insights/daily &mdash; 0.0025 XLM
+      </button>
+      <button class="pay-btn" id="pay-btn-analytics" onclick="callRoute('/api/analytics/full')">
+        Pay &amp; Call /api/analytics/full &mdash; 0.1 XLM
+      </button>
+      <button class="pay-btn" id="pay-btn-free" onclick="callRoute('/api/free')" style="background:var(--surface);color:var(--text);border:1px solid var(--border);">
+        Call /api/free &mdash; free
+      </button>
+    </div>
     <p id="pay-result" style="margin-top:.75rem;font-size:.875rem;"></p>
   </div>
 
@@ -346,7 +425,6 @@ app.get('/', (_req, res) => {
 const dot = document.getElementById('dot');
 const connText = document.getElementById('conn-text');
 const eventsList = document.getElementById('events');
-const payBtn = document.getElementById('pay-btn');
 const payResult = document.getElementById('pay-result');
 let hasEvents = false;
 
@@ -398,20 +476,28 @@ function showToast(data) {
   }, 4000);
 }
 
-// ---- Pay button (calls the x402-gated endpoint) ----
-async function callHello() {
-  payBtn.disabled = true;
-  payBtn.textContent = 'Paying\u2026';
+// ---- Pay button (calls the x402-gated endpoints, or the free route) ----
+async function callRoute(route) {
+  const id = {
+    '/api/hello': 'pay-btn-hello',
+    '/api/insights/daily': 'pay-btn-insights',
+    '/api/analytics/full': 'pay-btn-analytics',
+    '/api/free': 'pay-btn-free',
+  }[route];
+  const btn = document.getElementById(id);
+  const original = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Paying\u2026';
   payResult.textContent = '';
   try {
-    const res = await fetch('/api/hello');
+    const res = await fetch(route);
     const json = await res.json();
     payResult.textContent = JSON.stringify(json);
   } catch (err) {
     payResult.textContent = 'Error: ' + err.message;
   } finally {
-    payBtn.disabled = false;
-    payBtn.textContent = 'Pay & Call /api/hello';
+    btn.disabled = false;
+    btn.textContent = original;
   }
 }
 
@@ -428,7 +514,12 @@ connectSSE();
 app.listen(PORT, () => {
   console.log(`Demo merchant server running on port ${PORT}`);
   console.log(`Dashboard: http://localhost:${PORT}/`);
-  console.log(`Protected route: http://localhost:${PORT}/api/hello`);
+  console.log(`Protected routes:`);
+  for (const route of Object.keys(routesConfig)) {
+    const price = routesConfig[route].accepts.price;
+    console.log(`  - http://localhost:${PORT}${route} (${price.amount} stroops)`);
+  }
+  console.log(`Free route: http://localhost:${PORT}/api/free (no payment)`);
   console.log(`Reporting attribution to: ${ACCENSA_URL}/api/hook/settle`);
   console.log(`Webhook endpoint: POST http://localhost:${PORT}/api/webhooks/accensa`);
   console.log(`SSE stream: GET http://localhost:${PORT}/api/events`);

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
-import { decodeTransferEvent, transferTopicFilter, addressTopicFilter } from '@/lib/stellar-events';
+import { transferTopicFilter, addressTopicFilter } from '@/lib/stellar-events';
 import {
   withClient,
   withMerchantClient,
   ensureSchema,
   getLastSyncedLedger,
-  setLastSyncedLedger,
   getSyncState,
 } from '@/lib/db';
+import { eventsToPaymentRows, insertPaymentsInTransaction } from '@/lib/insert-payments';
 import { listMerchants, getMerchantFromRequest, type Merchant } from '@/lib/merchants';
 import { sweepLedgerRange, EVENTS_PAGE_LIMIT, type EventPage } from '@/lib/event-pager';
 import { cooldownRemaining } from '@/lib/sync-status';
@@ -172,49 +172,37 @@ async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
         { startLedger, endLedger: latestLedger, withinBudget: () => Date.now() < deadline },
       );
 
-      let inserted = 0;
-      let decoded = 0;
       const webhookUrl = merchant.webhookUrl ?? process.env.WEBHOOK_URL;
 
-      for (const event of events) {
-        const transferEvent = decodeTransferEvent(event);
-        // A malformed or non-transfer event must not stall the batch.
-        if (!transferEvent) continue;
-        decoded++;
+      // Per-event filtering lives in eventsToPaymentRows: a malformed or
+      // non-transfer event is skipped, and a transfer not addressed to this
+      // merchant is never recorded. Only the insert below is batched — batching
+      // must not quietly admit events that would have been filtered out.
+      const { rows, decoded } = eventsToPaymentRows(events, merchant);
 
-        // Defensive: never record a transfer that is not to this merchant.
-        if (transferEvent.to !== merchant.address) continue;
+      // DO UPDATE, not DO NOTHING: a row may already exist because the
+      // merchant reported route attribution before this transfer was indexed,
+      // which is the normal ordering — the hook fires the moment x402 settles,
+      // this job runs on a schedule. Skipping the conflict would leave that
+      // row permanently null and invisible. Only ledger-owned columns are
+      // written; route, method, request_id and hook_reported_at belong to the
+      // merchant's report and are left alone.
+      //
+      // The inserts and the cursor advance commit atomically (see
+      // insertPaymentsInTransaction): if any chunk fails, nothing commits and
+      // the cursor stays behind the failed run.
+      const { inserted, payments } = await insertPaymentsInTransaction(
+        client,
+        merchant.id,
+        rows,
+        sweptThrough,
+      );
 
-        // DO UPDATE, not DO NOTHING: a row may already exist because the
-        // merchant reported route attribution before this transfer was
-        // indexed, which is the normal ordering — the hook fires the moment
-        // x402 settles, this job runs on a schedule. Skipping the conflict
-        // would leave that row permanently null and invisible.
-        //
-        // Only ledger-owned columns are written. route, method, request_id and
-        // hook_reported_at belong to the merchant's report and are left alone.
-        const res = await client.query(
-          `INSERT INTO payments (merchant_id, tx_hash, ledger, payer, amount, asset, ts)
-  VALUES ($1, $2, $3, $4, $5::numeric, $6, $7::timestamptz)
-  ON CONFLICT (merchant_id, tx_hash) DO UPDATE
-  SET ledger = EXCLUDED.ledger,
-  payer = EXCLUDED.payer,
-  amount = EXCLUDED.amount,
-  asset = EXCLUDED.asset,
-  ts = EXCLUDED.ts
-  WHERE payments.ledger IS NULL RETURNING *`,
-          [
-            merchant.id,
-            transferEvent.txHash,
-            transferEvent.ledger,
-            transferEvent.from,
-            transferEvent.amount, // string - never a float
-            transferEvent.asset,
-            transferEvent.ledgerClosedAt,
-          ],
-        );
-        if (res.rowCount && res.rowCount > 0 && webhookUrl) {
-          const payment = res.rows[0];
+      // Webhooks fire after COMMIT, so a slow or failing webhook can neither
+      // hold the transaction open nor roll back a committed batch. The
+      // returned rows are exactly the payments written this run.
+      if (webhookUrl) {
+        for (const payment of payments) {
           const body = JSON.stringify(payment);
           const webhookSecret = process.env.WEBHOOK_SECRET;
           const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -241,16 +229,15 @@ async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
             }
           }
         }
-        inserted += res.rowCount ?? 0;
       }
 
-      // The sweep only ever reports whole windows, so this is safe whether or
-      // not it reached the head. Crucially it advances across empty windows
-      // too - a quiet merchant that never moved the cursor is how the indexer
-      // fell behind the RPC retention window and stopped seeing payments. Each
-      // merchant's cursor advances independently, so one merchant with no
-      // activity cannot hold back or be held back by another's progress.
-      await setLastSyncedLedger(client, merchant.id, sweptThrough);
+      // The sweep only ever reports whole windows, so the cursor advance is
+      // safe whether or not it reached the head. Crucially it advances across
+      // empty windows too - a quiet merchant that never moved the cursor is
+      // how the indexer fell behind the RPC retention window and stopped
+      // seeing payments. Each merchant's cursor advances independently, so one
+      // merchant with no activity cannot hold back or be held back by
+      // another's progress.
 
       return {
         merchant: merchant.address,

--- a/apps/web/src/lib/db.integration.test.ts
+++ b/apps/web/src/lib/db.integration.test.ts
@@ -6,6 +6,7 @@ import {
   setLastSyncedLedger,
   getLastSyncedLedger,
 } from './db';
+import { insertPaymentsInTransaction } from './insert-payments';
 import { getMerchantByAddress } from './merchants';
 
 describe('Database Integration', () => {
@@ -141,5 +142,124 @@ describe('Database Integration', () => {
       return res.rows;
     });
     expect(rowsSeenByB).toHaveLength(1);
+  });
+
+  it('batched inserts write many rows in one statement and commit the cursor atomically', async () => {
+    if (!process.env.DATABASE_URL) {
+      console.warn('Skipping integration test as DATABASE_URL is missing');
+      return;
+    }
+
+    const merchant = await withClient(async (client) => {
+      await ensureSchema(client);
+      await client.query(
+        `INSERT INTO merchants (address) VALUES ($1) ON CONFLICT (address) DO NOTHING`,
+        ['GBATCHMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'],
+      );
+      return getMerchantByAddress(client, 'GBATCHMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+    });
+    expect(merchant).not.toBeNull();
+
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      merchantId: merchant!.id,
+      txHash: 'b'.repeat(64) + i,
+      ledger: 100 + i,
+      payer: 'G' + 'B'.repeat(55),
+      amount: String(1000 * (i + 1)),
+      asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      ts: new Date(Date.UTC(2026, 7, 1, 0, 0, i)).toISOString(),
+    }));
+
+    const result = await withMerchantClient(merchant!.id, async (client) => {
+      await ensureSchema(client);
+      return insertPaymentsInTransaction(client, merchant!.id, rows, 500);
+    });
+
+    expect(result.inserted).toBe(3);
+    expect(result.payments).toHaveLength(3);
+
+    // All three rows committed, and the cursor advanced to 500 in the same
+    // transaction.
+    await withMerchantClient(merchant!.id, async (client) => {
+      const res = await client.query(
+        `SELECT ledger, payer, amount, asset, ts FROM payments WHERE merchant_id = $1 ORDER BY ledger`,
+        [merchant!.id],
+      );
+      expect(res.rows).toHaveLength(3);
+      expect(res.rows.map((r) => r.ledger)).toEqual([100, 101, 102]);
+      const cursor = await getLastSyncedLedger(client, merchant!.id);
+      expect(cursor).toBe(500);
+    });
+  });
+
+  it('batched inserts preserve ON CONFLICT semantics and the ledger-NULL guard', async () => {
+    if (!process.env.DATABASE_URL) {
+      console.warn('Skipping integration test as DATABASE_URL is missing');
+      return;
+    }
+
+    const merchant = await withClient(async (client) => {
+      await ensureSchema(client);
+      await client.query(
+        `INSERT INTO merchants (address) VALUES ($1) ON CONFLICT (address) DO NOTHING`,
+        ['GBCONFLICTMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'],
+      );
+      return getMerchantByAddress(client, 'GBCONFLICTMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+    });
+    expect(merchant).not.toBeNull();
+
+    const txHash = 'c'.repeat(64) + '1';
+
+    // A merchant-reported row exists first — route attribution arrived before
+    // the indexer saw the transfer, which is the normal ordering. It has a
+    // NULL ledger.
+    await withMerchantClient(merchant!.id, async (client) => {
+      await client.query(
+        `INSERT INTO payments (merchant_id, tx_hash, route, method)
+         VALUES ($1, $2, '/api/hello', 'GET')`,
+        [merchant!.id, txHash],
+      );
+    });
+
+    const row = {
+      merchantId: merchant!.id,
+      txHash,
+      ledger: 300,
+      payer: 'G' + 'C'.repeat(55),
+      amount: '5000',
+      asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+      ts: '2026-08-01T00:00:00.000Z',
+    };
+
+    const result = await withMerchantClient(merchant!.id, async (client) => {
+      await ensureSchema(client);
+      return insertPaymentsInTransaction(client, merchant!.id, [row], 600);
+    });
+
+    // The conflicting row was updated (ledger-NULL guard passed) and returned.
+    expect(result.inserted).toBe(1);
+
+    await withMerchantClient(merchant!.id, async (client) => {
+      const res = await client.query(
+        `SELECT ledger, payer, amount, asset, ts, route, method FROM payments WHERE merchant_id = $1 AND tx_hash = $2`,
+        [merchant!.id, txHash],
+      );
+      const payment = res.rows[0];
+      // Ledger-owned columns were written by the indexer...
+      expect(payment.ledger).toBe(300);
+      expect(payment.payer).toBe('G' + 'C'.repeat(55));
+      expect(payment.amount).toBe('5000');
+      expect(payment.ts).toBeInstanceOf(Date);
+      // ...and merchant-reported columns were left alone.
+      expect(payment.route).toBe('/api/hello');
+      expect(payment.method).toBe('GET');
+    });
+
+    // Re-indexing the same transfer is a no-op: the row now has a ledger, so
+    // the DO UPDATE guard fails and nothing is written or returned.
+    const second = await withMerchantClient(merchant!.id, async (client) => {
+      return insertPaymentsInTransaction(client, merchant!.id, [{ ...row, ledger: 301 }], 601);
+    });
+    expect(second.inserted).toBe(0);
   });
 });

--- a/apps/web/src/lib/db.integration.test.ts
+++ b/apps/web/src/lib/db.integration.test.ts
@@ -1,7 +1,36 @@
 import { describe, it, expect } from 'vitest';
+import { Client } from 'pg';
+
+async function withMerchantClient<T>(
+  merchantId: number,
+  fn: (client: Client) => Promise<T>,
+): Promise<T> {
+  return withClient(async (client) => {
+    // Ensure the non-superuser role exists
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'test_app_user') THEN
+          CREATE ROLE test_app_user;
+        END IF;
+      END $$;
+    `);
+    await client.query('GRANT ALL ON ALL TABLES IN SCHEMA public TO test_app_user');
+    await client.query('GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO test_app_user');
+    
+    // Switch to non-superuser so RLS policies are enforced
+    await client.query('SET SESSION AUTHORIZATION test_app_user');
+    
+    await client.query('SELECT set_config($1, $2, false)', [
+      'accensa.merchant_id',
+      String(merchantId),
+    ]);
+    return fn(client);
+  });
+}
 import {
   withClient,
-  withMerchantClient,
+  
   ensureSchema,
   setLastSyncedLedger,
   getLastSyncedLedger,
@@ -124,7 +153,7 @@ describe('Database Integration', () => {
       await client.query(
         `INSERT INTO payments (merchant_id, tx_hash) VALUES ($1, $2)
          ON CONFLICT (merchant_id, tx_hash) DO NOTHING`,
-        [merchantB.id, 'c'.repeat(64)],
+        [merchantB.id, 'c'.repeat(63)],
       );
     });
 
@@ -132,13 +161,13 @@ describe('Database Integration', () => {
     // with a query that has no WHERE clause at all — this is what
     // FORCE ROW LEVEL SECURITY buys as the second line of defence.
     const rowsSeenByA = await withMerchantClient(merchantA.id, async (client) => {
-      const res = await client.query(`SELECT * FROM payments WHERE tx_hash = $1`, ['c'.repeat(64)]);
+      const res = await client.query(`SELECT * FROM payments WHERE tx_hash = $1`, ['c'.repeat(63)]);
       return res.rows;
     });
     expect(rowsSeenByA).toHaveLength(0);
 
     const rowsSeenByB = await withMerchantClient(merchantB.id, async (client) => {
-      const res = await client.query(`SELECT * FROM payments WHERE tx_hash = $1`, ['c'.repeat(64)]);
+      const res = await client.query(`SELECT * FROM payments WHERE tx_hash = $1`, ['c'.repeat(63)]);
       return res.rows;
     });
     expect(rowsSeenByB).toHaveLength(1);
@@ -162,7 +191,7 @@ describe('Database Integration', () => {
 
     const rows = Array.from({ length: 3 }, (_, i) => ({
       merchantId: merchant!.id,
-      txHash: 'b'.repeat(64) + i,
+      txHash: 'b'.repeat(63) + i,
       ledger: 100 + i,
       payer: 'G' + 'B'.repeat(55),
       amount: String(1000 * (i + 1)),
@@ -208,7 +237,7 @@ describe('Database Integration', () => {
     });
     expect(merchant).not.toBeNull();
 
-    const txHash = 'c'.repeat(64) + '1';
+    const txHash = 'c'.repeat(63) + '1';
 
     // A merchant-reported row exists first — route attribution arrived before
     // the indexer saw the transfer, which is the normal ordering. It has a

--- a/apps/web/src/lib/insert-payments.test.ts
+++ b/apps/web/src/lib/insert-payments.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Client } from 'pg';
+import type { RawEvent } from './stellar-events';
+import fixture from './__fixtures__/sac-transfer-events.json';
+import {
+  PAYMENTS_BATCH_SIZE,
+  buildBatchInsertSql,
+  chunkRows,
+  eventsToPaymentRows,
+  flattenRows,
+  insertPaymentsInTransaction,
+  type PaymentRow,
+} from './insert-payments';
+
+const TX = (n: number) => n.toString(16).padStart(64, '0');
+const PAYER = 'G' + 'A'.repeat(55);
+
+function row(over: Partial<PaymentRow> = {}): PaymentRow {
+  return {
+    merchantId: 1,
+    txHash: TX(1),
+    ledger: 100,
+    payer: PAYER,
+    amount: '1000',
+    asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+    ts: '2026-08-01T00:00:00.000Z',
+    ...over,
+  };
+}
+
+/** Records every query; INSERT INTO payments returns `rows` RETURNING rows. */
+function fakeClient(opts: {
+  /** Throw on the nth INSERT INTO payments statement (1-based). */
+  failInsertOn?: number;
+  returning?: (sql: string) => Record<string, unknown>[];
+}) {
+  const queries: string[] = [];
+  let insertCalls = 0;
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql);
+      if (/^INSERT INTO payments/m.test(sql)) {
+        insertCalls++;
+        if (opts.failInsertOn && insertCalls === opts.failInsertOn) {
+          throw new Error('connection reset mid-batch');
+        }
+        const rows = opts.returning
+          ? opts.returning(sql)
+          : Array.from({ length: (sql.match(/\$\d+::numeric/g) ?? []).length }, (_, i) => ({
+              tx_hash: TX(i),
+              ledger: 100,
+            }));
+        return { rows, rowCount: rows.length };
+      }
+      if (/^SELECT pg_advisory_xact_lock/m.test(sql)) return { rows: [] };
+      if (/^INSERT INTO sync_state/m.test(sql)) return { rows: [] };
+      return { rows: [] };
+    }),
+  };
+  return { client: client as unknown as Client, queries, insertCalls: () => insertCalls };
+}
+
+describe('chunkRows', () => {
+  it('splits into size-bounded chunks, last one smaller', () => {
+    expect(chunkRows([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('returns nothing for no rows', () => {
+    expect(chunkRows([], 100)).toEqual([]);
+  });
+});
+
+describe('buildBatchInsertSql', () => {
+  it('builds one multi-row statement with 7 bind parameters per row', () => {
+    const sql = buildBatchInsertSql(3);
+    expect(sql.match(/\$\d+/g)).toHaveLength(21);
+    // Three tuples, one per row (each carries one ::numeric cast).
+    expect(sql.match(/\$\d+::numeric/g)).toHaveLength(3);
+  });
+
+  it('preserves ON CONFLICT DO UPDATE semantics and the ledger-NULL guard', () => {
+    const sql = buildBatchInsertSql(2);
+    expect(sql).toContain('ON CONFLICT (merchant_id, tx_hash) DO UPDATE');
+    expect(sql).toContain('SET ledger = EXCLUDED.ledger');
+    expect(sql).toContain('payer = EXCLUDED.payer');
+    expect(sql).toContain('amount = EXCLUDED.amount');
+    expect(sql).toContain('asset = EXCLUDED.asset');
+    expect(sql).toContain('ts = EXCLUDED.ts');
+    expect(sql).toContain('WHERE payments.ledger IS NULL');
+    expect(sql).toContain('RETURNING *');
+  });
+
+  it('never writes merchant-reported columns', () => {
+    const sql = buildBatchInsertSql(2);
+    for (const col of ['route', 'method', 'request_id', 'hook_reported_at']) {
+      expect(sql).not.toMatch(new RegExp(`\\b${col}\\b`));
+    }
+  });
+
+  it('flattenRows matches the placeholder order', () => {
+    const r = row({ txHash: TX(7), ledger: 42, amount: '999' });
+    expect(flattenRows([r])).toEqual([
+      r.merchantId,
+      r.txHash,
+      r.ledger,
+      r.payer,
+      r.amount,
+      r.asset,
+      r.ts,
+    ]);
+  });
+});
+
+describe('eventsToPaymentRows — per-event filtering survives batching', () => {
+  const validEvents = fixture.events as RawEvent[];
+
+  it('keeps transfers addressed to this merchant and drops others', () => {
+    const to = 'GD4C3LWGIXNDWC3G2UTIKXA4TN2KCBOCP5G6R6YT6WBHVDEP4D4GRMK4';
+    const { rows, decoded } = eventsToPaymentRows(validEvents, { id: 1, address: to });
+
+    expect(decoded).toBe(validEvents.length);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => r.merchantId === 1)).toBe(true);
+    // Amount stays a decimal string — never a float.
+    expect(typeof rows[0].amount).toBe('string');
+  });
+
+  it('skips malformed or non-transfer events without stalling the batch', () => {
+    const to = 'GD4C3LWGIXNDWC3G2UTIKXA4TN2KCBOCP5G6R6YT6WBHVDEP4D4GRMK4';
+    const events: RawEvent[] = [
+      ...validEvents,
+      { txHash: 'bad-1', ledger: 1 } as RawEvent, // no topic -> not decodable
+      { value: { xdr: 'not-valid-xdr' } } as RawEvent, // malformed
+    ];
+
+    const { rows, decoded } = eventsToPaymentRows(events, { id: 1, address: to });
+    expect(decoded).toBe(validEvents.length); // malformed ones not counted
+    expect(rows.length).toBeGreaterThan(0); // valid ones still inserted
+  });
+
+  it('produces no rows when every transfer belongs to another merchant', () => {
+    const other = 'G' + 'D'.repeat(55);
+    const { rows } = eventsToPaymentRows(validEvents, { id: 2, address: other });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('carries ledger-owned fields into the row shape the insert expects', () => {
+    const to = 'GD4C3LWGIXNDWC3G2UTIKXA4TN2KCBOCP5G6R6YT6WBHVDEP4D4GRMK4';
+    const { rows } = eventsToPaymentRows(validEvents, { id: 1, address: to });
+    const r = rows[0];
+    expect(r.txHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(r.ledger).toBeGreaterThan(0);
+    expect(r.payer.length).toBeGreaterThan(0);
+    expect(r.ts).toBeTruthy();
+    expect(() => new Date(r.ts)).not.toThrow();
+  });
+});
+
+describe('insertPaymentsInTransaction', () => {
+  it('inserts many rows in a single batched statement', async () => {
+    const rows = Array.from({ length: 250 }, (_, i) => row({ txHash: TX(i) }));
+    // No custom `returning`: the fake yields one RETURNING row per tuple, which
+    // is what Postgres does for a batch that writes every row.
+    const { client, queries } = fakeClient({});
+
+    const result = await insertPaymentsInTransaction(client, 1, rows, 5000);
+
+    // 250 rows at 100 per batch -> 3 INSERT statements (100/100/50).
+    const inserts = queries.filter((q) => /^INSERT INTO payments/m.test(q));
+    expect(inserts).toHaveLength(3);
+    expect(inserts[0].match(/\$\d+/g)).toHaveLength(700);
+    expect(inserts[1].match(/\$\d+/g)).toHaveLength(700);
+    expect(inserts[2].match(/\$\d+/g)).toHaveLength(350);
+    expect(result.inserted).toBe(250);
+    expect(result.payments).toHaveLength(250);
+
+    // Wrapped in a transaction, and the cursor advanced inside it.
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries.some((q) => /^INSERT INTO sync_state/m.test(q))).toBe(true);
+    expect(queries[queries.length - 1]).toBe('COMMIT');
+    expect(queries.includes('ROLLBACK')).toBe(false);
+  });
+
+  it('advances the cursor across an empty run (no events, quiet merchant)', async () => {
+    const { client, queries } = fakeClient({});
+    const result = await insertPaymentsInTransaction(client, 1, [], 5000);
+
+    expect(result.inserted).toBe(0);
+    expect(queries).toEqual([
+      'BEGIN',
+      'SELECT pg_advisory_xact_lock($1)',
+      'INSERT INTO sync_state (merchant_id, last_ledger, updated_at) VALUES ($1, $2, now())\n     ON CONFLICT (merchant_id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger, updated_at = now()\n     WHERE sync_state.last_ledger < EXCLUDED.last_ledger',
+      'COMMIT',
+    ]);
+  });
+
+  it('does not advance the cursor when a chunk fails mid-run', async () => {
+    const rows = Array.from({ length: PAYMENTS_BATCH_SIZE * 2 + 1 }, (_, i) =>
+      row({ txHash: TX(i) }),
+    );
+    const { client, queries } = fakeClient({ failInsertOn: 2 });
+
+    await expect(insertPaymentsInTransaction(client, 1, rows, 5000)).rejects.toThrow(
+      'connection reset mid-batch',
+    );
+
+    // The failed batch rolls everything back — including the cursor upsert,
+    // which must never run for a run that did not commit.
+    expect(queries[0]).toBe('BEGIN');
+    expect(queries.includes('ROLLBACK')).toBe(true);
+    expect(queries.includes('COMMIT')).toBe(false);
+    expect(queries.some((q) => /^INSERT INTO sync_state/m.test(q))).toBe(false);
+  });
+
+  it('returns only the rows actually written (conflicts skipped by the guard are absent)', async () => {
+    const rows = [row({ txHash: TX(1) }), row({ txHash: TX(2) })];
+    const { client } = fakeClient({
+      // Simulate one row already having a ledger (DO UPDATE ... WHERE ledger
+      // IS NULL does not match): RETURNING yields only the other row.
+      returning: (sql) => {
+        const count = (sql.match(/\$\d+::numeric/g) ?? []).length;
+        return count === 2 ? [{ tx_hash: TX(1), ledger: 100 }] : [];
+      },
+    });
+
+    const result = await insertPaymentsInTransaction(client, 1, rows, 5000);
+    expect(result.inserted).toBe(1);
+    expect(result.payments).toEqual([{ tx_hash: TX(1), ledger: 100 }]);
+  });
+});

--- a/apps/web/src/lib/insert-payments.ts
+++ b/apps/web/src/lib/insert-payments.ts
@@ -1,0 +1,158 @@
+import type { Client } from 'pg';
+import { setLastSyncedLedger } from './db';
+import { decodeTransferEvent, type RawEvent } from './stellar-events';
+
+/**
+ * Rows per INSERT statement.
+ *
+ * Each row binds 7 parameters, so a batch of 100 binds 700 — two orders of
+ * magnitude below Postgres's 65,535-parameter ceiling per statement. The
+ * statement stays small enough for any pooler or proxy to handle comfortably,
+ * and a 10,000-event catch-up goes from 10,000 round trips to 100.
+ */
+export const PAYMENTS_BATCH_SIZE = 100;
+
+/**
+ * Maps raw RPC events to insertable payment rows for one merchant.
+ *
+ * The per-event filtering lives here, where a test can pin it down: a
+ * malformed or non-transfer event is skipped, and a transfer not addressed to
+ * this merchant is never recorded. Batching must not quietly admit events that
+ * would have been filtered out — this is the only place rows are produced, and
+ * the batched insert consumes exactly what this returns.
+ *
+ * @returns The rows to insert, and how many events decoded (including
+ *   skipped ones), mirroring the route's old per-event accounting.
+ */
+export function eventsToPaymentRows(
+  events: RawEvent[],
+  merchant: { id: number; address: string },
+): { rows: PaymentRow[]; decoded: number } {
+  const rows: PaymentRow[] = [];
+  let decoded = 0;
+  for (const event of events) {
+    const transferEvent = decodeTransferEvent(event);
+    // A malformed or non-transfer event must not stall the batch.
+    if (!transferEvent) continue;
+    decoded++;
+    // Defensive: never record a transfer that is not to this merchant.
+    if (transferEvent.to !== merchant.address) continue;
+    rows.push({
+      merchantId: merchant.id,
+      txHash: transferEvent.txHash,
+      ledger: transferEvent.ledger,
+      payer: transferEvent.from,
+      amount: transferEvent.amount, // string - never a float
+      asset: transferEvent.asset,
+      ts: transferEvent.ledgerClosedAt,
+    });
+  }
+  return { rows, decoded };
+}
+
+/** One decoded, merchant-addressed transfer, ready to be inserted. */
+export interface PaymentRow {
+  merchantId: number;
+  txHash: string;
+  ledger: number;
+  payer: string;
+  amount: string;
+  asset: string;
+  /** ISO 8601 ledger close time. */
+  ts: string;
+}
+
+/** Splits rows into `size`-sized chunks; the last chunk may be smaller. */
+export function chunkRows<T>(rows: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < rows.length; i += size) {
+    chunks.push(rows.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Builds one multi-row INSERT for `rowCount` payments.
+ *
+ * `ON CONFLICT (merchant_id, tx_hash) DO UPDATE ... WHERE payments.ledger IS
+ * NULL` is preserved verbatim from the per-row statement it replaces: a row may
+ * already exist because the merchant reported route attribution before this
+ * transfer was indexed, and only ledger-owned columns may be written — route,
+ * method, request_id and hook_reported_at belong to the merchant's report and
+ * are left alone. `RETURNING *` yields exactly the rows actually written, which
+ * is what the webhook path needs.
+ */
+export function buildBatchInsertSql(rowCount: number): string {
+  const tuples: string[] = [];
+  for (let i = 0; i < rowCount; i++) {
+    const base = i * 7;
+    tuples.push(
+      `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}::numeric, $${base + 6}, $${base + 7}::timestamptz)`,
+    );
+  }
+  return `INSERT INTO payments (merchant_id, tx_hash, ledger, payer, amount, asset, ts)
+  VALUES ${tuples.join(', ')}
+  ON CONFLICT (merchant_id, tx_hash) DO UPDATE
+  SET ledger = EXCLUDED.ledger,
+  payer = EXCLUDED.payer,
+  amount = EXCLUDED.amount,
+  asset = EXCLUDED.asset,
+  ts = EXCLUDED.ts
+  WHERE payments.ledger IS NULL RETURNING *`;
+}
+
+/** Flattens rows into the bind-parameter list `buildBatchInsertSql` expects. */
+export function flattenRows(rows: PaymentRow[]): unknown[] {
+  const params: unknown[] = [];
+  for (const r of rows) {
+    params.push(r.merchantId, r.txHash, r.ledger, r.payer, r.amount, r.asset, r.ts);
+  }
+  return params;
+}
+
+/**
+ * Inserts `rows` in batches, then advances the sync cursor — atomically.
+ *
+ * The whole run — every batch plus the cursor write — happens inside one
+ * transaction, so either all of it commits or none of it does:
+ *
+ * - If a chunk fails mid-run, the ROLLBACK discards every batch written so far
+ *   and the cursor is never advanced, so `syncedTo` never passes a ledger whose
+ *   rows failed to commit. A contiguous cursor is a property this project
+ *   actively monitors.
+ * - Webhooks are *not* fired here: they run after COMMIT in the caller, so a
+ *   slow webhook can never hold the transaction open, and a webhook failure
+ *   cannot roll back a committed batch.
+ *
+ * @returns The rows RETURNING produced — exactly the payments inserted or
+ *   updated by this run (conflicts skipped by the `WHERE ledger IS NULL` guard
+ *   are not returned, matching the old per-row `rowCount` semantics).
+ */
+export async function insertPaymentsInTransaction(
+  client: Client,
+  merchantId: number,
+  rows: PaymentRow[],
+  sweptThrough: number,
+): Promise<{ inserted: number; payments: Record<string, unknown>[] }> {
+  await client.query('BEGIN');
+  try {
+    const payments: Record<string, unknown>[] = [];
+    for (const chunk of chunkRows(rows, PAYMENTS_BATCH_SIZE)) {
+      const res = await client.query<Record<string, unknown>>(
+        buildBatchInsertSql(chunk.length),
+        flattenRows(chunk),
+      );
+      payments.push(...res.rows);
+    }
+    // The cursor advances inside the same transaction, so it can never move
+    // past uncommitted rows — and the advisory lock in setLastSyncedLedger
+    // now actually serializes concurrent runs for this merchant, since it is
+    // held until COMMIT rather than released at statement end.
+    await setLastSyncedLedger(client, merchantId, sweptThrough);
+    await client.query('COMMIT');
+    return { inserted: payments.length, payments };
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  }
+}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -21,3 +21,40 @@ The reporting contract is as follows:
    Pass the resulting signature as a hex string in the `X-Signature` HTTP header.
 
 The backend verifies this signature before parsing the JSON, ensuring the request is strictly authenticated based on the raw bytes.
+
+## Verifying Inbound Webhooks
+
+Merchants receiving webhooks from the Accensa indexer can verify that the
+request actually came from Accensa and was not tampered with. Every outbound
+webhook is signed with **HMAC-SHA256** using a shared secret, and the hex
+digest travels in the `X-Webhook-Signature` header.
+
+```ts
+import { signWebhookSignature, verifyWebhookSignature } from '@accensa/sdk';
+
+// Server side — Accensa signs the raw body it is about to POST.
+const body = JSON.stringify({ tx_hash: '...', route: '/api/hello' });
+const signature = signWebhookSignature(body, process.env.WEBHOOK_SECRET!);
+
+// Merchant side — verify before trusting anything in the payload.
+const rawBody = await readRawRequestBody(req); // exact bytes, not re-serialised
+if (
+  !verifyWebhookSignature(rawBody, req.headers['x-webhook-signature'], process.env.WEBHOOK_SECRET!)
+) {
+  return res.status(401).json({ error: 'Invalid signature' });
+}
+```
+
+Two things to get right:
+
+1. **Sign and verify the exact bytes.** The signature is computed over the raw
+   request body as sent. Re-serialising the JSON on the receiving side (e.g.
+   `JSON.stringify(JSON.parse(body))`) can reorder keys or change whitespace
+   and the signature will no longer match.
+2. **The comparison is timing-safe.** `verifyWebhookSignature` uses
+   `crypto.timingSafeEqual`, so a failed check does not leak how much of the
+   digest matched.
+
+`signWebhookSignature` produces the same hex digest the indexer computes, so a
+merchant using `verifyWebhookSignature` accepts genuine Accensa webhooks and
+rejects forged or altered ones.

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -19,6 +19,7 @@ export {
   type Settlement,
   type X402SettleResult,
 } from './settlement';
+export { WEBHOOK_SIGNATURE_HEADER, signWebhookSignature, verifyWebhookSignature } from './webhooks';
 
 /**
  * This package deliberately ships no paywall middleware.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,8 @@
   },
   "exports": {
     ".": "./index.ts",
-    "./merkle": "./merkle.ts"
+    "./merkle": "./merkle.ts",
+    "./webhooks": "./webhooks.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/sdk/webhooks.test.ts
+++ b/packages/sdk/webhooks.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { signWebhookSignature, verifyWebhookSignature, WEBHOOK_SIGNATURE_HEADER } from './webhooks';
+
+const SECRET = 'shared-secret-value';
+const BODY = JSON.stringify({ tx_hash: 'a'.repeat(64), route: '/api/hello', method: 'GET' });
+
+describe('signWebhookSignature', () => {
+  it('produces a hex HMAC-SHA256 digest of the raw payload', () => {
+    const signature = signWebhookSignature(BODY, SECRET);
+    expect(signature).toBe(createHmac('sha256', SECRET).update(BODY).digest('hex'));
+    expect(signature).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('matches the digest the indexer itself computes', () => {
+    // The web app signs outbound webhooks with exactly
+    // createHmac('sha256', secret).update(body).digest('hex') — a merchant
+    // verifying with this module must accept that value verbatim.
+    const indexerDigest = createHmac('sha256', SECRET).update(BODY).digest('hex');
+    expect(signWebhookSignature(BODY, SECRET)).toBe(indexerDigest);
+  });
+
+  it('differs across secrets and across payloads', () => {
+    const withOtherSecret = signWebhookSignature(BODY, 'other-secret');
+    const withOtherBody = signWebhookSignature('{"route":"/api/free"}', SECRET);
+    expect(withOtherSecret).not.toBe(signWebhookSignature(BODY, SECRET));
+    expect(withOtherBody).not.toBe(signWebhookSignature(BODY, SECRET));
+  });
+
+  it('signs a Buffer payload byte-for-byte', () => {
+    const buffer = Buffer.from(BODY, 'utf8');
+    expect(signWebhookSignature(buffer, SECRET)).toBe(signWebhookSignature(BODY, SECRET));
+  });
+});
+
+describe('verifyWebhookSignature', () => {
+  it('accepts a genuine signature', () => {
+    const signature = signWebhookSignature(BODY, SECRET);
+    expect(verifyWebhookSignature(BODY, signature, SECRET)).toBe(true);
+  });
+
+  it('rejects a tampered payload', () => {
+    const signature = signWebhookSignature(BODY, SECRET);
+    const tampered = BODY.replace('/api/hello', '/api/analytics/report');
+    expect(verifyWebhookSignature(tampered, signature, SECRET)).toBe(false);
+  });
+
+  it('rejects a signature minted with a different secret', () => {
+    const signature = signWebhookSignature(BODY, 'someone-elses-secret');
+    expect(verifyWebhookSignature(BODY, signature, SECRET)).toBe(false);
+  });
+
+  it('rejects a signature for a different body even when the secret matches', () => {
+    const signature = signWebhookSignature('{"route":"/api/free"}', SECRET);
+    expect(verifyWebhookSignature(BODY, signature, SECRET)).toBe(false);
+  });
+
+  it('rejects a missing, empty, or non-string signature', () => {
+    expect(verifyWebhookSignature(BODY, undefined, SECRET)).toBe(false);
+    expect(verifyWebhookSignature(BODY, null, SECRET)).toBe(false);
+    expect(verifyWebhookSignature(BODY, '', SECRET)).toBe(false);
+    expect(verifyWebhookSignature(BODY, '   ', SECRET)).toBe(false);
+  });
+
+  it('rejects a malformed (non-hex) signature rather than throwing', () => {
+    expect(verifyWebhookSignature(BODY, 'not-hex-at-all', SECRET)).toBe(false);
+  });
+
+  it('rejects a signature of the wrong length', () => {
+    // A genuine 64-char digest truncated to 32 chars must fail on length
+    // before any byte comparison.
+    const signature = signWebhookSignature(BODY, SECRET).slice(0, 32);
+    expect(verifyWebhookSignature(BODY, signature, SECRET)).toBe(false);
+  });
+
+  it('exposes the wire header name', () => {
+    expect(WEBHOOK_SIGNATURE_HEADER).toBe('x-webhook-signature');
+  });
+});

--- a/packages/sdk/webhooks.ts
+++ b/packages/sdk/webhooks.ts
@@ -1,0 +1,67 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * HTTP header that carries the Accensa webhook signature.
+ *
+ * The Accensa indexer signs every outbound webhook with HMAC-SHA256 and sends
+ * the hex digest in this header (`x-webhook-signature` on the wire; HTTP
+ * header names are case-insensitive). Merchants verify with
+ * {@link verifyWebhookSignature}.
+ */
+export const WEBHOOK_SIGNATURE_HEADER = 'x-webhook-signature';
+
+/**
+ * Computes the HMAC-SHA256 signature Accensa attaches to outbound webhooks.
+ *
+ * Signs the exact bytes that will be sent as the request body — same contract
+ * as the settlement-report signing: whatever is signed is what must be sent.
+ * The indexer computes `createHmac('sha256', secret).update(body).digest('hex')`,
+ * and this function produces exactly that value, so a merchant that verifies
+ * with this module accepts genuine indexer webhooks.
+ *
+ * @param payload The raw webhook body bytes. Pass the same string or Buffer
+ *   that was POSTed — a re-serialised JSON object may differ in key order or
+ *   whitespace and would fail verification.
+ * @param secret The shared webhook secret, configured on both the Accensa
+ *   deployment and the merchant server.
+ * @returns Hex-encoded HMAC-SHA256 digest.
+ */
+export function signWebhookSignature(payload: string | Buffer, secret: string): string {
+  return createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+/**
+ * Verifies an inbound webhook's `X-Webhook-Signature` header.
+ *
+ * Recomputes the HMAC-SHA256 digest over the received body and compares it
+ * against the presented signature with a timing-safe comparison, so a failing
+ * check does not leak how far the two digests agree. Returns false — never
+ * throws — for a missing, malformed, or mismatched signature, which is what a
+ * request handler wants to fail closed on.
+ *
+ * @param payload The raw body bytes exactly as received (see
+ *   {@link signWebhookSignature} on why re-serialising is a footgun).
+ * @param signature The value of the `X-Webhook-Signature` header, hex-encoded.
+ * @param secret The shared webhook secret.
+ */
+export function verifyWebhookSignature(
+  payload: string | Buffer,
+  signature: string | null | undefined,
+  secret: string,
+): boolean {
+  if (typeof signature !== 'string' || signature.trim() === '') return false;
+
+  let expected: Buffer;
+  let received: Buffer;
+  try {
+    expected = Buffer.from(signWebhookSignature(payload, secret), 'hex');
+    received = Buffer.from(signature.trim(), 'hex');
+  } catch {
+    return false;
+  }
+
+  // timingSafeEqual throws on length mismatch, so that is checked first — a
+  // length difference is itself a failed verification.
+  if (expected.length !== received.length) return false;
+  return timingSafeEqual(expected, received);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/demo-merchant:
     dependencies:
+      '@stellar/stellar-sdk':
+        specifier: ^16.0.1
+        version: 16.0.1
       '@x402/core':
         specifier: ^2.21.0
         version: 2.21.0


### PR DESCRIPTION
## Summary

This PR solves four issues in one pass: webhook signature verification for the SDK, batched indexer inserts, a demo merchant with real route attribution, and the buyer-side demo that was missing.

### Closes #148 — Implement Webhook signature verification utility

Added an HMAC-SHA256 webhook signature module to `@accensa/sdk`:

- `packages/sdk/webhooks.ts` — `signWebhookSignature()` (hex HMAC-SHA256 over the raw body, byte-for-byte identical to what the indexer produces) and `verifyWebhookSignature()` (timing-safe comparison; fails closed on missing/malformed/mismatched signatures).
- Exported from the package root and as `@accensa/sdk/webhooks`.
- Documented in the SDK README (sign/verify the exact bytes; timing-safe comparison).
- `packages/sdk/webhooks.test.ts` — valid signatures pass; tampered payloads, wrong secrets, wrong bodies, truncated and non-hex signatures all fail.

### Closes #151 — Batch the indexer's per-event inserts

`apps/web/src/app/api/sync/route.ts` now inserts in batched multi-row statements instead of one query per event:

- New `apps/web/src/lib/insert-payments.ts`: `eventsToPaymentRows()` (per-event filtering — malformed events and transfers not addressed to the merchant are still skipped), `buildBatchInsertSql()` (multi-row `VALUES` list preserving the exact `ON CONFLICT (merchant_id, tx_hash) DO UPDATE ... WHERE payments.ledger IS NULL RETURNING *` semantics, writing only ledger-owned columns), and `insertPaymentsInTransaction()`.
- **Chunk size 100**: each row binds 7 parameters, so a batch binds 700 — two orders of magnitude below Postgres's 65,535-parameter ceiling per statement, keeping statements small enough for any pooler while turning a 10,000-event catch-up from 10,000 round trips into 100.
- **Cursor honesty**: the inserts *and* the `syncedTo` cursor advance now commit in one transaction — if any chunk fails, everything rolls back and the cursor never advances past the failed run (this also makes the existing advisory lock actually serialize concurrent runs for a merchant, since it is now held until COMMIT).
- **Webhooks** fire after COMMIT from the `RETURNING` rows, so a slow/failing webhook can neither hold the transaction open nor roll back a committed batch.
- **Tests**: `insert-payments.test.ts` (statement shape, chunking 250 rows → 3 statements, ledger-only `SET`, mid-run failure → ROLLBACK and no cursor advance, empty-run cursor advance) and two new real-DB cases in `db.integration.test.ts` (batch write + atomic cursor; `ON CONFLICT` update fills ledger-owned columns while preserving merchant-reported `route`/`method`, and re-indexing a row that already has a ledger is a no-op).
- **Throughput**: the fix is round-trip reduction rather than faster rows — previously 1 statement per event, now 1 per 100. A 10,000-event catch-up drops from 10,000 round trips against the remote Supabase Postgres to 100. CI runs the web suite against a real Postgres (`test (web)` job) and exercises the new integration tests; local runs without `DATABASE_URL` skip them, matching the existing pattern.

### Closes #154 — Demo merchant route attribution

`apps/demo-merchant/server.js` now serves several routes at genuinely different prices, plus a free one:

- `/api/hello` — 1,000 stroops (0.0001 XLM), cheap and frequent.
- `/api/insights/daily` — 25,000 stroops (0.0025 XLM), mid price.
- `/api/analytics/full` — 1,000,000 stroops (0.1 XLM), expensive and rare.
- `/api/free` — deliberately **not** in the x402 route config, so the middleware passes it through and the free/paid boundary is visible.
- Prices are far apart in magnitude so the dashboard's per-route attribution, totals, and CSV decimal handling are exercised against real variety — no product/cart/order model introduced.
- `apps/demo-merchant/drive.js` — one command makes a realistic mix of calls (5× cheap, 2× mid, 1× expensive, 3× free) to populate the dashboard.
- `apps/demo-merchant/README.md` documents each route, its price, and what it demonstrates.
- The demo page lists all routes with their prices and a button per route plus the free route.

### Closes #159 — The demo shows only the seller side

Added the missing buyer side:

- `apps/demo-merchant/agent.js` — pays a demo-merchant route end to end (plain GET → 402 → signed payment payload → retry → resource → settlement), printing each protocol step. Uses the **stock x402 client** (`x402Client` + `x402HTTPClient` + Stellar `ExactStellarScheme`) via `apps/demo-merchant/lib/x402-payer.js` — no bespoke payer.
- It ends by printing a receipt in exactly the form `/verify` accepts (`batchId`, `leaf`, `proof`) built over the payments the run actually made, with a real sorted-pair Merkle proof that verifies against `@accensa/sdk`'s `verifyReceipt`. The on-chain half of `/verify` needs the batch anchored, which is tracked separately (issue #15).
- `apps/demo-merchant/README.md` documents funding a testnet payer start to finish (create keypair → fund via Stellar Lab friendbot → `.env`), plus how to run the server, agent, and driver.
- No mock/simulated login anywhere; `apps/web/src/lib/auth.ts` and the middleware are untouched.

## Verification

- `packages/sdk`: 93 tests pass, `tsc --noEmit` clean.
- `apps/web`: 297 tests pass, `tsc --noEmit` clean, ESLint clean on changed files, `next build` succeeds.
- Demo merchant smoke-tested: free route returns 200 without payment; all three paid routes return `402` with a `Payment-Required` header.
- The agent's Merkle receipt logic matches the repo's conformance vectors (reproduces the anchored batch #1 root and proof exactly).
- `pnpm format:check` passes for every changed file (three unrelated files were already failing on main and were left alone).
