### PR TITLE
feat(web): cache merchant profile reads with tag-based invalidation

### DIFF
--- a/apps/web/src/app/api/merchant/profile/route.test.ts
+++ b/apps/web/src/app/api/merchant/profile/route.test.ts
@@ -1,0 +1,137 @@
+import { expect, test, vi, describe, beforeEach } from 'vitest';
+import { GET, PATCH } from './route';
+
+const {
+  MERCHANT,
+  mockWithClient,
+  mockWithMerchantClient,
+  mockGetMerchantFromRequest,
+  mockUpdateMerchantProfile,
+  mockGetCachedMerchantFromRequest,
+  mockRevalidateTag,
+} = vi.hoisted(() => {
+  const merchant = { id: 1, address: 'GABC' };
+  return {
+    MERCHANT: merchant,
+    mockWithClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => fn({})),
+    mockWithMerchantClient: vi.fn(
+      async (_merchantId: number, fn: (client: unknown) => Promise<unknown>) => fn({}),
+    ),
+    mockGetMerchantFromRequest: vi.fn().mockResolvedValue(merchant),
+    mockUpdateMerchantProfile: vi.fn(),
+    mockGetCachedMerchantFromRequest: vi.fn(),
+    mockRevalidateTag: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/db', () => ({
+  withClient: mockWithClient,
+  withMerchantClient: mockWithMerchantClient,
+}));
+
+vi.mock('@/lib/merchants', () => ({
+  getMerchantFromRequest: mockGetMerchantFromRequest,
+  updateMerchantProfile: mockUpdateMerchantProfile,
+}));
+
+vi.mock('@/lib/merchant-profile', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/merchant-profile')>('@/lib/merchant-profile');
+  return {
+    ...actual,
+    getCachedMerchantFromRequest: mockGetCachedMerchantFromRequest,
+  };
+});
+
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: unknown) => fn,
+  revalidateTag: mockRevalidateTag,
+}));
+
+describe('/api/merchant/profile GET', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns 401 when no merchant resolves from the request', async () => {
+    mockGetCachedMerchantFromRequest.mockResolvedValue(null);
+    const res = await GET(new Request('http://localhost/api/merchant/profile'));
+    expect(res.status).toBe(401);
+  });
+
+  test('serves the profile from the cached lookup, not a direct DB call', async () => {
+    mockGetCachedMerchantFromRequest.mockResolvedValue(MERCHANT);
+    const res = await GET(new Request('http://localhost/api/merchant/profile'));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.profile).toEqual(MERCHANT);
+    expect(mockGetCachedMerchantFromRequest).toHaveBeenCalledOnce();
+    expect(mockWithClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/merchant/profile PATCH', () => {
+  const patchRequest = (body: unknown) =>
+    new Request('http://localhost/api/merchant/profile', {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMerchantFromRequest.mockResolvedValue(MERCHANT);
+  });
+
+  test('rejects a non-JSON body', async () => {
+    const res = await PATCH(
+      new Request('http://localhost/api/merchant/profile', { method: 'PATCH', body: 'nope{' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('rejects an invalid field before touching the database', async () => {
+    const res = await PATCH(patchRequest({ webhookUrl: 'not a url' }));
+    expect(res.status).toBe(400);
+    expect(mockWithClient).not.toHaveBeenCalled();
+    expect(mockRevalidateTag).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when the caller does not resolve to a merchant', async () => {
+    mockGetMerchantFromRequest.mockResolvedValue(null);
+    const res = await PATCH(patchRequest({ webhookUrl: 'https://merchant.example/hook' }));
+    expect(res.status).toBe(401);
+    expect(mockRevalidateTag).not.toHaveBeenCalled();
+  });
+
+  test('updates the profile scoped to the caller and invalidates its cache tag', async () => {
+    const updated = { ...MERCHANT, webhookUrl: 'https://merchant.example/hook' };
+    mockUpdateMerchantProfile.mockResolvedValue(updated);
+
+    const res = await PATCH(patchRequest({ webhookUrl: 'https://merchant.example/hook' }));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.profile).toEqual(updated);
+
+    expect(mockWithMerchantClient).toHaveBeenCalledWith(MERCHANT.id, expect.any(Function));
+    expect(mockUpdateMerchantProfile).toHaveBeenCalledWith({}, MERCHANT.id, {
+      webhookUrl: 'https://merchant.example/hook',
+    });
+
+    // Immediate expiry, not the stale-while-revalidate 'max' profile - the
+    // caller must see its own write on the very next read.
+    expect(mockRevalidateTag).toHaveBeenCalledWith(`merchant-profile-${MERCHANT.address}`, {
+      expire: 0,
+    });
+  });
+
+  test("never invalidates another merchant's cache tag", async () => {
+    mockUpdateMerchantProfile.mockResolvedValue(MERCHANT);
+    await PATCH(patchRequest({ webhookUrl: 'https://merchant.example/hook' }));
+
+    const [tag] = mockRevalidateTag.mock.calls[0];
+    expect(tag).toBe(`merchant-profile-${MERCHANT.address}`);
+    expect(tag).not.toBe('merchant-profile-someone-else');
+  });
+});

--- a/apps/web/src/app/api/merchant/profile/route.ts
+++ b/apps/web/src/app/api/merchant/profile/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+import { withClient, withMerchantClient } from '@/lib/db';
+import { getMerchantFromRequest, updateMerchantProfile, type Merchant } from '@/lib/merchants';
+import {
+  getCachedMerchantFromRequest,
+  merchantProfileCacheTag,
+  parseMerchantProfileUpdate,
+} from '@/lib/merchant-profile';
+
+/**
+ * Serves the merchant's own profile (signing key, asset watch-list, refund
+ * vault, webhook URL) from Next.js's Data Cache instead of Postgres on every
+ * dashboard load, and invalidates that cache the moment the profile changes.
+ */
+
+export interface MerchantProfileResponse {
+  profile: Merchant;
+}
+
+export async function GET(request: Request) {
+  const merchant = await getCachedMerchantFromRequest(request);
+  if (!merchant) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json<MerchantProfileResponse>({ profile: merchant });
+}
+
+export async function PATCH(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Request body must be JSON' }, { status: 400 });
+  }
+
+  const parsed = parseMerchantProfileUpdate(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const caller = await withClient((client) => getMerchantFromRequest(client, request));
+  if (!caller) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const profile = await withMerchantClient(caller.id, (client) =>
+    updateMerchantProfile(client, caller.id, parsed.update),
+  );
+
+  // `{ expire: 0 }` expires the tag immediately rather than the
+  // stale-while-revalidate behaviour of `revalidateTag(tag, 'max')`, which
+  // would still serve one more stale read before fetching fresh data - this
+  // route needs the very next read to see the write.
+  revalidateTag(merchantProfileCacheTag(caller.address), { expire: 0 });
+
+  return NextResponse.json<MerchantProfileResponse>({ profile: profile as Merchant });
+}

--- a/apps/web/src/lib/merchant-profile.test.ts
+++ b/apps/web/src/lib/merchant-profile.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetMerchantByAddress, mockUnstableCache } = vi.hoisted(() => ({
+  mockGetMerchantByAddress: vi.fn(),
+  // A pass-through fake: calls the wrapped function on every invocation, so
+  // tests exercise `getCachedMerchantByAddress`'s own logic without needing a
+  // real Next.js cache runtime.
+  mockUnstableCache: vi.fn((fn: (...args: unknown[]) => unknown) => fn),
+}));
+
+vi.mock('./db', () => ({
+  withClient: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => fn({})),
+}));
+
+vi.mock('./merchants', () => ({
+  getMerchantByAddress: mockGetMerchantByAddress,
+}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache: mockUnstableCache,
+}));
+
+const CONTRACT_ID = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const KEY_HEX = 'a'.repeat(64);
+
+describe('merchantProfileCacheTag', () => {
+  it('scopes the tag by address', async () => {
+    const { merchantProfileCacheTag } = await import('./merchant-profile');
+    expect(merchantProfileCacheTag('GABC')).toBe('merchant-profile-GABC');
+    expect(merchantProfileCacheTag('GABC')).not.toBe(merchantProfileCacheTag('GXYZ'));
+  });
+});
+
+describe('getCachedMerchantByAddress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('wraps the DB lookup with unstable_cache, tagged for this merchant', async () => {
+    const { getCachedMerchantByAddress, merchantProfileCacheTag } =
+      await import('./merchant-profile');
+    const merchant = { id: 1, address: 'GABC' };
+    mockGetMerchantByAddress.mockResolvedValue(merchant);
+
+    const result = await getCachedMerchantByAddress('GABC');
+
+    expect(result).toEqual(merchant);
+    expect(mockGetMerchantByAddress).toHaveBeenCalledWith({}, 'GABC');
+    expect(mockUnstableCache).toHaveBeenCalledWith(
+      expect.any(Function),
+      ['merchant-profile', 'GABC'],
+      { tags: [merchantProfileCacheTag('GABC')] },
+    );
+  });
+});
+
+describe('getCachedMerchantFromRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when the trusted merchant header is missing', async () => {
+    const { getCachedMerchantFromRequest } = await import('./merchant-profile');
+    const result = await getCachedMerchantFromRequest(new Request('http://localhost/'));
+    expect(result).toBeNull();
+    expect(mockGetMerchantByAddress).not.toHaveBeenCalled();
+  });
+
+  it('resolves the merchant named by x-accensa-merchant', async () => {
+    const { getCachedMerchantFromRequest } = await import('./merchant-profile');
+    const merchant = { id: 1, address: 'GABC' };
+    mockGetMerchantByAddress.mockResolvedValue(merchant);
+
+    const result = await getCachedMerchantFromRequest(
+      new Request('http://localhost/', { headers: { 'x-accensa-merchant': 'GABC' } }),
+    );
+
+    expect(result).toEqual(merchant);
+    expect(mockGetMerchantByAddress).toHaveBeenCalledWith({}, 'GABC');
+  });
+});
+
+describe('parseMerchantProfileUpdate', () => {
+  it('accepts an empty object (no-op update)', async () => {
+    const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+    expect(parseMerchantProfileUpdate({})).toEqual({ ok: true, update: {} });
+  });
+
+  it('rejects a non-object body', async () => {
+    const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+    expect(parseMerchantProfileUpdate(null)).toEqual({
+      ok: false,
+      error: 'Body must be a JSON object',
+    });
+    expect(parseMerchantProfileUpdate([1, 2]).ok).toBe(false);
+    expect(parseMerchantProfileUpdate('nope').ok).toBe(false);
+  });
+
+  describe('publicKeyHex', () => {
+    it('accepts a valid hex-encoded 32-byte key, lowercased', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      const result = parseMerchantProfileUpdate({ publicKeyHex: KEY_HEX.toUpperCase() });
+      expect(result).toEqual({ ok: true, update: { publicKeyHex: KEY_HEX } });
+    });
+
+    it('accepts null to clear it', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ publicKeyHex: null })).toEqual({
+        ok: true,
+        update: { publicKeyHex: null },
+      });
+    });
+
+    it('rejects the wrong length', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      const result = parseMerchantProfileUpdate({ publicKeyHex: 'a'.repeat(63) });
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects a non-string', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ publicKeyHex: 123 }).ok).toBe(false);
+    });
+  });
+
+  describe('assetContractIds', () => {
+    it('accepts an array of valid contract IDs', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      const result = parseMerchantProfileUpdate({ assetContractIds: [CONTRACT_ID] });
+      expect(result).toEqual({ ok: true, update: { assetContractIds: [CONTRACT_ID] } });
+    });
+
+    it('accepts null to clear it', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ assetContractIds: null })).toEqual({
+        ok: true,
+        update: { assetContractIds: null },
+      });
+    });
+
+    it('rejects a non-array', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ assetContractIds: CONTRACT_ID }).ok).toBe(false);
+    });
+
+    it('rejects an array containing an invalid contract ID', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ assetContractIds: [CONTRACT_ID, 'not-a-cid'] }).ok).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('refundVaultId', () => {
+    it('accepts a valid contract ID', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      const result = parseMerchantProfileUpdate({ refundVaultId: CONTRACT_ID });
+      expect(result).toEqual({ ok: true, update: { refundVaultId: CONTRACT_ID } });
+    });
+
+    it('rejects a Stellar account ID (G-address) here - this field wants a contract', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ refundVaultId: 'G' + 'A'.repeat(55) }).ok).toBe(false);
+    });
+  });
+
+  describe('webhookUrl', () => {
+    it('accepts a valid https URL', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      const result = parseMerchantProfileUpdate({ webhookUrl: 'https://merchant.example/hook' });
+      expect(result).toEqual({
+        ok: true,
+        update: { webhookUrl: 'https://merchant.example/hook' },
+      });
+    });
+
+    it('accepts null to clear it', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ webhookUrl: null })).toEqual({
+        ok: true,
+        update: { webhookUrl: null },
+      });
+    });
+
+    it('rejects a non-http(s) scheme', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ webhookUrl: 'ftp://merchant.example' }).ok).toBe(false);
+    });
+
+    it('rejects an unparsable URL', async () => {
+      const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+      expect(parseMerchantProfileUpdate({ webhookUrl: 'not a url' }).ok).toBe(false);
+    });
+  });
+
+  it('validates multiple fields in one call and reports the first failure', async () => {
+    const { parseMerchantProfileUpdate } = await import('./merchant-profile');
+    const result = parseMerchantProfileUpdate({
+      publicKeyHex: KEY_HEX,
+      webhookUrl: 'not a url',
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/web/src/lib/merchant-profile.ts
+++ b/apps/web/src/lib/merchant-profile.ts
@@ -1,0 +1,118 @@
+import { unstable_cache } from 'next/cache';
+import { withClient } from './db';
+import { getMerchantByAddress, type Merchant, type MerchantProfileUpdate } from './merchants';
+
+/**
+ * Reading and validating the merchant profile: the mutable fields on
+ * `merchants` (signing key, asset watch-list, refund vault, webhook URL).
+ *
+ * `getMerchantFromRequest` backs the auth/scoping check on nearly every API
+ * route, which meant this row was re-read from Postgres on every request even
+ * though these fields change rarely. `GET /api/merchant/profile` is the one
+ * route that fronts a cached copy instead - see `getCachedMerchantByAddress`
+ * below. Every other route keeps reading `merchants` live on purpose: RLS
+ * scoping and settlement-signature verification must never act on a stale key
+ * or vault ID.
+ */
+
+/** Ed25519 public keys: 32 bytes, hex-encoded. */
+const HEX_32_BYTES = /^[0-9a-f]{64}$/i;
+
+/** Soroban contract IDs: 56-character base32 starting with C. */
+const CONTRACT_ID = /^C[A-Z2-7]{55}$/;
+
+/** The Data Cache tag scoping one merchant's cached profile. */
+export function merchantProfileCacheTag(address: string): string {
+  return `merchant-profile-${address}`;
+}
+
+/**
+ * Cached merchant lookup by address, tagged per merchant so updating one
+ * merchant's profile never invalidates another tenant's cached copy.
+ */
+export async function getCachedMerchantByAddress(address: string): Promise<Merchant | null> {
+  return unstable_cache(
+    async () => withClient((client) => getMerchantByAddress(client, address)),
+    ['merchant-profile', address],
+    { tags: [merchantProfileCacheTag(address)] },
+  )();
+}
+
+/** Cached equivalent of `getMerchantFromRequest` for read-only profile access. */
+export async function getCachedMerchantFromRequest(request: Request): Promise<Merchant | null> {
+  const address = request.headers.get('x-accensa-merchant');
+  if (!address) return null;
+  return getCachedMerchantByAddress(address);
+}
+
+export type ParseProfileUpdateResult =
+  { ok: true; update: MerchantProfileUpdate } | { ok: false; error: string };
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates a `PATCH /api/merchant/profile` body.
+ *
+ * Every field is optional and independently nullable: omitting a key leaves
+ * that column untouched, while `null` clears it back to the deployment-wide
+ * default (see the `Merchant` docstring in `./merchants`).
+ */
+export function parseMerchantProfileUpdate(body: unknown): ParseProfileUpdateResult {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return { ok: false, error: 'Body must be a JSON object' };
+  }
+  const b = body as Record<string, unknown>;
+  const update: MerchantProfileUpdate = {};
+
+  if ('publicKeyHex' in b) {
+    if (b.publicKeyHex === null) {
+      update.publicKeyHex = null;
+    } else if (typeof b.publicKeyHex !== 'string' || !HEX_32_BYTES.test(b.publicKeyHex)) {
+      return { ok: false, error: 'publicKeyHex must be a hex-encoded 32-byte Ed25519 key' };
+    } else {
+      update.publicKeyHex = b.publicKeyHex.toLowerCase();
+    }
+  }
+
+  if ('assetContractIds' in b) {
+    if (b.assetContractIds === null) {
+      update.assetContractIds = null;
+    } else if (
+      !Array.isArray(b.assetContractIds) ||
+      b.assetContractIds.some((id) => typeof id !== 'string' || !CONTRACT_ID.test(id))
+    ) {
+      return { ok: false, error: 'assetContractIds must be an array of Soroban contract IDs' };
+    } else {
+      update.assetContractIds = b.assetContractIds as string[];
+    }
+  }
+
+  if ('refundVaultId' in b) {
+    if (b.refundVaultId === null) {
+      update.refundVaultId = null;
+    } else if (typeof b.refundVaultId !== 'string' || !CONTRACT_ID.test(b.refundVaultId)) {
+      return { ok: false, error: 'refundVaultId must be a Soroban contract ID' };
+    } else {
+      update.refundVaultId = b.refundVaultId;
+    }
+  }
+
+  if ('webhookUrl' in b) {
+    if (b.webhookUrl === null) {
+      update.webhookUrl = null;
+    } else if (typeof b.webhookUrl !== 'string' || !isHttpUrl(b.webhookUrl)) {
+      return { ok: false, error: 'webhookUrl must be an http(s) URL' };
+    } else {
+      update.webhookUrl = b.webhookUrl;
+    }
+  }
+
+  return { ok: true, update };
+}

--- a/apps/web/src/lib/merchants.test.ts
+++ b/apps/web/src/lib/merchants.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Client } from 'pg';
+import { updateMerchantProfile, getMerchantById } from './merchants';
+
+const ROW = {
+  id: 1,
+  address: 'G' + 'A'.repeat(55),
+  public_key_hex: 'a'.repeat(64),
+  asset_contract_ids: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+  refund_vault_id: 'CBHRJU7CF4XIFRNDITFHNQHABKBMFM2FYFHLGWN3JGSFYYCDSMDAWPRV',
+  webhook_url: 'https://merchant.example/hook',
+};
+
+function fakeClient(returning: Record<string, unknown>[] = [ROW]) {
+  const query = vi.fn(async () => ({ rows: returning, rowCount: returning.length }));
+  return { query } as unknown as Client;
+}
+
+describe('updateMerchantProfile', () => {
+  it('writes only the fields present in the update, scoped by id', async () => {
+    const client = fakeClient();
+    await updateMerchantProfile(client, 1, { webhookUrl: 'https://merchant.example/hook' });
+
+    const [sql, params] = (client.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    const setClause = sql.slice(sql.indexOf('SET') + 3, sql.indexOf('WHERE'));
+    expect(setClause).toContain('webhook_url = $2');
+    expect(setClause).not.toContain('public_key_hex');
+    expect(setClause).not.toContain('asset_contract_ids');
+    expect(setClause).not.toContain('refund_vault_id');
+    expect(sql).toContain('WHERE id = $1');
+    expect(params).toEqual([1, 'https://merchant.example/hook']);
+  });
+
+  it('joins assetContractIds into the comma-separated column format', async () => {
+    const client = fakeClient();
+    await updateMerchantProfile(client, 1, {
+      assetContractIds: ['CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC', 'CABC'],
+    });
+
+    const [, params] = (client.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(params[1]).toBe('CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC,CABC');
+  });
+
+  it('writes null for a field explicitly cleared', async () => {
+    const client = fakeClient();
+    await updateMerchantProfile(client, 1, { webhookUrl: null });
+
+    const [, params] = (client.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(params).toEqual([1, null]);
+  });
+
+  it('writes null for an empty assetContractIds array rather than an empty string', async () => {
+    const client = fakeClient();
+    await updateMerchantProfile(client, 1, { assetContractIds: [] });
+
+    const [, params] = (client.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(params).toEqual([1, null]);
+  });
+
+  it('writes every provided field in one query', async () => {
+    const client = fakeClient();
+    await updateMerchantProfile(client, 1, {
+      publicKeyHex: 'b'.repeat(64),
+      refundVaultId: 'CBHRJU7CF4XIFRNDITFHNQHABKBMFM2FYFHLGWN3JGSFYYCDSMDAWPRV',
+    });
+
+    const [sql, params] = (client.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sql).toContain('public_key_hex = $2');
+    expect(sql).toContain('refund_vault_id = $3');
+    expect(params).toEqual([
+      1,
+      'b'.repeat(64),
+      'CBHRJU7CF4XIFRNDITFHNQHABKBMFM2FYFHLGWN3JGSFYYCDSMDAWPRV',
+    ]);
+  });
+
+  it('returns the updated merchant mapped from the RETURNING row', async () => {
+    const client = fakeClient([ROW]);
+    const result = await updateMerchantProfile(client, 1, { webhookUrl: ROW.webhook_url });
+    expect(result).toEqual({
+      id: 1,
+      address: ROW.address,
+      publicKeyHex: ROW.public_key_hex,
+      assetContractIds: [ROW.asset_contract_ids],
+      refundVaultId: ROW.refund_vault_id,
+      webhookUrl: ROW.webhook_url,
+    });
+  });
+
+  it('returns null when the merchant id does not exist', async () => {
+    const client = fakeClient([]);
+    const result = await updateMerchantProfile(client, 999, { webhookUrl: 'https://x.example' });
+    expect(result).toBeNull();
+  });
+
+  it('falls back to a plain read and issues no UPDATE when the update is empty', async () => {
+    const client = fakeClient([ROW]);
+    const result = await updateMerchantProfile(client, 1, {});
+
+    expect(result).not.toBeNull();
+    const [sql] = (client.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sql).not.toContain('UPDATE');
+  });
+});
+
+describe('getMerchantById', () => {
+  it('queries by id and maps the row', async () => {
+    const client = fakeClient([ROW]);
+    const result = await getMerchantById(client, 1);
+    expect(result?.address).toBe(ROW.address);
+    const [sql, params] = (client.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(sql).toContain('WHERE id = $1');
+    expect(params).toEqual([1]);
+  });
+});

--- a/apps/web/src/lib/merchants.ts
+++ b/apps/web/src/lib/merchants.ts
@@ -99,3 +99,60 @@ export async function listMerchants(client: Client): Promise<Merchant[]> {
   );
   return res.rows.map(fromRow);
 }
+
+/**
+ * A partial write to the mutable fields of a `Merchant`.
+ *
+ * `address` and `id` are the merchant's identity and are never written here.
+ * A key present with value `null` clears that column back to the
+ * deployment-wide default; an absent key leaves the column untouched.
+ */
+export interface MerchantProfileUpdate {
+  publicKeyHex?: string | null;
+  assetContractIds?: string[] | null;
+  refundVaultId?: string | null;
+  webhookUrl?: string | null;
+}
+
+/**
+ * Applies a partial profile update and returns the merchant's new state.
+ *
+ * Only columns present in `update` are written, so a caller that omits a
+ * field can never accidentally null it out.
+ */
+export async function updateMerchantProfile(
+  client: Client,
+  merchantId: number,
+  update: MerchantProfileUpdate,
+): Promise<Merchant | null> {
+  const sets: string[] = [];
+  const params: (string | null)[] = [];
+
+  if ('publicKeyHex' in update) {
+    params.push(update.publicKeyHex ?? null);
+    sets.push(`public_key_hex = $${params.length + 1}`);
+  }
+  if ('assetContractIds' in update) {
+    params.push(update.assetContractIds?.length ? update.assetContractIds.join(',') : null);
+    sets.push(`asset_contract_ids = $${params.length + 1}`);
+  }
+  if ('refundVaultId' in update) {
+    params.push(update.refundVaultId ?? null);
+    sets.push(`refund_vault_id = $${params.length + 1}`);
+  }
+  if ('webhookUrl' in update) {
+    params.push(update.webhookUrl ?? null);
+    sets.push(`webhook_url = $${params.length + 1}`);
+  }
+
+  if (sets.length === 0) {
+    return getMerchantById(client, merchantId);
+  }
+
+  const res = await client.query<MerchantRow>(
+    `UPDATE merchants SET ${sets.join(', ')} WHERE id = $1
+     RETURNING id, address, public_key_hex, asset_contract_ids, refund_vault_id, webhook_url`,
+    [merchantId, ...params],
+  );
+  return res.rows.length ? fromRow(res.rows[0]) : null;
+}


### PR DESCRIPTION
Closes #133

## Summary

Merchant profile data (signing key, asset watch-list, refund vault, webhook URL — the mutable fields on the `merchants` table) was read from Postgres on nearly every API request via `getMerchantFromRequest`/`getMerchantById`, since that lookup also backs auth/scoping. This adds a dedicated, cached read path for profile access, and an update route that invalidates it immediately.

`merchants` currently has no `name`/generic `settings` column (only `address`, `public_key_hex`, `asset_contract_ids`, `refund_vault_id`, `webhook_url`), so "profile" here refers to those existing mutable fields rather than new ones — no schema migration is included.

**Scope note:** only the new `/api/merchant/profile` route reads from the cache. Every other existing route (`/api/payments`, `/api/sync`, `/api/refund/preflight`, `/api/hook/settle`, auth routes, …) keeps reading `merchants` live and is untouched — RLS scoping and settlement-signature verification must never act on a stale signing key or vault ID, so swapping those to a cached read was out of scope for this change.

## What's new

- **`apps/web/src/lib/merchant-profile.ts`** (new)
  - `merchantProfileCacheTag(address)` — builds the per-merchant cache tag `merchant-profile-<address>`.
  - `getCachedMerchantByAddress(address)` — wraps the existing `getMerchantByAddress` DB call in `unstable_cache`, tagged per merchant so one merchant's update can never invalidate another tenant's cached copy.
  - `getCachedMerchantFromRequest(request)` — cached equivalent of `getMerchantFromRequest`, used only by the new GET route.
  - `parseMerchantProfileUpdate(body)` — hand-rolled validation for a `PATCH` body (mirrors the existing `settlement-report.ts` pattern of validation kept separate from the route handler). Every field is optional and independently nullable — an absent key leaves the column untouched, `null` clears it back to the deployment-wide default.

- **`apps/web/src/app/api/merchant/profile/route.ts`** (new)
  - `GET` — resolves the caller via the cached lookup and returns `{ profile }`. Returns 401 if the trusted `x-accensa-merchant` header doesn't resolve to a merchant.
  - `PATCH` — validates the body, resolves the caller via the existing (uncached) `getMerchantFromRequest`, writes the update inside `withMerchantClient` (RLS-scoped), then calls `revalidateTag(merchantProfileCacheTag(caller.address), { expire: 0 })` before responding.

- **`apps/web/src/lib/merchants.ts`** (modified)
  - Adds `MerchantProfileUpdate` and `updateMerchantProfile(client, merchantId, update)` — writes only the columns present in `update`, scoped by `id`, and returns the merchant's new state via `RETURNING`.

## Implementation details

- Uses `unstable_cache` from `next/cache` (not `"use cache"`/Cache Components — this app doesn't have `cacheComponents` enabled in `next.config.ts`, and `unstable_cache` remains the supported API for that mode in Next.js 16.3).
- Cache tags are scoped **per merchant address** (`merchant-profile-<address>`) rather than one global tag, so a write from one merchant only ever invalidates that merchant's own cached entry.
- Invalidation uses the two-argument `revalidateTag(tag, { expire: 0 })` form. Next 16 deprecated the single-argument call, and the recommended `'max'` profile gives stale-while-revalidate semantics (one more stale read is still possible after the call) — `{ expire: 0 }` is what Next's own docs recommend for a Route Handler that needs the very next read to reflect the write (`updateTag` was not usable here since it only works inside Server Actions, not Route Handlers).
- `updateMerchantProfile` only writes fields explicitly present in the request body (checked via `'field' in body`), so omitting a field can never accidentally null it out, while passing `null` explicitly clears that field back to the deployment-wide env-var default (matching the existing convention documented on the `Merchant` type).

## Tests added

- **`apps/web/src/lib/merchant-profile.test.ts`** (new, 21 tests) — `merchantProfileCacheTag` scoping, `getCachedMerchantByAddress`/`getCachedMerchantFromRequest` wiring (with `next/cache` and the DB layer mocked), and full validation coverage for `parseMerchantProfileUpdate` (valid/invalid/null-clearing for each of the four fields).
- **`apps/web/src/lib/merchants.test.ts`** (new, 9 tests) — `updateMerchantProfile`: writes only provided fields, joins `assetContractIds` into the stored comma-separated format, writes `null` for explicit clears (including an empty array), writes multiple fields in one query, maps the `RETURNING` row back correctly, returns `null` for an unknown id, and issues no `UPDATE` at all for an empty update object. Also covers `getMerchantById`.
- **`apps/web/src/app/api/merchant/profile/route.test.ts`** (new, 7 tests) — `GET` returns 401 with no resolvable merchant and otherwise serves from the cached lookup (asserting the uncached DB path is never touched); `PATCH` rejects a non-JSON body and invalid fields before touching the database, returns 401 for an unresolvable caller, and on success asserts the write is scoped to the caller's own merchant id and that `revalidateTag` is called with that merchant's own tag and `{ expire: 0 }`.

All 342 tests in `apps/web` pass (`pnpm --filter web test`), and `tsc --noEmit`/`eslint` are clean on every file this PR touches.

**Pre-existing, unrelated to this PR:** `apps/web/src/app/api/sync/route.ts` on `main` currently contains unresolved `<<<<<<< HEAD` / `>>>>>>> origin/main` merge conflict markers (from commit `e691010`, "Resolve merge conflict in route.ts"), which breaks the repo's own `pnpm typecheck` and `pnpm lint` scripts repo-wide. This PR does not touch that file; flagging it since it may be worth its own fix.

## How to test

1. `pnpm --filter web test` — runs the full suite, including the new tests above.
2. `pnpm --filter web typecheck` / `pnpm --filter web lint` (both currently fail only on the pre-existing conflict markers in `api/sync/route.ts`, noted above and unrelated to this change).
3. Manually, with `DATABASE_URL` set against a dev Postgres and a signed-in session cookie:
   - `GET /api/merchant/profile` twice in a row — the second call is served from cache (no new query against `merchants`, visible via Postgres query logging).
   - `PATCH /api/merchant/profile` with e.g. `{"webhookUrl": "https://example.com/hook"}`, then `GET /api/merchant/profile` again — the response reflects the new `webhookUrl` immediately, proving the cache was invalidated rather than serving a stale value.