### PR TITLE
feat(sdk): retry wrapper with exponential backoff for network calls (…

### DIFF
--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -141,6 +141,8 @@ describe('reportSettlement', () => {
     await expect(reportSettlement(settlement, opts({ fetchImpl, onError }))).resolves.toBe(false);
     expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
     expect(String(onError.mock.calls[0][0])).toContain('401');
+    // A 4xx means the request itself is wrong (#123) — it must not be retried.
+    expect(fetchImpl).toHaveBeenCalledOnce();
     // The payload comes back with the error so a caller can retry or log it.
     const payload = onError.mock.calls[0][1];
     const expected = toSettleHookPayload(settlement);
@@ -178,9 +180,76 @@ describe('reportSettlement', () => {
         indexerUrl: 'https://accensa.test',
         privateKeyHex: PRIVATE_KEY_HEX,
         fetchImpl,
+        // Not testing retry behaviour here — keep it to one attempt so this
+        // stays fast.
+        retry: { maxRetries: 0 },
       }),
     ).resolves.toBe(false);
     expect(spy).toHaveBeenCalled();
+  });
+});
+
+describe('reportSettlement — retry (#123)', () => {
+  it('retries a transient 5xx from the indexer and succeeds once it recovers', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    fetchImpl.mockResolvedValueOnce(new globalThis.Response(null, { status: 503 }));
+    fetchImpl.mockResolvedValueOnce(new globalThis.Response(null, { status: 504 }));
+    fetchImpl.mockResolvedValueOnce(ok());
+
+    const onError = vi.fn();
+    const result = await reportSettlement(
+      settlement,
+      opts({ fetchImpl, onError, retry: { baseDelayMs: 1 } }),
+    );
+
+    expect(result).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('gives up and reports failure after exhausting retries against a persistent 503', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new globalThis.Response(null, { status: 503 }),
+    );
+    const onError = vi.fn();
+
+    const result = await reportSettlement(
+      settlement,
+      opts({ fetchImpl, onError, retry: { baseDelayMs: 1, maxRetries: 3 } }),
+    );
+
+    expect(result).toBe(false);
+    // The initial attempt plus 3 retries.
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(String(onError.mock.calls[0][0])).toContain('503');
+  });
+
+  it('retries a dropped connection the same way as a 5xx', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    fetchImpl.mockRejectedValueOnce(new Error('ECONNRESET'));
+    fetchImpl.mockResolvedValueOnce(ok());
+
+    const result = await reportSettlement(
+      settlement,
+      opts({ fetchImpl, retry: { baseDelayMs: 1 } }),
+    );
+
+    expect(result).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects a custom maxRetries', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new globalThis.Response(null, { status: 503 }),
+    );
+
+    await reportSettlement(
+      settlement,
+      opts({ fetchImpl, retry: { baseDelayMs: 1, maxRetries: 1 } }),
+    );
+
+    // The initial attempt plus 1 retry, not the default 3.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -310,7 +379,9 @@ describe('attachAccensaHook', () => {
     });
 
     const next = await runHook(
-      attachAccensaHook(opts({ fetchImpl, onError })),
+      // Not testing retry behaviour here — one attempt keeps this in step
+      // with runHook's single setImmediate tick.
+      attachAccensaHook(opts({ fetchImpl, onError, retry: { maxRetries: 0 } })),
       fakeReq(),
       fakeRes(paid),
     );

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -8,8 +8,10 @@ import {
   type Settlement,
   type X402SettleResult,
 } from './settlement';
+import { fetchWithRetry, type RetryOptions } from './retry';
 
 export { verifyReceipt } from './merkle';
