### PR TITLE
feat(indexer): structured failure logging for sync (#135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@11
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Check formatting
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@11
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       # Lints apps/web and packages/sdk from the root.
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@11
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test SDK
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@11
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test web
@@ -105,7 +105,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@11
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       # Typechecks apps/web and packages/sdk from the root.
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: '22'
       - name: Install pnpm
-        run: npm install -g pnpm@9
+        run: npm install -g pnpm@11
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build Next.js app

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -13,6 +13,7 @@ import {
   parallelSweepLedgerRange,
   PARALLEL_SYNC_THRESHOLD,
   EVENTS_PAGE_LIMIT,
+  LedgerWindowFetchError,
   type EventPage,
 } from '@/lib/event-pager';
 import {
@@ -26,6 +27,7 @@ import {
 import { listMerchants, getMerchantFromRequest, type Merchant } from '@/lib/merchants';
 import { cooldownRemaining } from '@/lib/sync-status';
 import { isAuthorizedCronRequest } from '@/lib/cron-auth';
+import { logSyncFailure, notifySyncFailure, type SyncFailureContext } from '@/lib/sync-logger';
 import { createHmac } from 'node:crypto';
 
 export const dynamic = 'force-dynamic';
@@ -328,12 +330,38 @@ async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
 
 type SyncResult = Awaited<ReturnType<typeof runSync>>;
 
+/** One merchant's sync throwing instead of returning a result (#135). */
+interface SyncFailure {
+  merchant: string;
+  error: string;
+}
+
 /** Maps one merchant's run to its response fragment. */
 function summarize(result: SyncResult) {
   if ('cooldown' in result) {
     return { cooldown: true, retryAfterMs: Math.ceil(result.retryAfterMs) };
   }
   return result;
+}
+
+/**
+ * Builds the context+logging a caught sync error needs, then reports it both
+ * to the log (always) and to SYNC_ALERT_WEBHOOK_URL (if configured) (#135).
+ *
+ * A LedgerWindowFetchError carries the exact window being read when the RPC
+ * call failed; anything else (a parsing error, a DB error) is logged without
+ * ledger context rather than guessing at one.
+ */
+function reportSyncError(error: unknown, merchant?: string): void {
+  const context: SyncFailureContext = {
+    ...(merchant ? { merchant } : {}),
+    ...(error instanceof LedgerWindowFetchError
+      ? { startLedger: error.startLedger, endLedger: error.endLedger }
+      : {}),
+  };
+  logSyncFailure(context, error);
+  // Alerting must never block or fail the sync job itself.
+  void notifySyncFailure(context, error);
 }
 
 /**
@@ -345,12 +373,18 @@ function summarize(result: SyncResult) {
  * as deployment-wide maximums alongside the full per-merchant `results`, so
  * that check keeps working unchanged whether this deployment has one merchant
  * or many.
+ *
+ * `failures` (#135) are merchants whose sync threw rather than returned — they
+ * no longer abort the whole batch (see GET below), so they are reported here
+ * instead: `success` goes false, which the workflow already treats as a
+ * warning worth surfacing, while `results`/`syncedTo` still reflect whatever
+ * other merchants did complete.
  */
-function respond(results: SyncResult[]) {
+function respond(results: SyncResult[], failures: SyncFailure[] = []) {
   // The manual, single-merchant POST path preserves the original 429 +
   // Retry-After contract exactly, since the dashboard's "Sync now" button
   // already depends on it.
-  if (results.length === 1 && 'cooldown' in results[0]) {
+  if (failures.length === 0 && results.length === 1 && 'cooldown' in results[0]) {
     const retryAfterMs = Math.ceil(results[0].retryAfterMs);
     return NextResponse.json(
       { success: true, cooldown: true, retryAfterMs },
@@ -367,14 +401,15 @@ function respond(results: SyncResult[]) {
   const drained = synced.length ? synced.every((s) => s.drained) : true;
 
   return NextResponse.json({
-    success: true,
+    success: failures.length === 0,
     results: summaries,
     ...(syncedTo !== null ? { syncedTo, skippedLedgers, drained } : {}),
+    ...(failures.length ? { failures } : {}),
   });
 }
 
-function failed(error: unknown) {
-  console.error('Error during sync:', error);
+function failed(error: unknown, merchant?: string) {
+  reportSyncError(error, merchant);
   return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 });
 }
 
@@ -412,10 +447,22 @@ export async function GET(request: Request) {
     }
 
     const results: SyncResult[] = [];
+    const failures: SyncFailure[] = [];
     for (const merchant of merchants) {
-      results.push(await runSync(merchant));
+      // One merchant's RPC error or parsing failure must not cost every
+      // merchant after it in this run their turn (#135) — each is isolated
+      // and logged with context, and the loop moves on.
+      try {
+        results.push(await runSync(merchant));
+      } catch (error) {
+        reportSyncError(error, merchant.address);
+        failures.push({
+          merchant: merchant.address,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
-    return respond(results);
+    return respond(results, failures);
   } catch (error: unknown) {
     return failed(error);
   }
@@ -433,14 +480,15 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'DATABASE_URL is not configured' }, { status: 500 });
   }
 
+  let merchant: Merchant | null = null;
   try {
-    const merchant = await withClient((client) => getMerchantFromRequest(client, request));
+    merchant = await withClient((client) => getMerchantFromRequest(client, request));
     if (!merchant) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     return respond([await runSync(merchant, { cooldownMs: MANUAL_COOLDOWN_MS })]);
   } catch (error: unknown) {
-    return failed(error);
+    return failed(error, merchant?.address);
   }
 }

--- a/apps/web/src/lib/event-pager.test.ts
+++ b/apps/web/src/lib/event-pager.test.ts
@@ -5,6 +5,7 @@ import {
   parallelSweepLedgerRange,
   EVENTS_PAGE_LIMIT,
   LEDGER_WINDOW,
+  LedgerWindowFetchError,
   type EventPage,
 } from './event-pager';
 import type { RawEvent } from './stellar-events';
@@ -108,6 +109,54 @@ describe('drainEvents', () => {
     expect(result.drained).toBe(false);
     expect(result.pages).toBe(2);
     expect(result.events).toHaveLength(400);
+  });
+
+  it('wraps a failed fetch in a LedgerWindowFetchError carrying the window (#135)', async () => {
+    const rpcError = new Error('RPC getEvents: [-32001] request exceeded processing limit');
+    const fetchPage = async (): Promise<EventPage> => {
+      throw rpcError;
+    };
+
+    await expect(
+      drainEvents(fetchPage, { startLedger: 12_345, endLedger: 22_345 }),
+    ).rejects.toThrow(LedgerWindowFetchError);
+
+    try {
+      await drainEvents(fetchPage, { startLedger: 12_345, endLedger: 22_345 });
+      expect.unreachable('drainEvents should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(LedgerWindowFetchError);
+      const wrapped = error as LedgerWindowFetchError;
+      expect(wrapped.startLedger).toBe(12_345);
+      expect(wrapped.endLedger).toBe(22_345);
+      expect(wrapped.cause).toBe(rpcError);
+      expect(wrapped.message).toContain('12345');
+      expect(wrapped.message).toContain('22345');
+    }
+  });
+
+  it('falls back to startLedger for the window end when a later page has no endLedger', async () => {
+    // A cursor-following page omits endLedger entirely (see the "supersedes
+    // startLedger" comment above) — a failure there must still report a
+    // sensible window rather than an undefined endLedger.
+    const all = makeEvents(EVENTS_PAGE_LIMIT + 1, () => 100);
+    let calls = 0;
+    const fetchPage = async (): Promise<EventPage> => {
+      calls++;
+      if (calls === 1) {
+        return { events: all.slice(0, EVENTS_PAGE_LIMIT), cursor: 'evt-199' };
+      }
+      throw new Error('second page failed');
+    };
+
+    try {
+      await drainEvents(fetchPage, { startLedger: 100 });
+      expect.unreachable('drainEvents should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(LedgerWindowFetchError);
+      expect((error as LedgerWindowFetchError).startLedger).toBe(100);
+      expect((error as LedgerWindowFetchError).endLedger).toBe(100);
+    }
   });
 });
 

--- a/apps/web/src/lib/event-pager.ts
+++ b/apps/web/src/lib/event-pager.ts
@@ -12,6 +12,27 @@ export interface EventPage {
 
 export type EventConsumer = (events: RawEvent[]) => void | Promise<void>;
 
+/**
+ * Thrown when a `getEvents` page fetch fails, carrying the exact ledger window
+ * that was being read at the time (#135). Without this, an RPC error or a
+ * parsing failure bubbles up as a bare error with no way to tell which ledgers
+ * were affected — the window is only ever in scope at the call site below.
+ */
+export class LedgerWindowFetchError extends Error {
+  readonly startLedger: number;
+  readonly endLedger: number;
+
+  constructor(startLedger: number, endLedger: number, cause: unknown) {
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    super(`Failed to fetch events for ledger window [${startLedger}, ${endLedger}]: ${reason}`, {
+      cause,
+    });
+    this.name = 'LedgerWindowFetchError';
+    this.startLedger = startLedger;
+    this.endLedger = endLedger;
+  }
+}
+
 export interface DrainResult {
   events: RawEvent[];
   /**
@@ -70,7 +91,12 @@ export async function drainEvents(
 
   for (;;) {
     // A cursor supersedes startLedger; sending both is rejected by the RPC.
-    const page = await fetchPage(cursor ? { cursor } : { startLedger, endLedger });
+    let page: EventPage;
+    try {
+      page = await fetchPage(cursor ? { cursor } : { startLedger, endLedger });
+    } catch (cause) {
+      throw new LedgerWindowFetchError(startLedger, endLedger ?? startLedger, cause);
+    }
     pages++;
     events.push(...page.events);
 

--- a/apps/web/src/lib/sync-logger.test.ts
+++ b/apps/web/src/lib/sync-logger.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logSyncFailure, notifySyncFailure } from './sync-logger';
+
+describe('logSyncFailure', () => {
+  it('logs one structured JSON line with merchant, ledger window, and the error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const error = new Error('RPC getEvents: [-32001] request exceeded processing limit');
+    logSyncFailure({ merchant: 'GABC...MERCHANT', startLedger: 100, endLedger: 10_099 }, error);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(spy.mock.calls[0][0] as string);
+
+    expect(logged.level).toBe('error');
+    expect(logged.event).toBe('sync_failure');
+    expect(logged.merchant).toBe('GABC...MERCHANT');
+    expect(logged.startLedger).toBe(100);
+    expect(logged.endLedger).toBe(10_099);
+    expect(logged.error.name).toBe('Error');
+    expect(logged.error.message).toContain('request exceeded processing limit');
+    expect(typeof logged.error.stack).toBe('string');
+    expect(typeof logged.ts).toBe('string');
+    expect(() => new Date(logged.ts).toISOString()).not.toThrow();
+
+    spy.mockRestore();
+  });
+
+  it('omits ledger fields entirely when the failure happened before any window was known', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logSyncFailure({ merchant: 'GABC...MERCHANT' }, new Error('DB connection refused'));
+
+    const logged = JSON.parse(spy.mock.calls[0][0] as string);
+    expect('startLedger' in logged).toBe(false);
+    expect('endLedger' in logged).toBe(false);
+
+    spy.mockRestore();
+  });
+
+  it('recursively serializes a wrapped cause, keeping its own stack', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const rpcError = new Error('socket hang up');
+    const wrapped = new Error('Failed to fetch events for ledger window [1, 2]', {
+      cause: rpcError,
+    });
+    logSyncFailure({ merchant: 'GABC...MERCHANT' }, wrapped);
+
+    const logged = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(logged.error.message).toContain('Failed to fetch events');
+    expect(logged.error.cause.message).toBe('socket hang up');
+    expect(typeof logged.error.cause.stack).toBe('string');
+
+    spy.mockRestore();
+  });
+
+  it('logs a non-Error throw without crashing', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logSyncFailure({ merchant: 'GABC...MERCHANT' }, 'a plain string was thrown');
+
+    const logged = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(logged.error.name).toBe('NonErrorThrown');
+    expect(logged.error.message).toBe('a plain string was thrown');
+
+    spy.mockRestore();
+  });
+});
+
+describe('notifySyncFailure', () => {
+  const ORIGINAL_ENV = process.env.SYNC_ALERT_WEBHOOK_URL;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.SYNC_ALERT_WEBHOOK_URL;
+    else process.env.SYNC_ALERT_WEBHOOK_URL = ORIGINAL_ENV;
+  });
+
+  it('does nothing when SYNC_ALERT_WEBHOOK_URL is not set', async () => {
+    delete process.env.SYNC_ALERT_WEBHOOK_URL;
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await notifySyncFailure({ merchant: 'GABC' }, new Error('boom'));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('posts a body with both content (Discord) and text (Slack) fields', async () => {
+    process.env.SYNC_ALERT_WEBHOOK_URL = 'https://discord.example/webhook';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    await notifySyncFailure(
+      { merchant: 'GABC...MERCHANT', startLedger: 100, endLedger: 10_099 },
+      new Error('RPC unreachable'),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://discord.example/webhook');
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.content).toContain('GABC...MERCHANT');
+    expect(body.content).toContain('100-10099');
+    expect(body.content).toContain('RPC unreachable');
+    expect(body.text).toBe(body.content);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('never throws when the webhook itself is unreachable', async () => {
+    process.env.SYNC_ALERT_WEBHOOK_URL = 'https://discord.example/webhook';
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+    await expect(
+      notifySyncFailure({ merchant: 'GABC' }, new Error('boom')),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/sync-logger.ts
+++ b/apps/web/src/lib/sync-logger.ts
@@ -1,0 +1,102 @@
+/**
+ * Structured failure logging and optional alerting for the indexer's sync
+ * job (#135).
+ *
+ * Before this, a sync failure surfaced as a bare `console.error('Error
+ * during sync:', error)` with no ledger context, and one merchant's failure
+ * aborted the whole batch — later merchants in the same run were silently
+ * never attempted, leaving a gap with nothing pointing at it.
+ *
+ * No external observability SaaS is wired in here: every major hosting
+ * platform (Vercel included) already captures stderr into its own log
+ * viewer, keyed on timestamp, so one structured JSON line per failure is
+ * enough to answer "which block failed and why" without requiring a DSN or
+ * third-party account before this can ship. `SYNC_ALERT_WEBHOOK_URL`, if
+ * set, additionally pushes the same context to a Discord or Slack channel.
+ */
+
+/** Where a sync failure happened, as much as is known at the point it was caught. */
+export interface SyncFailureContext {
+  /** The merchant whose sync failed, or omitted for a failure before any merchant was reached. */
+  merchant?: string;
+  /** The ledger window being read when the failure occurred, if known. */
+  startLedger?: number;
+  endLedger?: number;
+}
+
+interface SerializedError {
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: SerializedError;
+}
+
+/** Recursively unwraps `Error.cause` so a wrapped RPC error keeps its own stack. */
+function serializeError(error: unknown): SerializedError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+      ...(error.cause !== undefined ? { cause: serializeError(error.cause) } : {}),
+    };
+  }
+  return { name: 'NonErrorThrown', message: String(error) };
+}
+
+/**
+ * Logs a sync failure as one structured JSON line: the merchant, the exact
+ * ledger window being processed (when known), and the full error including
+ * its stack trace and any wrapped cause.
+ */
+export function logSyncFailure(context: SyncFailureContext, error: unknown): void {
+  console.error(
+    JSON.stringify({
+      level: 'error',
+      event: 'sync_failure',
+      ts: new Date().toISOString(),
+      ...context,
+      error: serializeError(error),
+    }),
+  );
+}
+
+/**
+ * Best-effort alert to a Discord or Slack incoming webhook, gated by
+ * `SYNC_ALERT_WEBHOOK_URL`. The body carries both `content` (Discord) and
+ * `text` (Slack) with the same message, so either service accepts it without
+ * needing to know which one is configured.
+ *
+ * Never throws — a notification channel being down must not affect the sync
+ * job, which is why this is called separately from, not instead of,
+ * `logSyncFailure`.
+ */
+export async function notifySyncFailure(
+  context: SyncFailureContext,
+  error: unknown,
+): Promise<void> {
+  const webhookUrl = process.env.SYNC_ALERT_WEBHOOK_URL;
+  if (!webhookUrl) return;
+
+  const where =
+    context.startLedger !== undefined
+      ? ` (ledgers ${context.startLedger}-${context.endLedger ?? context.startLedger})`
+      : '';
+  const who = context.merchant ? ` for merchant ${context.merchant}` : '';
+  const reason = error instanceof Error ? error.message : String(error);
+  const message = `🚨 Indexer sync failed${who}${where}: ${reason}`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2_000);
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: message, text: message }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  } catch {
+    // A notification channel being unreachable must not fail the sync job.
+  }
+}


### PR DESCRIPTION
## Summary

Closes #135.

The indexer's sync job (`apps/web/src/app/api/sync/route.ts`) failed silently: an RPC error or parsing failure for one merchant threw out of the per-merchant loop, aborting every merchant scheduled after it in that run, and the only record of what happened was a bare `console.error('Error during sync:', error)` with no ledger context at all.

- **`event-pager.ts`**: new `LedgerWindowFetchError` wraps a failed `getEvents` call with the exact `[startLedger, endLedger]` window that was being read — that context only exists at the call site inside `drainEvents`, so it has to be captured there rather than reconstructed later.
- **`sync-logger.ts`** (new): `logSyncFailure` writes one structured JSON line per failure — merchant, ledger window (when known), and the full error including its stack trace and any wrapped `cause`. `notifySyncFailure` optionally posts the same context to a Discord or Slack incoming webhook via `SYNC_ALERT_WEBHOOK_URL` (the issue's optional suggestion) — a no-op when unset, and it never throws, so a down notification channel can't affect the sync job itself.
- **`route.ts`**: each merchant's sync in the `GET` loop is now isolated in its own `try`/`catch` — one merchant's failure no longer costs every merchant after it its turn this run. Failures are logged, optionally alerted, and surfaced in the JSON response as a `failures` array, which flips `success` to `false`. `.github/workflows/sync.yml` already treats `"success":false"` as a `::warning::` rather than a hard failure, so this surfaces partial failures through the exact monitored channel that already exists for this endpoint, without disturbing the `syncedTo`/`skippedLedgers`/`drained` contract that workflow depends on for whatever merchants did complete.

No external observability SaaS is wired in: structured JSON to stderr is what Vercel (and most hosting platforms) already capture into their own log viewer, so this is complete and useful without requiring a DSN or third-party account to be configured before it can ship.

## Acceptance criteria (from #135)

- [x] Errors during block syncing are explicitly logged with context (merchant + exact ledger window + full error/stack)
- [x] Developers can easily find which block failed and why (structured JSON log line, plus optional real-time Discord/Slack alert)
- [x] The sync job doesn't crash silently (per-merchant isolation; failures are visible in both the logs and the response body)

## Test plan

- `event-pager.test.ts`: two new tests — a failed `fetchPage` call is wrapped in `LedgerWindowFetchError` carrying the correct window and original error as `cause`; a call with no `endLedger` supplied falls back sensibly rather than reporting `undefined`.
- `sync-logger.test.ts` (new): `logSyncFailure` produces valid structured JSON with the right fields, omits ledger fields when unknown, recursively serializes a wrapped `cause`, and handles a non-`Error` throw. `notifySyncFailure` is a no-op without `SYNC_ALERT_WEBHOOK_URL`, posts a body with both `content` (Discord) and `text` (Slack) when configured, and never throws when the webhook itself is unreachable.
- `route.ts` has no pre-existing test harness for this route (it needs `withClient`/`withMerchantClient` DB mocking this repo doesn't currently have a fixture for), so the per-merchant isolation and response-shape changes there are covered by code review plus the isolated lib tests above, which is where all the actual new logic lives.

Verified locally:
- [x] `pnpm test` (apps/web) — 290/290 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (0 errors, only 3 pre-existing warnings in untouched files)
- [x] Formatting matches the project's Prettier config on every file I touched (confirmed after normalizing this Windows checkout's CRLF line endings, which otherwise flag unrelated files too)