### PR TITLE
security(sdk): document and narrow the merchant signing key

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,3 +12,7 @@ Instead, reach out to the maintainer via email at security@accensa.dev or via di
 Please allow 48 hours for a response and triage.
 
 **Note:** The application code in this repository is currently UNAUDITED. Use it at your own risk.
+
+## Merchant Key Management
+
+For details on the SDK signing key threat model, rotation, and storage guidance, please refer to the [SDK Security & Key Management documentation](packages/sdk/README.md#security--key-management).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,4 +15,5 @@ Please allow 48 hours for a response and triage.
 
 ## Merchant Key Management
 
-For details on the SDK signing key threat model, rotation, and storage guidance, please refer to the [SDK Security & Key Management documentation](packages/sdk/README.md#security--key-management).
+For details on the SDK signing key threat model, rotation, and storage guidance, please refer to
+the [SDK Security & Key Management documentation](packages/sdk/README.md#security--key-management).

--- a/apps/web/src/app/api/hook/settle/route.ts
+++ b/apps/web/src/app/api/hook/settle/route.ts
@@ -20,6 +20,7 @@ async function verifyingMerchant(
   merchants: Merchant[],
   raw: string,
   signatureHex: string,
+  keyId?: string | null,
 ): Promise<Merchant | null> {
   const crypto = await import('node:crypto');
   let signature: Buffer;
@@ -29,24 +30,35 @@ async function verifyingMerchant(
     return null;
   }
 
+
+  
   for (const merchant of merchants) {
     if (!merchant.publicKeyHex) continue;
-    try {
-      const keyBuffer = Buffer.from(merchant.publicKeyHex, 'hex');
-      const publicKey = crypto.createPublicKey({
-        key: Buffer.concat([
-          Buffer.from('302a300506032b6570032100', 'hex'), // SubjectPublicKeyInfo Ed25519 header
-          keyBuffer,
-        ]),
-        format: 'der',
-        type: 'spki',
-      });
-      if (crypto.verify(null, Buffer.from(raw, 'utf8'), publicKey, signature)) {
-        return merchant;
+    const publicKeys = merchant.publicKeyHex.split(',').map(k => k.trim()).filter(Boolean);
+    
+    for (const pubKeyHex of publicKeys) {
+      try {
+        const keyBuffer = Buffer.from(pubKeyHex, 'hex');
+        const publicKey = crypto.createPublicKey({
+          key: Buffer.concat([
+            Buffer.from('302a300506032b6570032100', 'hex'), // SubjectPublicKeyInfo Ed25519 header
+            keyBuffer,
+          ]),
+          format: 'der',
+          type: 'spki',
+        });
+        if (crypto.verify(null, Buffer.from(raw, 'utf8'), publicKey, signature)) {
+          if (keyId) {
+            console.log(`[accensa] settlement reported with key id: ${keyId}`);
+          } else if (publicKeys.length > 1) {
+            console.log(`[accensa] settlement reported with key: ${pubKeyHex.substring(0, 8)}... (key rotation in progress)`);
+          }
+          return merchant;
+        }
+      } catch {
+        // A malformed key for one merchant must not block checking the rest.
+        continue;
       }
-    } catch {
-      // A malformed key for one merchant must not block checking the rest.
-      continue;
     }
   }
   return null;
@@ -84,7 +96,7 @@ export async function POST(request: Request) {
   const merchant = await withClient(async (client) => {
     await ensureSchema(client);
     const merchants = await listMerchants(client);
-    return await verifyingMerchant(merchants, raw, signature);
+    return await verifyingMerchant(merchants, raw, signature, request.headers.get('x-key-id'));
   });
 
   if (!merchant) {

--- a/apps/web/src/app/api/hook/settle/route.ts
+++ b/apps/web/src/app/api/hook/settle/route.ts
@@ -52,12 +52,9 @@ async function verifyingMerchant(
           if (keyId) {
             console.info(`[accensa] settlement reported with key id: ${keyId}`);
           } else if (publicKeys.length > 1) {
-            console.info(
-              `[accensa] settlement reported with key: ${pubKeyHex.substring(
-                0,
-                8,
-              )}... (key rotation in progress)`,
-            );
+            const prefix = pubKeyHex.substring(0, 8);
+            const msg = `[accensa] settlement reported with key: ${prefix}... (key rotation)`;
+            console.info(msg);
           }
           return merchant;
         }

--- a/apps/web/src/app/api/hook/settle/route.ts
+++ b/apps/web/src/app/api/hook/settle/route.ts
@@ -34,8 +34,11 @@ async function verifyingMerchant(
   
   for (const merchant of merchants) {
     if (!merchant.publicKeyHex) continue;
-    const publicKeys = merchant.publicKeyHex.split(',').map(k => k.trim()).filter(Boolean);
-    
+    const publicKeys = merchant.publicKeyHex
+      .split(',')
+      .map((k) => k.trim())
+      .filter(Boolean);
+
     for (const pubKeyHex of publicKeys) {
       try {
         const keyBuffer = Buffer.from(pubKeyHex, 'hex');
@@ -49,9 +52,14 @@ async function verifyingMerchant(
         });
         if (crypto.verify(null, Buffer.from(raw, 'utf8'), publicKey, signature)) {
           if (keyId) {
-            console.log(`[accensa] settlement reported with key id: ${keyId}`);
+            console.info(`[accensa] settlement reported with key id: ${keyId}`);
           } else if (publicKeys.length > 1) {
-            console.log(`[accensa] settlement reported with key: ${pubKeyHex.substring(0, 8)}... (key rotation in progress)`);
+            console.info(
+              `[accensa] settlement reported with key: ${pubKeyHex.substring(
+                0,
+                8,
+              )}... (key rotation in progress)`,
+            );
           }
           return merchant;
         }

--- a/apps/web/src/app/api/hook/settle/route.ts
+++ b/apps/web/src/app/api/hook/settle/route.ts
@@ -30,8 +30,6 @@ async function verifyingMerchant(
     return null;
   }
 
-
-  
   for (const merchant of merchants) {
     if (!merchant.publicKeyHex) continue;
     const publicKeys = merchant.publicKeyHex

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -149,13 +149,14 @@ async function ensureMultiMerchantSchema(client: Client): Promise<void> {
     CREATE TABLE IF NOT EXISTS merchants (
       id                 SERIAL PRIMARY KEY,
       address            VARCHAR(56) UNIQUE NOT NULL,
-      public_key_hex     VARCHAR(64),
+      public_key_hex     TEXT,
       asset_contract_ids TEXT,
       refund_vault_id    VARCHAR(56),
       webhook_url        TEXT,
       created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
     );
   `);
+  await client.query(`ALTER TABLE merchants ALTER COLUMN public_key_hex TYPE TEXT;`);
 
   if (process.env.MERCHANT_ADDRESS) {
     await client.query(

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -156,7 +156,18 @@ async function ensureMultiMerchantSchema(client: Client): Promise<void> {
       created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
     );
   `);
-  await client.query(`ALTER TABLE merchants ALTER COLUMN public_key_hex TYPE TEXT;`);
+
+  await client.query(`
+    DO $$ 
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name='merchants' AND column_name='public_key_hex' AND data_type='character varying'
+      ) THEN
+        ALTER TABLE merchants ALTER COLUMN public_key_hex TYPE TEXT;
+      END IF;
+    END $$;
+  `);
 
   if (process.env.MERCHANT_ADDRESS) {
     await client.query(

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -158,10 +158,10 @@ async function ensureMultiMerchantSchema(client: Client): Promise<void> {
   `);
 
   await client.query(`
-    DO $$ 
+    DO $$
     BEGIN
       IF EXISTS (
-        SELECT 1 FROM information_schema.columns 
+        SELECT 1 FROM information_schema.columns
         WHERE table_name='merchants' AND column_name='public_key_hex' AND data_type='character varying'
       ) THEN
         ALTER TABLE merchants ALTER COLUMN public_key_hex TYPE TEXT;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -10,6 +10,41 @@ To maintain integrity, the payload is authenticated. Sellers using `@accensa/sdk
 
 Signing uses WebCrypto Ed25519 when `globalThis.crypto.subtle` supports it, and falls back to Node.js `crypto` otherwise. The SDK is supported and tested on Node.js, Vercel Edge Functions, Cloudflare Workers, and Deno Deploy. Runtimes without either WebCrypto Ed25519 or Node.js crypto fail loudly rather than sending an unsigned report.
 
+## Security & Key Management
+
+### The Signing Key
+
+**This is a dedicated signing key, generated specifically for settlement reporting.**
+**It is NEVER your merchant's Stellar account key.**
+
+Generating a key for this purpose (requires Node.js):
+
+```sh
+node -e "const crypto = require('crypto'); console.log(crypto.generateKeyPairSync('ed25519').privateKey.export({format: 'der', type: 'pkcs8'}).toString('hex').slice(32))"
+```
+
+Or you can use any standard tool to generate a 32-byte Ed25519 seed in hex.
+
+### Threat Model
+
+- **What the key grants**: The ability to write route attribution for payments to the indexer.
+- **What it does NOT grant**: The ability to fabricate a payment, move funds, or change ledger records. The indexer verifies all payments on-chain, so an attacker cannot invent a transaction that never happened on the Stellar ledger.
+- **Blast radius**: An attacker with this key can misattribute revenue (e.g. assigning analytics credit to a different route) or create attribution for real payments to routes that don't exist.
+- **Detection**: To detect a compromise, monitor your analytics for attribution to routes your application does not serve, or unusual spikes in attribution for specific routes that don't match your web traffic.
+- **Storage Guidance**: The private key (`privateKeyHex`) must be provided via an environment variable at minimum, or ideally fetched from a secret manager at runtime. Never commit the key to source control. The SDK is designed to ensure the key is never logged (even on failure).
+
+### Key Rotation
+
+Accensa supports key rotation with zero downtime.
+
+During a rollover, your deployment's `MERCHANT_PUBLIC_KEY` environment variable (or the database `merchants` row) accepts a comma-separated list of multiple public keys. The indexer will accept a signature from any of them.
+
+1. Generate a new keypair.
+2. Add the new public key to the list in your Accensa backend (e.g. `MERCHANT_PUBLIC_KEY="old_key,new_key"`).
+3. Wait for the new configuration to deploy.
+4. Update your seller application to use the new `privateKeyHex` (and pass `keyId` to `reportSettlement` / `AccensaHookOptions` so the backend can easily identify which key was used if desired).
+5. Once all instances are running the new key, remove the old public key from the backend. The entire rollover can be safely completed within a short maintenance window, but keys can overlap indefinitely if needed.
+
 ### Signing Contract (For Non-JS Implementers)
 
 If you are integrating with Accensa from a non-JavaScript environment, you must construct and sign the settlement report yourself.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -27,23 +27,40 @@ Or you can use any standard tool to generate a 32-byte Ed25519 seed in hex.
 
 ### Threat Model
 
-- **What the key grants**: The ability to write route attribution for payments to the indexer.
-- **What it does NOT grant**: The ability to fabricate a payment, move funds, or change ledger records. The indexer verifies all payments on-chain, so an attacker cannot invent a transaction that never happened on the Stellar ledger.
-- **Blast radius**: An attacker with this key can misattribute revenue (e.g. assigning analytics credit to a different route) or create attribution for real payments to routes that don't exist.
-- **Detection**: To detect a compromise, monitor your analytics for attribution to routes your application does not serve, or unusual spikes in attribution for specific routes that don't match your web traffic.
-- **Storage Guidance**: The private key (`privateKeyHex`) must be provided via an environment variable at minimum, or ideally fetched from a secret manager at runtime. Never commit the key to source control. The SDK is designed to ensure the key is never logged (even on failure).
+- **What the key grants**: The ability to write route attribution for payments
+  to the indexer.
+- **What it does NOT grant**: The ability to fabricate a payment, move funds, or
+  change ledger records. The indexer verifies all payments on-chain, so an
+  attacker cannot invent a transaction that never happened on the Stellar ledger.
+- **Blast radius**: An attacker with this key can misattribute revenue (e.g.
+  assigning analytics credit to a different route) or create attribution for
+  real payments to routes that don't exist.
+- **Detection**: To detect a compromise, monitor your analytics for attribution
+  to routes your application does not serve, or unusual spikes in attribution
+  for specific routes that don't match your web traffic.
+- **Storage Guidance**: The private key (`privateKeyHex`) must be provided via
+  an environment variable at minimum, or ideally fetched from a secret manager
+  at runtime. Never commit the key to source control. The SDK is designed to
+  ensure the key is never logged (even on failure).
 
 ### Key Rotation
 
 Accensa supports key rotation with zero downtime.
 
-During a rollover, your deployment's `MERCHANT_PUBLIC_KEY` environment variable (or the database `merchants` row) accepts a comma-separated list of multiple public keys. The indexer will accept a signature from any of them.
+During a rollover, your deployment's `MERCHANT_PUBLIC_KEY` environment variable
+(or the database `merchants` row) accepts a comma-separated list of multiple
+public keys. The indexer will accept a signature from any of them.
 
 1. Generate a new keypair.
-2. Add the new public key to the list in your Accensa backend (e.g. `MERCHANT_PUBLIC_KEY="old_key,new_key"`).
+2. Add the new public key to the list in your Accensa backend (e.g.
+   `MERCHANT_PUBLIC_KEY="old_key,new_key"`).
 3. Wait for the new configuration to deploy.
-4. Update your seller application to use the new `privateKeyHex` (and pass `keyId` to `reportSettlement` / `AccensaHookOptions` so the backend can easily identify which key was used if desired).
-5. Once all instances are running the new key, remove the old public key from the backend. The entire rollover can be safely completed within a short maintenance window, but keys can overlap indefinitely if needed.
+4. Update your seller application to use the new `privateKeyHex` (and pass
+   `keyId` to `reportSettlement` / `AccensaHookOptions` so the backend can
+   easily identify which key was used if desired).
+5. Once all instances are running the new key, remove the old public key from
+   the backend. The entire rollover can be safely completed within a short
+   maintenance window, but keys can overlap indefinitely if needed.
 
 ### Signing Contract (For Non-JS Implementers)
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -8,6 +8,39 @@ Accensa supports merchant-reported route attribution via the `/api/hook/settle` 
 
 To maintain integrity, the payload is authenticated. Sellers using `@accensa/sdk` will have this handled automatically via `createSettleHook` or `attachAccensaHook`.
 
+## Security & Key Management
+
+### The Signing Key
+
+**This is a dedicated signing key, generated specifically for settlement reporting.**
+**It is NEVER your merchant's Stellar account key.**
+
+Generating a key for this purpose (requires Node.js):
+```sh
+node -e "const crypto = require('crypto'); console.log(crypto.generateKeyPairSync('ed25519').privateKey.export({format: 'der', type: 'pkcs8'}).toString('hex').slice(32))"
+```
+Or you can use any standard tool to generate a 32-byte Ed25519 seed in hex.
+
+### Threat Model
+
+- **What the key grants**: The ability to write route attribution for payments to the indexer.
+- **What it does NOT grant**: The ability to fabricate a payment, move funds, or change ledger records. The indexer verifies all payments on-chain, so an attacker cannot invent a transaction that never happened on the Stellar ledger.
+- **Blast radius**: An attacker with this key can misattribute revenue (e.g. assigning analytics credit to a different route) or create attribution for real payments to routes that don't exist.
+- **Detection**: To detect a compromise, monitor your analytics for attribution to routes your application does not serve, or unusual spikes in attribution for specific routes that don't match your web traffic.
+- **Storage Guidance**: The private key (`privateKeyHex`) must be provided via an environment variable at minimum, or ideally fetched from a secret manager at runtime. Never commit the key to source control. The SDK is designed to ensure the key is never logged (even on failure).
+
+### Key Rotation
+
+Accensa supports key rotation with zero downtime. 
+
+During a rollover, your deployment's `MERCHANT_PUBLIC_KEY` environment variable (or the database `merchants` row) accepts a comma-separated list of multiple public keys. The indexer will accept a signature from any of them.
+
+1. Generate a new keypair.
+2. Add the new public key to the list in your Accensa backend (e.g. `MERCHANT_PUBLIC_KEY="old_key,new_key"`).
+3. Wait for the new configuration to deploy.
+4. Update your seller application to use the new `privateKeyHex` (and pass `keyId` to `reportSettlement` / `AccensaHookOptions` so the backend can easily identify which key was used if desired).
+5. Once all instances are running the new key, remove the old public key from the backend. The entire rollover can be safely completed within a short maintenance window, but keys can overlap indefinitely if needed.
+
 ### Signing Contract (For Non-JS Implementers)
 
 If you are integrating with Accensa from a non-JavaScript environment, you must construct and sign the settlement report yourself.

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -151,17 +151,20 @@ describe('reportSettlement', () => {
 
   it('never logs the private key on signing failure', async () => {
     const onError = vi.fn();
-    const badKeyHex = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'; // valid hex length, but maybe fails during import? Actually wait, to force a throw in `signSettlementPayload` we can just pass an invalid length key hex.
-    const veryBadKeyHex = 'abc'; 
-    await expect(reportSettlement(settlement, opts({ privateKeyHex: veryBadKeyHex, onError }))).resolves.toBe(false);
-    
+    const veryBadKeyHex = 'abc';
+    await expect(
+      reportSettlement(settlement, opts({ privateKeyHex: veryBadKeyHex, onError })),
+    ).resolves.toBe(false);
+
     expect(onError).toHaveBeenCalledOnce();
     const errorStr = String(onError.mock.calls[0][0]);
     expect(errorStr).not.toContain(veryBadKeyHex);
     
     // Also test fallback console.error
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    await expect(reportSettlement(settlement, opts({ privateKeyHex: 'def', onError: undefined }))).resolves.toBe(false);
+    await expect(
+      reportSettlement(settlement, opts({ privateKeyHex: 'def', onError: undefined })),
+    ).resolves.toBe(false);
     expect(String(consoleSpy.mock.calls[0][0])).not.toContain('def');
     expect(String(consoleSpy.mock.calls[0][2])).not.toContain('def');
   });

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -134,6 +134,23 @@ describe('reportSettlement', () => {
     expect(fetchImpl.mock.calls[0][0]).toBe(`https://accensa.test${SETTLE_ENDPOINT}`);
   });
 
+  it('never logs the private key on signing failure', async () => {
+    const onError = vi.fn();
+    const badKeyHex = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'; // valid hex length, but maybe fails during import? Actually wait, to force a throw in `signSettlementPayload` we can just pass an invalid length key hex.
+    const veryBadKeyHex = 'abc'; 
+    await expect(reportSettlement(settlement, opts({ privateKeyHex: veryBadKeyHex, onError }))).resolves.toBe(false);
+    
+    expect(onError).toHaveBeenCalledOnce();
+    const errorStr = String(onError.mock.calls[0][0]);
+    expect(errorStr).not.toContain(veryBadKeyHex);
+    
+    // Also test fallback console.error
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(reportSettlement(settlement, opts({ privateKeyHex: 'def', onError: undefined }))).resolves.toBe(false);
+    expect(String(consoleSpy.mock.calls[0][0])).not.toContain('def');
+    expect(String(consoleSpy.mock.calls[0][2])).not.toContain('def');
+  });
+
   it('reports a non-2xx response as a failure without throwing', async () => {
     const onError = vi.fn();
     const fetchImpl = vi.fn(async () => new globalThis.Response(null, { status: 401 }));
@@ -141,6 +158,7 @@ describe('reportSettlement', () => {
     await expect(reportSettlement(settlement, opts({ fetchImpl, onError }))).resolves.toBe(false);
     expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
     expect(String(onError.mock.calls[0][0])).toContain('401');
+    expect(String(onError.mock.calls[0][0])).not.toContain(PRIVATE_KEY_HEX);
     // A 4xx means the request itself is wrong (#123) — it must not be retried.
     expect(fetchImpl).toHaveBeenCalledOnce();
     // The payload comes back with the error so a caller can retry or log it.

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -152,8 +152,9 @@ describe('reportSettlement', () => {
   it('never logs the private key on signing failure', async () => {
     const onError = vi.fn();
     const veryBadKeyHex = 'abc';
+    const fetchImpl = vi.fn();
     await expect(
-      reportSettlement(settlement, opts({ privateKeyHex: veryBadKeyHex, onError })),
+      reportSettlement(settlement, opts({ privateKeyHex: veryBadKeyHex, onError, fetchImpl })),
     ).resolves.toBe(false);
 
     expect(onError).toHaveBeenCalledOnce();

--- a/packages/sdk/index.test.ts
+++ b/packages/sdk/index.test.ts
@@ -153,9 +153,8 @@ describe('reportSettlement', () => {
     const onError = vi.fn();
     const veryBadKeyHex = 'abc';
     const fetchImpl = vi.fn();
-    await expect(
-      reportSettlement(settlement, opts({ privateKeyHex: veryBadKeyHex, onError, fetchImpl })),
-    ).resolves.toBe(false);
+    const options = opts({ privateKeyHex: veryBadKeyHex, onError, fetchImpl });
+    await expect(reportSettlement(settlement, options)).resolves.toBe(false);
 
     expect(onError).toHaveBeenCalledOnce();
     const errorStr = String(onError.mock.calls[0][0]);
@@ -163,9 +162,8 @@ describe('reportSettlement', () => {
     
     // Also test fallback console.error
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    await expect(
-      reportSettlement(settlement, opts({ privateKeyHex: 'def', onError: undefined })),
-    ).resolves.toBe(false);
+    const optionsFallback = opts({ privateKeyHex: 'def', onError: undefined });
+    await expect(reportSettlement(settlement, optionsFallback)).resolves.toBe(false);
     expect(String(consoleSpy.mock.calls[0][0])).not.toContain('def');
     expect(String(consoleSpy.mock.calls[0][2])).not.toContain('def');
   });

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -47,6 +47,11 @@ export interface AccensaHookOptions {
   indexerUrl: string;
   /** Ed25519 private key in hex format to sign the settlement report. */
   privateKeyHex: string;
+  /**
+   * Identifies which key signed this report, when multiple keys are active
+   * during a rollover. Passed to the indexer as the X-Key-Id header.
+   */
+  keyId?: string;
   /** Abandon a report after this many milliseconds. Defaults to 5000. */
   timeoutMs?: number;
   /** Injected in tests. Defaults to global fetch. */
@@ -184,6 +189,7 @@ export async function reportSettlement(
         headers: {
           'Content-Type': 'application/json',
           'X-Signature': signatureHex,
+          ...(opts.keyId ? { 'X-Key-Id': opts.keyId } : {}),
         },
         body: payload,
         signal: controller.signal,

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -108,8 +108,8 @@ async function signSettlementPayload(payload: string, privateKeyHex: string): Pr
   if (subtle) {
     try {
       const key = await subtle.importKey('pkcs8', pkcs8, { name: 'Ed25519' }, false, ['sign']);
-      const signature = await subtle.sign({ name: 'Ed25519' }, key, data);
-      return Array.from(new Uint8Array(signature), (byte) => byte.toString(16).padStart(2, '0')).join('');
+      const signatureBytes = new Uint8Array(signature);
+      return Array.from(signatureBytes, (b) => b.toString(16).padStart(2, '0')).join('');
     } catch {
       // Ed25519 is not available in every WebCrypto implementation; try Node below.
     }


### PR DESCRIPTION
- Documented threat model, generation and storage in SDK README
- Allowed multiple keys in MERCHANT_PUBLIC_KEY for rotation
- Implemented X-Key-Id header passing for key identification
- Assured private keys are never logged in tests
- Linked SECURITY.md to new SDK security docs

Closes #100