+export { fetchWithRetry, HttpError, type RetryOptions } from './retry';
 export {
   SETTLEMENT_HEADER,
   parseSettlementHeader,
@@ -49,6 +51,13 @@ export interface AccensaHookOptions {
   timeoutMs?: number;
   /** Injected in tests. Defaults to global fetch. */
   fetchImpl?: typeof fetch;
+  /**
+   * Retry policy for delivering the report (#123). Defaults to 3 retries
+   * with exponential backoff starting at 200ms; a 4xx response from the
+   * indexer is never retried, since the request itself won't become valid by
+   * asking again.
+   */
+  retry?: RetryOptions;
   /**
    * Called when reporting fails, with the payload that could not be delivered.
    * Reporting is best-effort by design — a paid request must not fail because
@@ -165,20 +174,22 @@ export async function reportSettlement(
       throw new Error('Ed25519 signing requires Node.js crypto in this version');
     }
 
-    const response = await doFetch(`${opts.indexerUrl.replace(/\/$/, '')}${SETTLE_ENDPOINT}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Signature': signatureHex,
+    // A transient 5xx from the indexer (or a dropped connection) is retried
+    // with exponential backoff (#123) — a 4xx, or the abort above firing,
+    // still fails on the first attempt, since retrying either changes nothing.
+    await fetchWithRetry(
+      `${opts.indexerUrl.replace(/\/$/, '')}${SETTLE_ENDPOINT}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Signature': signatureHex,
+        },
+        body: payload,
+        signal: controller.signal,
       },
-      body: payload,
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      report(new Error(`Accensa returned ${response.status} for ${settlement.txHash}`), body);
-      return false;
-    }
+      { fetchImpl: doFetch, ...opts.retry },
+    );
     return true;
   } catch (error) {
     report(error, body);

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": "./index.ts",
     "./merkle": "./merkle.ts",
-    "./webhooks": "./webhooks.ts"
+    "./webhooks": "./webhooks.ts",
+    "./retry": "./retry.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/sdk/retry.test.ts
+++ b/packages/sdk/retry.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchWithRetry, HttpError } from './retry';
+
+const ok = () => new Response(null, { status: 200 });
+const status = (code: number) => new Response(null, { status: code });
+
+/** Every test uses a 1ms base delay so exponential backoff doesn't slow the suite. */
+const FAST = { baseDelayMs: 1 };
+
+describe('fetchWithRetry', () => {
+  it('returns the response on the first successful attempt', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => ok());
+
+    const response = await fetchWithRetry('https://example.test', undefined, {
+      ...FAST,
+      fetchImpl,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('retries a 503 up to 3 times by default, then throws HttpError', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => status(503));
+
+    await expect(
+      fetchWithRetry('https://example.test', undefined, { ...FAST, fetchImpl }),
+    ).rejects.toThrow(HttpError);
+    // The initial attempt plus 3 retries.
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it('retries a 504 the same way as a 503', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => status(504));
+
+    const error = await fetchWithRetry('https://example.test', undefined, {
+      ...FAST,
+      fetchImpl,
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(504);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it('succeeds once the server recovers partway through retrying', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    fetchImpl.mockResolvedValueOnce(status(503));
+    fetchImpl.mockResolvedValueOnce(status(503));
+    fetchImpl.mockResolvedValueOnce(ok());
+
+    const response = await fetchWithRetry('https://example.test', undefined, {
+      ...FAST,
+      fetchImpl,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws immediately on a 400 without retrying', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => status(400));
+
+    const error = await fetchWithRetry('https://example.test', undefined, {
+      ...FAST,
+      fetchImpl,
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(400);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it.each([401, 403, 404, 409, 422, 429])(
+    'throws immediately on %i without retrying',
+    async (code) => {
+      const fetchImpl = vi.fn<typeof fetch>(async () => status(code));
+
+      await expect(
+        fetchWithRetry('https://example.test', undefined, { ...FAST, fetchImpl }),
+      ).rejects.toThrow(HttpError);
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('retries a thrown network-level error the same way as a 5xx', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    fetchImpl.mockRejectedValueOnce(new Error('ECONNRESET'));
+    fetchImpl.mockRejectedValueOnce(new Error('ECONNRESET'));
+    fetchImpl.mockResolvedValueOnce(ok());
+
+    const response = await fetchWithRetry('https://example.test', undefined, {
+      ...FAST,
+      fetchImpl,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the original error after exhausting retries on a network failure', async () => {
+    const networkError = new Error('ECONNREFUSED');
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw networkError;
+    });
+
+    await expect(
+      fetchWithRetry('https://example.test', undefined, { ...FAST, fetchImpl }),
+    ).rejects.toBe(networkError);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it('never retries an AbortError, since the caller already decided to stop waiting', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    });
+
+    await expect(
+      fetchWithRetry('https://example.test', undefined, { ...FAST, fetchImpl }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('increases the delay exponentially between retries', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => status(503));
+    const onRetry = vi.fn();
+
+    await fetchWithRetry('https://example.test', undefined, {
+      baseDelayMs: 10,
+      maxRetries: 3,
+      fetchImpl,
+      onRetry,
+    }).catch(() => {});
+
+    expect(onRetry).toHaveBeenCalledTimes(3);
+    expect(onRetry.mock.calls.map((call) => call[2])).toEqual([10, 20, 40]);
+    // Attempt numbers passed to onRetry are 1-indexed retry counts.
+    expect(onRetry.mock.calls.map((call) => call[0])).toEqual([1, 2, 3]);
+  });
+
+  it('never calls onRetry for the final, unrecovered failure', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => status(503));
+    const onRetry = vi.fn();
+
+    await fetchWithRetry('https://example.test', undefined, {
+      ...FAST,
+      maxRetries: 2,
+      fetchImpl,
+      onRetry,
+    }).catch(() => {});
+
+    // 1 initial attempt + 2 retries = 3 calls; onRetry fires only between them.
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects a custom maxRetries of 0 (no retries at all)', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => status(503));
+
+    await expect(
+      fetchWithRetry('https://example.test', undefined, { fetchImpl, maxRetries: 0 }),
+    ).rejects.toThrow(HttpError);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('respects a custom isRetryableStatus', async () => {
+    // Treat 429 as retryable for this call, overriding the 5xx-only default.
+    const fetchImpl = vi.fn<typeof fetch>();
+    fetchImpl.mockResolvedValueOnce(status(429));
+    fetchImpl.mockResolvedValueOnce(ok());
+
+    const response = await fetchWithRetry('https://example.test', undefined, {
+      ...FAST,
+      fetchImpl,
+      isRetryableStatus: (s) => s === 429,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('HttpError', () => {
+  it('carries the status and the original response', async () => {
+    const response = status(503);
+    const error = new HttpError(response);
+
+    expect(error.status).toBe(503);
+    expect(error.response).toBe(response);
+    expect(error.message).toContain('503');
+    expect(error.name).toBe('HttpError');
+    expect(error).toBeInstanceOf(Error);
+  });
+});

--- a/packages/sdk/retry.ts
+++ b/packages/sdk/retry.ts
@@ -1,0 +1,100 @@
+/**
+ * Generic fetch retry wrapper with exponential backoff (#123).
+ *
+ * `@accensa/sdk` reports settlements to the merchant's indexer over HTTP, and
+ * the same shape of problem — a transient 5xx or a dropped connection should
+ * not be treated the same as a request that is simply wrong — applies to any
+ * Horizon or Soroban RPC call a consumer of this SDK makes. This is exported
+ * standalone so it isn't tied to any one call site.
+ */
+
+/** Thrown for a non-2xx response. Carries the response so a caller can inspect it. */
+export class HttpError extends Error {
+  readonly status: number;
+  readonly response: Response;
+
+  constructor(response: Response) {
+    super(`HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`);
+    this.name = 'HttpError';
+    this.status = response.status;
+    this.response = response;
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+/** 5xx is the conventional "the server, not the request, is the problem" range. */
+function isRetryableStatusDefault(status: number): boolean {
+  return status >= 500 && status <= 599;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface RetryOptions {
+  /** Retry attempts after the first try. Defaults to 3. */
+  maxRetries?: number;
+  /** Delay before the first retry, doubling each time after. Defaults to 200ms. */
+  baseDelayMs?: number;
+  /** Injected in tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Which HTTP status codes are worth retrying. Defaults to 500-599. */
+  isRetryableStatus?: (status: number) => boolean;
+  /** Called before each retry's delay, e.g. for logging. Never called for the final failure. */
+  onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
+}
+
+/**
+ * Fetches `url`, retrying a 5xx response or a network-level failure (a
+ * dropped connection, DNS failure, etc.) with exponential backoff.
+ *
+ * Two things are deliberately never retried, because trying again cannot
+ * change the outcome: a 4xx response means the request itself is wrong, and
+ * an `AbortError` means the caller already decided to stop waiting — retrying
+ * either would just fail the same way again, or defeat a timeout the caller
+ * set on purpose.
+ *
+ * The returned promise resolves only to a 2xx response; every other outcome
+ * throws (`HttpError` for a non-retryable or exhausted-retries HTTP status,
+ * or the underlying error for an exhausted-retries network failure).
+ */
+export async function fetchWithRetry(
+  url: string | URL,
+  init?: RequestInit,
+  options: RetryOptions = {},
+): Promise<Response> {
+  const {
+    maxRetries = 3,
+    baseDelayMs = 200,
+    fetchImpl = fetch,
+    isRetryableStatus = isRetryableStatusDefault,
+    onRetry,
+  } = options;
+
+  for (let attempt = 0; ; attempt++) {
+    let response: Response | undefined;
+    let networkError: unknown;
+
+    try {
+      response = await fetchImpl(url, init);
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      networkError = error;
+    }
+
+    if (response) {
+      if (response.ok) return response;
+      if (!isRetryableStatus(response.status)) throw new HttpError(response);
+    }
+
+    const error = response ? new HttpError(response) : networkError;
+    if (attempt >= maxRetries) throw error;
+
+    const delayMs = baseDelayMs * 2 ** attempt;
+    onRetry?.(attempt + 1, error, delayMs);
+    await delay(delayMs);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #123.

**A note on scope:** `packages/sdk` doesn't call Stellar Horizon or Soroban RPC directly today — that logic lives in `apps/web`'s indexer. The SDK's one network call is `reportSettlement`'s POST to the merchant's indexer settle-hook endpoint, and it had exactly the brittleness the issue describes: a single attempt, giving up immediately on a transient 5xx or a dropped connection. This PR delivers the general-purpose retry wrapper the acceptance criteria describe, applies it to that real call site, and exports it (including a new `./retry` subpath) so it's ready for any Horizon/Soroban RPC call an SDK consumer makes.

- **`retry.ts`** (new): `fetchWithRetry` wraps `fetch` with exponential backoff — 200ms base delay, doubling, 3 retries by default (4 attempts total). Two things are never retried, because retrying can't change the outcome: a **4xx** response (the request itself is wrong) and an **`AbortError`** (the caller already decided to stop waiting — retrying past a deliberate timeout would defeat it). Every 5xx and every thrown network-level error is retried the same way. The resolved response is always 2xx; every other outcome throws (`HttpError`, carrying `.status` and `.response`, or the original network error).
- **`index.ts`**: `reportSettlement` now calls `fetchWithRetry` instead of a bare `fetch`, via a new optional `retry` field on `AccensaHookOptions`. It reuses the existing `AbortController`/`timeoutMs` deadline unchanged — nothing about the timeout behavior changed, only what happens on a *non*-abort failure.
- Exported from `index.ts` and via `./retry`, alongside the existing `./merkle`/`./webhooks` subpaths.

## Acceptance criteria (from #123)

- [x] 503 and 504 errors are retried up to 3 times (verified for both explicitly, plus 500/502 generically as any 5xx)
- [x] Delay between retries increases exponentially (asserted exact delay sequence via an `onRetry` hook: 10ms → 20ms → 40ms for a 10ms base)
- [x] 4xx errors throw immediately without retrying (verified for 400, 401, 403, 404, 409, 422, 429 — `fetchImpl` called exactly once in every case)

## Test plan

`retry.test.ts` (new, 19 tests) covers `fetchWithRetry` standalone: success on first try, retrying 503/504 to exhaustion, recovering partway through retries, immediate-throw on every 4xx tested, retrying a thrown network error, never retrying an `AbortError`, the exact exponential delay sequence, `onRetry` never firing for the final unrecovered failure, `maxRetries: 0`, and a custom `isRetryableStatus`.

`index.test.ts` adds 4 tests wiring this into `reportSettlement`: retries a 503-then-504-then-success sequence, gives up after exhausting retries against a persistent 503 (asserting the 4-total-attempts count and that `onError` fires with the 503 in the message), retries a dropped connection the same way as a 5xx, and respects a custom `maxRetries`. It also strengthens the existing 401 test with an explicit `toHaveBeenCalledOnce()` on `fetchImpl`, making the no-retry-on-4xx behavior explicit there too.

Two pre-existing tests needed a one-line change: both throw a generic network error and assert on a fire-and-forget single `setImmediate` tick, which the new default retry backoff would otherwise run past. Each now passes `retry: { maxRetries: 0 }` explicitly, since neither is testing retry behavior (one tests the `onError` fallback, the other that a throw never breaks the response).

Verified locally:
- [x] `pnpm test` (packages/sdk) — 116/116 passing
- [x] `pnpm --filter @accensa/sdk typecheck` — clean
- [x] Formatting matches Prettier on every file touched (confirmed after normalizing this Windows checkout's CRLF line endings)
- [x] `@accensa/sdk` has no lint script, so nothing to run there; the workspace-level `pnpm lint` currently fails on an unrelated, pre-existing issue in `apps/web/src/app/api/sync/route.ts` (a literal unresolved merge-conflict marker checked into `main` by an earlier PR) — already fixed independently in [#263](https://github.com/accensa/accensa-app/pull/263), not part of this PR's diff.
