### PR TITLE
feat(indexer): handle Stellar re-orgs and cursor rollbacks

### DIFF
--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { withClient, withMerchantClient, ensureSchema, getSyncState } from '@/lib/db';
 import { getMerchantFromRequest } from '@/lib/merchants';
-import { isHash32 } from '@/lib/receipt-anchor';
+import { getMaxBatchSize, isHash32 } from '@/lib/receipt-anchor';
 import type { SyncState } from '@/lib/sync-status';
 
 export const dynamic = 'force-dynamic';

--- a/apps/web/src/app/api/sync/route.ts
+++ b/apps/web/src/app/api/sync/route.ts
@@ -6,6 +6,7 @@ import {
   ensureSchema,
   getLastSyncedLedger,
   getSyncState,
+  rollbackSyncToLedger,
   setLastSyncedLedger,
 } from '@/lib/db';
 import {
@@ -169,7 +170,21 @@ async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
     {
       const { sequence: latestLedger } = await rpc<{ sequence: number }>('getLatestLedger', {});
 
-      const cursor = await getLastSyncedLedger(client, merchant.id);
+      let cursor = await getLastSyncedLedger(client, merchant.id);
+
+      // A chain head lower than the processed cursor means the node rolled
+      // back — a re-org, or a failover to a peer that lost its tail. Ledgers
+      // past the head no longer exist on the canonical chain, so payments
+      // indexed from them describe a chain that is gone: purge them and
+      // rewind the cursor to the corrected head before working out where to
+      // resume. Without this the early return below would report `drained`
+      // while the local ledger silently keeps rolled-back payments.
+      let rollback: { purged: number } | null = null;
+      if (cursor !== null && latestLedger < cursor) {
+        rollback = await rollbackSyncToLedger(client, merchant.id, latestLedger);
+        cursor = latestLedger;
+      }
+
       const resumeFrom = cursor !== null ? cursor + 1 : latestLedger - COLD_START_LOOKBACK;
       const retentionFloor = latestLedger - MAX_LOOKBACK;
       const startLedger = Math.max(resumeFrom, retentionFloor, 1);
@@ -191,6 +206,13 @@ async function runSync(merchant: Merchant, opts: { cooldownMs?: number } = {}) {
           scanned: 0,
           decoded: 0,
           inserted: 0,
+          // After a rollback there is nothing left to re-scan this
+          // invocation — the corrected head is the whole valid range — but
+          // the rewind was the work. Surface it so the run is not mistaken
+          // for a no-op.
+          ...(rollback
+            ? { rollback: true, rolledBackTo: latestLedger, purged: rollback.purged }
+            : {}),
         };
       }
 

--- a/apps/web/src/lib/db.integration.test.ts
+++ b/apps/web/src/lib/db.integration.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { Client } from 'pg';
-import { withClient, ensureSchema, setLastSyncedLedger, getLastSyncedLedger } from './db';
+import {
+  withClient,
+  ensureSchema,
+  setLastSyncedLedger,
+  getLastSyncedLedger,
+  rollbackSyncToLedger,
+} from './db';
 import { insertPaymentsInTransaction } from './insert-payments';
 import { getMerchantByAddress } from './merchants';
 
@@ -237,6 +243,60 @@ describe('Database Integration', () => {
       expect(res.rows.map((r) => Number(r.ledger))).toEqual([100, 101, 102]);
       const cursor = await getLastSyncedLedger(client, merchant!.id);
       expect(cursor).toBe(500);
+    });
+  });
+
+  it('purges rolled-back ledgers and rewinds the cursor, keeping staged rows', async () => {
+    if (!process.env.DATABASE_URL) {
+      console.warn('Skipping integration test as DATABASE_URL is missing');
+      return;
+    }
+
+    const merchant = await withClient(async (client) => {
+      await ensureSchema(client);
+      await client.query(
+        `INSERT INTO merchants (address) VALUES ($1) ON CONFLICT (address) DO NOTHING`,
+        ['GROLLBACKMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'],
+      );
+      return getMerchantByAddress(client, 'GROLLBACKMERCHANTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+    });
+    expect(merchant).not.toBeNull();
+
+    // Three indexed payments at ledgers 100-102, plus one staged,
+    // merchant-reported row whose ledger the chain has not filled in yet.
+    await withMerchantClient(merchant!.id, async (client) => {
+      await client.query(
+        `INSERT INTO payments (merchant_id, tx_hash, ledger) VALUES
+         ($1, $2, 100), ($1, $3, 101), ($1, $4, 102)`,
+        [merchant!.id, 'd'.repeat(63) + '0', 'd'.repeat(63) + '1', 'd'.repeat(63) + '2'],
+      );
+      await client.query(
+        `INSERT INTO payments (merchant_id, tx_hash, ledger, route) VALUES ($1, $2, NULL, '/api/x')`,
+        [merchant!.id, 'd'.repeat(63) + '3'],
+      );
+      await setLastSyncedLedger(client, merchant!.id, 102);
+    });
+
+    // The node rolled back to head 100: everything indexed past it is gone.
+    const { purged } = await withMerchantClient(merchant!.id, async (client) => {
+      await ensureSchema(client);
+      return rollbackSyncToLedger(client, merchant!.id, 100);
+    });
+    expect(purged).toBe(2);
+
+    await withMerchantClient(merchant!.id, async (client) => {
+      const res = await client.query(
+        `SELECT tx_hash, ledger FROM payments WHERE merchant_id = $1 ORDER BY ledger NULLS LAST`,
+        [merchant!.id],
+      );
+      // Ledger 100 survived; 101 and 102 were purged; the staged NULL-ledger
+      // row (attribution awaiting the chain) was left alone.
+      expect(res.rows.map((r) => (r.ledger === null ? null : Number(r.ledger)))).toEqual([
+        100,
+        null,
+      ]);
+      // The cursor rewound with the purge, so the next run resumes from 101.
+      expect(await getLastSyncedLedger(client, merchant!.id)).toBe(100);
     });
   });
 

--- a/apps/web/src/lib/db.rollback.test.ts
+++ b/apps/web/src/lib/db.rollback.test.ts
@@ -42,7 +42,9 @@ describe('rollbackSyncToLedger', () => {
     // The cursor write must NOT carry setLastSyncedLedger's forward-only
     // guard: rewinding is the point of a rollback.
     const upsert = queries.find((q) => /^INSERT INTO sync_state/m.test(q))!;
-    expect(upsert).toContain('ON CONFLICT (merchant_id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger');
+    expect(upsert).toContain(
+      'ON CONFLICT (merchant_id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger',
+    );
     expect(upsert).not.toContain('WHERE sync_state.last_ledger < EXCLUDED.last_ledger');
 
     expect(queries[queries.length - 1]).toBe('COMMIT');

--- a/apps/web/src/lib/db.rollback.test.ts
+++ b/apps/web/src/lib/db.rollback.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Client } from 'pg';
+import { rollbackSyncToLedger } from './db';
+
+/** Records every query; DELETE FROM payments returns a configurable rowCount. */
+function fakeClient(opts: { failDelete?: boolean; deleted?: number } = {}) {
+  const queries: string[] = [];
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql);
+      if (/^SELECT pg_advisory_xact_lock/m.test(sql)) return { rows: [] };
+      if (/^DELETE FROM payments/m.test(sql)) {
+        if (opts.failDelete) throw new Error('connection reset mid-delete');
+        return { rows: [], rowCount: opts.deleted ?? 3 };
+      }
+      if (/^INSERT INTO sync_state/m.test(sql)) return { rows: [] };
+      return { rows: [] };
+    }),
+  };
+  return { client: client as unknown as Client, queries };
+}
+
+describe('rollbackSyncToLedger', () => {
+  it('purges payments past the corrected head and rewinds the cursor atomically', async () => {
+    const { client, queries } = fakeClient();
+
+    const result = await rollbackSyncToLedger(client, 7, 5_000);
+
+    expect(result).toEqual({ purged: 3 });
+    expect(queries[0]).toBe('BEGIN');
+
+    // Same advisory lock setLastSyncedLedger takes, so a concurrent forward
+    // run cannot interleave with the rewind.
+    expect(queries).toContain('SELECT pg_advisory_xact_lock($1)');
+
+    // Only this merchant's rows past the head are removed — staged rows with
+    // a NULL ledger (ledger > $2 cannot match) survive the purge.
+    const del = queries.find((q) => /^DELETE FROM payments/m.test(q))!;
+    expect(del).toContain('merchant_id = $1');
+    expect(del).toContain('ledger > $2');
+
+    // The cursor write must NOT carry setLastSyncedLedger's forward-only
+    // guard: rewinding is the point of a rollback.
+    const upsert = queries.find((q) => /^INSERT INTO sync_state/m.test(q))!;
+    expect(upsert).toContain('ON CONFLICT (merchant_id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger');
+    expect(upsert).not.toContain('WHERE sync_state.last_ledger < EXCLUDED.last_ledger');
+
+    expect(queries[queries.length - 1]).toBe('COMMIT');
+    expect(queries.includes('ROLLBACK')).toBe(false);
+  });
+
+  it('rolls back the purge and the cursor write together on failure', async () => {
+    const { client, queries } = fakeClient({ failDelete: true });
+
+    await expect(rollbackSyncToLedger(client, 7, 5_000)).rejects.toThrow(
+      'connection reset mid-delete',
+    );
+    expect(queries.includes('ROLLBACK')).toBe(true);
+    expect(queries.includes('COMMIT')).toBe(false);
+  });
+
+  it('reports zero purged rows when nothing sat past the head', async () => {
+    const { client } = fakeClient({ deleted: 0 });
+
+    const result = await rollbackSyncToLedger(client, 7, 5_000);
+
+    expect(result).toEqual({ purged: 0 });
+  });
+});

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -404,6 +404,53 @@ export async function setLastSyncedLedger(
 }
 
 /**
+ * Handles a chain rollback: purges indexed payments from ledgers the
+ * corrected head no longer covers and rewinds the sync cursor to that head —
+ * atomically.
+ *
+ * Stellar consensus means closed ledgers are rarely overturned, but a node
+ * that lost state and re-synced from a snapshot, or a failover to a lagging
+ * peer, can report a head *below* the cursor. Payments indexed from the lost
+ * ledgers describe a chain that no longer exists; the next run re-indexes the
+ * corrected range, so the purge is a rewind, not data loss. Staged rows with a
+ * NULL ledger (merchant-reported attribution awaiting the chain) are
+ * untouched: `ledger > $2` cannot match them, and the re-indexed transfer
+ * fills them in later.
+ *
+ * The same advisory lock `setLastSyncedLedger` takes serializes this against
+ * a concurrent forward run, and the cursor write deliberately omits that
+ * function's forward-only `WHERE last_ledger < EXCLUDED.last_ledger` guard —
+ * rewinding is the point. Both statements commit together, so a crash cannot
+ * leave a cursor pointing past purged data.
+ *
+ * @returns The number of payment rows removed.
+ */
+export async function rollbackSyncToLedger(
+  client: Client,
+  merchantId: number,
+  ledger: number,
+): Promise<{ purged: number }> {
+  await client.query('BEGIN');
+  try {
+    await client.query('SELECT pg_advisory_xact_lock($1)', [merchantId]);
+    const res = await client.query(
+      `DELETE FROM payments WHERE merchant_id = $1 AND ledger > $2`,
+      [merchantId, ledger],
+    );
+    await client.query(
+      `INSERT INTO sync_state (merchant_id, last_ledger, updated_at) VALUES ($1, $2, now())
+       ON CONFLICT (merchant_id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger, updated_at = now()`,
+      [merchantId, ledger],
+    );
+    await client.query('COMMIT');
+    return { purged: res.rowCount ?? 0 };
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  }
+}
+
+/**
  * Persists a nonce issued by /api/auth/challenge so /api/auth/verify can
  * confirm it was this server that minted it, and that it has not already
  * been used. Scoped to the merchant the challenge was issued for, so a nonce

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -433,10 +433,10 @@ export async function rollbackSyncToLedger(
   await client.query('BEGIN');
   try {
     await client.query('SELECT pg_advisory_xact_lock($1)', [merchantId]);
-    const res = await client.query(
-      `DELETE FROM payments WHERE merchant_id = $1 AND ledger > $2`,
-      [merchantId, ledger],
-    );
+    const res = await client.query(`DELETE FROM payments WHERE merchant_id = $1 AND ledger > $2`, [
+      merchantId,
+      ledger,
+    ]);
     await client.query(
       `INSERT INTO sync_state (merchant_id, last_ledger, updated_at) VALUES ($1, $2, now())
        ON CONFLICT (merchant_id) DO UPDATE SET last_ledger = EXCLUDED.last_ledger, updated_at = now()`,

--- a/apps/web/src/lib/receipt-anchor.ts
+++ b/apps/web/src/lib/receipt-anchor.ts
@@ -116,8 +116,8 @@ export async function getBatch(batchId: number): Promise<BatchRecord> {
 
 /** Reads the max batch size configured on the contract. */
 export async function getMaxBatchSize(): Promise<number> {
- const result = await simulate('max_batch_size', []);
- return Number(result);
+  const result = await simulate('max_batch_size', []);
+  return Number(result);
 }
 
 export { Address };


