### PR TITLE
feat: micro-frontend scaffold (#162)

### DIFF
--- a/apps/web/module-federation.config.js
+++ b/apps/web/module-federation.config.js
@@ -1,0 +1,52 @@
+/**
+ * Webpack Module Federation configuration for the Accensa web application.
+ *
+ * This config defines the host (shell) application that will consume
+ * federated remote modules from domain-specific micro-frontends.
+ *
+ * Usage:
+ *   - In next.config.ts, import this config and merge with webpack config
+ *   - Each remote entry points to a separate Next.js or standalone build
+ *   - Shared packages (@accensa/shared) are singleton to avoid duplication
+ */
+
+/** @type {import('@module-federation/enhanced').ModuleFederationPluginOptions} */
+const moduleFederationConfig = {
+  name: 'accensa_shell',
+  filename: 'static/chunks/remoteEntry.js',
+
+  remotes: {
+    // Domain remotes will be registered here as they are extracted.
+    // Example:
+    // payments_domain: 'payments_domain@/_next/static/chunks/remoteEntry.js',
+    // settings_domain: 'settings_domain@/_next/static/chunks/remoteEntry.js',
+  },
+
+  shared: {
+    // Core shared dependencies across all federated modules
+    react: {
+      singleton: true,
+      requiredVersion: '^19.0.0',
+      eager: false,
+    },
+    'react-dom': {
+      singleton: true,
+      requiredVersion: '^19.0.0',
+      eager: false,
+    },
+    // Accensa shared primitives
+    '@accensa/shared': {
+      singleton: true,
+      requiredVersion: '^0.1.0',
+      eager: true,
+    },
+  },
+
+  // Exposes shared components and types from this shell app
+  exposes: {
+    './ShellLayout': './src/components/ShellLayout',
+    './ThemeProvider': './src/components/ThemeProvider',
+  },
+};
+
+export default moduleFederationConfig;

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,34 @@
+# @accensa/shared
+
+Shared components, utilities, and types for micro-frontend federation across Accensa applications.
+
+## Purpose
+
+This package serves as the shared layer for Webpack Module Federation. It provides:
+
+- **Shared components** – UI primitives that can be consumed by federated remotes
+- **Shared utilities** – Cross-cutting helper functions (event bus, formatting, etc.)
+- **Shared types** – TypeScript interfaces that define contracts between micro-frontends
+
+## Structure
+
+```
+src/
+├── components/   # Shared UI components and component registry
+├── utils/        # Cross-cutting utilities (events, formatting)
+└── types/        # Shared TypeScript interfaces
+```
+
+## Module Federation
+
+This package is configured as a singleton shared dependency in the Module Federation host config (`apps/web/module-federation.config.js`). All federated remotes and the shell host share a single instance to avoid duplication and ensure type safety at runtime.
+
+## Development
+
+```bash
+# Type-check
+pnpm typecheck
+
+# Lint
+pnpm lint
+```

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@accensa/shared",
+  "version": "0.1.0",
+  "description": "Shared components, utilities, and types for micro-frontend federation across Accensa applications",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT",
+  "homepage": "https://accensa.github.io/accensa-app/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/accensa/accensa-app.git",
+    "directory": "packages/shared"
+  },
+  "bugs": {
+    "url": "https://github.com/accensa/accensa-app/issues"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./components": "./src/components/index.ts",
+    "./utils": "./src/utils/index.ts",
+    "./types": "./src/types/index.ts"
+  },
+  "scripts": {
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.3"
+  }
+}

--- a/packages/shared/src/components/index.ts
+++ b/packages/shared/src/components/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared UI components for micro-frontend federation.
+ *
+ * These components will be exposed as Module Federation remote entries
+ * once domain-specific applications are extracted into separate builds.
+ */
+
+export interface ComponentConfig {
+  /** Unique identifier for the component within the federated scope. */
+  id: string;
+  /** Display name used in dev tools and error boundaries. */
+  displayName: string;
+  /** Semantic version string. */
+  version: string;
+}
+
+export function defineComponent(config: ComponentConfig): ComponentConfig {
+  return config;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @accensa/shared – Micro-frontend shared package
+ *
+ * This package serves as the shared layer for Webpack Module Federation.
+ * Domain-specific components and logic will be extracted into remotes over time.
+ * For now, this scaffold provides the infrastructure and shared primitives.
+ */
+
+export * from './components';
+export * from './utils';
+export * from './types';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared type definitions for micro-frontend boundaries.
+ *
+ * These types define the contracts between federated modules, ensuring
+ * type safety across remote boundaries.
+ */
+
+export interface Merchant {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface Payment {
+  tx_hash: string;
+  ledger: number | null;
+  payer: string;
+  amount: string;
+  asset: string | null;
+  ts: string;
+  route: string | null;
+  method: string | null;
+}
+
+export interface SyncState {
+  lastSyncTs: string | null;
+  status: 'idle' | 'syncing' | 'error';
+}
+
+export interface FilterParams {
+  route?: string;
+  payer?: string;
+  asset?: string;
+  date_from?: string;
+  date_to?: string;
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared utilities for micro-frontend communication and coordination.
+ */
+
+export interface FedEvent<T = unknown> {
+  type: string;
+  payload: T;
+  source: string;
+  timestamp: number;
+}
+
+/**
+ * Create a typed event for cross-remote communication.
+ */
+export function createEvent<T>(type: string, payload: T, source: string): FedEvent<T> {
+  return { type, payload, source, timestamp: Date.now() };
+}
+
+/**
+ * Format a currency amount for display across micro-frontends.
+ */
+export function formatAmount(amount: string | number, asset?: string | null): string {
+  const num = typeof amount === 'string' ? parseFloat(amount) : amount;
+  if (Number.isNaN(num)) return '0';
+  const formatted = num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+  return asset ? `${formatted} ${asset}` : formatted;
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #162

Minimal Webpack Module Federation scaffold for future micro-frontend extraction.

Changes:
- Create `packages/shared/` package with shared components, utilities, and types
- Add `apps/web/module-federation.config.js` with host configuration
- Configure shared dependencies (React, @accensa/shared) as singletons
- Add type definitions for cross-micro-frontend contracts (Merchant, Payment, FilterParams, etc.)

This is infrastructure-only — no actual domain extraction yet. The scaffold sets up the shared layer so individual domains (payments, settings, etc.) can be extracted into separate remote builds incrementally.