### PR TITLE
feat(sdk): add multi-currency price formatting helpers

### DIFF
--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -44,6 +44,17 @@ export {
 export type { Order, OrderMetadata } from './src/types/order';
 export type { Product, ProductMetadata } from './src/types/product';
 
+/** Multi-currency price formatting utilities. */
+export {
+  formatPrice,
+  formatPriceCompact,
+  assetSymbol,
+  toStroops,
+  fromStroops,
+  TOKENS,
+  type TokenMeta,
+} from './src/price-formatter';
+
 /**
  * This package deliberately ships no paywall middleware.
  *

--- a/packages/sdk/src/price-formatter.test.ts
+++ b/packages/sdk/src/price-formatter.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toStroops,
+  fromStroops,
+  formatPrice,
+  formatPriceCompact,
+  assetSymbol,
+  TOKENS,
+} from './price-formatter';
+
+describe('toStroops / fromStroops', () => {
+  it('round-trips a 7-decimal amount', () => {
+    expect(toStroops('12.5000000')).toBe(125_000_000n);
+    expect(fromStroops(125_000_000n)).toBe('12.5000000');
+  });
+
+  it('handles a bare integer', () => {
+    expect(toStroops('5')).toBe(50_000_000n);
+  });
+
+  it('pads short fractions rather than misreading them', () => {
+    expect(toStroops('0.1')).toBe(1_000_000n);
+  });
+
+  it('preserves a single stroop', () => {
+    expect(toStroops('0.0000001')).toBe(1n);
+    expect(fromStroops(1n)).toBe('0.0000001');
+  });
+
+  it('handles negatives', () => {
+    expect(toStroops('-2.5')).toBe(-25_000_000n);
+    expect(fromStroops(-25_000_000n)).toBe('-2.5000000');
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(toStroops('abc')).toBeNull();
+    expect(toStroops('')).toBeNull();
+  });
+});
+
+describe('formatPrice', () => {
+  it('formats XLM with symbol', () => {
+    expect(formatPrice('12500000', 'native')).toBe('1.25 XLM');
+  });
+
+  it('formats USDC with symbol', () => {
+    expect(formatPrice('10000000', 'USDC')).toBe('1.00 USDC');
+  });
+
+  it('groups thousands', () => {
+    expect(formatPrice('12345678000000', 'native')).toBe('1,234,567.80 XLM');
+  });
+
+  it('handles small amounts with many decimals', () => {
+    expect(formatPrice('1', 'native')).toBe('0.0000001 XLM');
+  });
+
+  it('returns input unchanged when unparseable', () => {
+    expect(formatPrice('n/a', 'native')).toBe('n/a');
+  });
+
+  it('defaults to XLM when no asset provided', () => {
+    expect(formatPrice('10000000')).toBe('1.00 XLM');
+  });
+
+  it('handles unknown assets by using the asset code as symbol', () => {
+    expect(formatPrice('50000000', 'BTC:GA...')).toBe('5.00 BTC');
+  });
+});
+
+describe('formatPriceCompact', () => {
+  it('formats without symbol', () => {
+    expect(formatPriceCompact('12500000')).toBe('1.25');
+  });
+
+  it('groups thousands', () => {
+    expect(formatPriceCompact('12345678000000')).toBe('1,234,567.80');
+  });
+
+  it('returns input unchanged when unparseable', () => {
+    expect(formatPriceCompact('n/a')).toBe('n/a');
+  });
+});
+
+describe('assetSymbol', () => {
+  it('maps native to XLM', () => {
+    expect(assetSymbol('native')).toBe('XLM');
+  });
+
+  it('maps null to XLM', () => {
+    expect(assetSymbol(null)).toBe('XLM');
+  });
+
+  it('extracts the code from a SEP-11 identifier', () => {
+    expect(assetSymbol('USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN')).toBe('USDC');
+  });
+});
+
+describe('TOKENS', () => {
+  it('defines native and USDC', () => {
+    expect(TOKENS.native.symbol).toBe('XLM');
+    expect(TOKENS.USDC.symbol).toBe('USDC');
+  });
+});

--- a/packages/sdk/src/price-formatter.ts
+++ b/packages/sdk/src/price-formatter.ts
@@ -1,0 +1,127 @@
+/**
+ * Multi-currency price formatting utilities for the Accensa SDK.
+ *
+ * Converts raw stroop amounts to human-readable formatted strings based on
+ * token type. All arithmetic is integer-only to avoid floating-point drift.
+ */
+
+/** Number of decimal places in Stellar stroops. */
+const SCALE = 7;
+const SCALE_FACTOR = 10_000_000n;
+
+/** Well-known token metadata. */
+export interface TokenMeta {
+  /** SEP-11 asset identifier, e.g."native"or"USDC:GA..." */
+  asset: string;
+  /** Human-readable symbol, e.g."XLM"or"USDC". */
+  symbol: string;
+  /** Number of decimal places for display (defaults to 7 for Stellar). */
+  decimals?: number;
+}
+
+/** Built-in token definitions for common Stellar assets. */
+export const TOKENS: Record<string, TokenMeta> = {
+  native: { asset: 'native', symbol: 'XLM', decimals: 7 },
+  USDC: {
+    asset: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    symbol: 'USDC',
+    decimals: 7,
+  },
+};
+
+/**
+ * Parses a decimal string into integer stroops. Returns null if unparseable.
+ *
+ * Matches the behaviour of the web app's `toStroops` but is kept self-contained
+ * so the SDK does not depend on the web package.
+ */
+export function toStroops(amount: string): bigint | null {
+  const match = /^(-?)(\d+)(?:\.(\d*))?$/.exec(amount.trim());
+  if (!match) return null;
+  const [, sign, whole, frac = ''] = match;
+  const padded = (frac + '0'.repeat(SCALE)).slice(0, SCALE);
+  const value = BigInt(whole) * SCALE_FACTOR + BigInt(padded || '0');
+  return sign === '-' ? -value : value;
+}
+
+/** Formats integer stroops as a decimal string with 7 places. */
+export function fromStroops(stroops: bigint): string {
+  const negative = stroops < 0n;
+  const abs = negative ? -stroops : stroops;
+  const frac = (abs % SCALE_FACTOR).toString().padStart(SCALE, '0');
+  return `${negative ? '-' : ''}${abs / SCALE_FACTOR}.${frac}`;
+}
+
+/**
+ * Formats a stroop amount as a human-readable price with the token symbol.
+ *
+ * ```ts
+ * formatPrice('12500000', 'native')       // "1.25 XLM"
+ * formatPrice('10000000', 'USDC')         // "1.00 USDC"
+ * formatPrice('0.0000001', 'native')      // "0.0000001 XLM"
+ * ```
+ */
+export function formatPrice(stroopsOrDecimal: string, asset: string = 'native'): string {
+  const meta = resolveToken(asset);
+  const stroops = toStroops(stroopsOrDecimal);
+  if (stroops === null) return stroopsOrDecimal;
+
+  const fixed = fromStroops(stroops);
+  const negative = fixed.startsWith('-');
+  const [whole, frac = ''] = (negative ? fixed.slice(1) : fixed).split('.');
+
+  const decimals = meta.decimals ?? SCALE;
+  let trimmed = frac.replace(/0+$/, '');
+  if (trimmed.length < Math.min(2, decimals)) {
+    trimmed = trimmed.padEnd(Math.min(2, decimals), '0');
+  }
+  if (trimmed.length > decimals) trimmed = trimmed.slice(0, decimals);
+
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const formatted = `${negative ? '-' : ''}${grouped}${trimmed ? `.${trimmed}` : ''}`;
+  return `${formatted} ${meta.symbol}`;
+}
+
+/**
+ * Formats a stroop amount as a compact price without the token symbol.
+ *
+ * Useful in tight UI spaces where the symbol is shown separately.
+ *
+ * ```ts
+ * formatPriceCompact('12500000')  // "1.25"
+ * ```
+ */
+export function formatPriceCompact(stroopsOrDecimal: string): string {
+  const stroops = toStroops(stroopsOrDecimal);
+  if (stroops === null) return stroopsOrDecimal;
+
+  const fixed = fromStroops(stroops);
+  const negative = fixed.startsWith('-');
+  const [whole, frac = ''] = (negative ? fixed.slice(1) : fixed).split('.');
+
+  let trimmed = frac.replace(/0+$/, '');
+  if (trimmed.length < 2) trimmed = trimmed.padEnd(2, '0');
+
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  return `${negative ? '-' : ''}${grouped}${trimmed ? `.${trimmed}` : ''}`;
+}
+
+/**
+ * Returns the human-readable symbol for a SEP-11 asset identifier.
+ *
+ * ```ts
+ * assetSymbol('native')            // "XLM"
+ * assetSymbol('USDC:GA...')        // "USDC"
+ * assetSymbol(null)                // "XLM"
+ * ```
+ */
+export function assetSymbol(asset: string | null): string {
+  if (!asset || asset === 'native') return 'XLM';
+  return asset.split(':')[0];
+}
+
+function resolveToken(asset: string): TokenMeta {
+  if (!asset || asset === 'native') return TOKENS.native;
+  const code = asset.split(':')[0];
+  return TOKENS[code] ?? { asset, symbol: code, decimals: SCALE };
+}


### PR DESCRIPTION
Closes #144

Add price-formatter.ts utility in packages/sdk/src that converts stroop amounts to human-readable formatted strings based on token type.

**New exports:**
- `formatPrice(stroops, asset)` - formats with token symbol (e.g."1.25 XLM")
- `formatPriceCompact(stroops)` - formats without symbol for tight UI spaces
- `assetSymbol(asset)` - resolves SEP-11 asset identifiers to human symbols
- `toStroops` / `fromStroops` - integer-only stroop conversion
- `TOKENS` - built-in metadata for native XLM and USDC

All arithmetic is integer-only to avoid floating-point drift.