### PR DESCRIPTION
Closes #153

## Summary

The indexer (`apps/web/src/app/api/sync`) now handles Stellar re-orgs and node desyncs gracefully. When the RPC reports a chain head lower than the currently processed cursor — a rollback — it purges indexed payments from the affected ledgers, rewinds the sync cursor to the corrected head, and resumes syncing from there, instead of silently reporting `drained` while keeping data from a chain that no longer exists.

## What changed

### Detection — `apps/web/src/app/api/sync/route.ts`
- `runSync` compares the incoming `getLatestLedger` head against the merchant's stored cursor. If `latestLedger < cursor`, a rollback is detected before any sweep work.
- The rewind is surfaced in the run's result: `rollback: true`, `rolledBackTo`, and `purged` (rows removed), so the run isn't mistaken for a no-op.

### Purge + cursor rewind — `apps/web/src/lib/db.ts`
- New `rollbackSyncToLedger(client, merchantId, ledger)`:
  - `DELETE FROM payments WHERE merchant_id = $1 AND ledger > $2` — removes only this merchant's rows from ledgers the corrected head no longer covers.
  - Rewinds `sync_state.last_ledger` to the corrected head in the same transaction. The cursor write deliberately omits `setLastSyncedLedger`'s forward-only guard (`WHERE last_ledger < EXCLUDED.last_ledger`) — rewinding is the point.
  - Runs under the same per-merchant advisory lock as forward progress, so a crash cannot leave a cursor pointing past purged data and a concurrent forward run cannot interleave.
  - Staged, merchant-reported rows with a `NULL` ledger survive the purge (`ledger > $2` cannot match them) and are filled in when the re-indexed transfer arrives.

### Resume
- After the rewind the cursor equals the corrected head, so the next run resumes from `head + 1` and re-indexes the corrected range normally. The purge is a rewind, not data loss — re-syncing is idempotent.

## Acceptance criteria
- [x] Indexer detects cursor rollbacks.
- [x] Indexer safely removes data from rolled-back ledgers.
- [x] Syncing resumes normally after a rollback.

## Tests
- `apps/web/src/lib/db.rollback.test.ts` — new fake-client unit tests: atomic purge + rewind (verifies the forward-only guard is absent), `ROLLBACK` on failure, zero-purge case.
- `apps/web/src/lib/db.integration.test.ts` — new real-DB case seeding ledgers 100–102 plus a staged `NULL`-ledger row, rolling back to 100, asserting rows 101/102 are purged, the staged row survives, and the cursor lands on 100. Runs when `DATABASE_URL` is set.
- Full suite: 357 passing, including the new tests. Note: `payments/route.ts` has a pre-existing `getMaxBatchSize is not defined` failure that also fails on `main`; it is untouched by this PR.