### PR TITLE
feat: payments filter (#158)

### DIFF
--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -36,6 +36,14 @@ export interface PaymentsResponse {
   total_count?: number;
   /** Sum of all settled payment amounts for this merchant. */
   total_amount?: string;
+  /** Filter metadata returned when filters are applied. */
+  filter_info?: {
+    route?: string;
+    payer?: string;
+    asset?: string;
+    date_from?: string;
+    date_to?: string;
+  };
 }
 
 export async function GET(request: Request) {
@@ -97,6 +105,13 @@ export async function GET(request: Request) {
 
   const offset = (page - 1) * limit;
 
+  // Filter parameters
+  const filterRoute = searchParams.get('route');
+  const filterPayer = searchParams.get('payer');
+  const filterAsset = searchParams.get('asset');
+  const filterDateFrom = searchParams.get('date_from');
+  const filterDateTo = searchParams.get('date_to');
+
   try {
     const merchant = await withClient((client) => getMerchantFromRequest(client, request));
     if (!merchant) {
@@ -120,6 +135,29 @@ export async function GET(request: Request) {
                               THEN MIN(COALESCE(asset, 'native')) OVER() END AS total_asset
                   FROM payments WHERE merchant_id = $1 AND ts IS NOT NULL`;
       const params: (string | number)[] = [merchant.id];
+
+      // Apply filter parameters
+      if (filterRoute) {
+        query += ` AND route = $${params.length + 1}`;
+        params.push(filterRoute);
+      }
+      if (filterPayer) {
+        query += ` AND payer = $${params.length + 1}`;
+        params.push(filterPayer);
+      }
+      if (filterAsset) {
+        query += ` AND asset = $${params.length + 1}`;
+        params.push(filterAsset);
+      }
+      if (filterDateFrom) {
+        query += ` AND ts >= $${params.length + 1}`;
+        params.push(filterDateFrom);
+      }
+      if (filterDateTo) {
+        query += ` AND ts <= $${params.length + 1}`;
+        params.push(filterDateTo);
+      }
+
       if (parsedCursor) {
         query += ` AND (ts < $${params.length + 1} OR (ts = $${params.length + 1} AND tx_hash < $${params.length + 2}))`;
         params.push(parsedCursor.ts, parsedCursor.txHash);
@@ -199,6 +237,17 @@ export async function GET(request: Request) {
       total_pages: totalPages,
       total_count: totalCount,
       total_amount: totalAmount,
+      ...(filterRoute || filterPayer || filterAsset || filterDateFrom || filterDateTo
+        ? {
+            filter_info: {
+              route: filterRoute ?? undefined,
+              payer: filterPayer ?? undefined,
+              asset: filterAsset ?? undefined,
+              date_from: filterDateFrom ?? undefined,
+              date_to: filterDateTo ?? undefined,
+            },
+          }
+        : {}),
     };
     return NextResponse.json(body, {
       headers: {


### PR DESCRIPTION
Closes #158

Adds server-side filter parameters (route, payer, asset, date_from, date_to) to the payments API endpoint.

Changes:
- Parse filter query params from URL searchParams
- Add WHERE clauses to the SQL query for each filter
- Add optional `filter_info` field to PaymentsResponse type
- Return active filters in response when any are applied