### PR TITLE
fix(web): handle large decimal amounts safely in the UI

### DIFF
--- a/apps/web/src/app/api/payments/route.ts
+++ b/apps/web/src/app/api/payments/route.ts
@@ -114,9 +114,10 @@ export async function GET(request: Request) {
     if (!merchant) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+    const merchantId = merchant.id;
 
-    const { rows, sync } = await withMerchantClient(
-      merchant.id,
+    const { rows, sync, totalCount, totalAmount } = await withMerchantClient(
+      merchantId,
       async (client) => {
         await ensureSchema(client);
 
@@ -131,7 +132,7 @@ export async function GET(request: Request) {
                                      MAX(COALESCE(asset, 'native')) OVER()
                                 THEN MIN(COALESCE(asset, 'native')) OVER() END AS total_asset
                     FROM payments WHERE merchant_id = $1 AND ts IS NOT NULL`;
-        const params: (string | number)[] = [merchant.id];
+        const params: (string | number)[] = [merchantId];
 
         // Apply date range filter (#142)
         if (fromDate) {
@@ -150,9 +151,6 @@ export async function GET(request: Request) {
         query += ` ORDER BY ts DESC, tx_hash DESC LIMIT $${params.length + 1}`;
         params.push(limit);
 
-        query += ` ORDER BY ts DESC, tx_hash DESC LIMIT $${params.length + 1}`;
-        params.push(limit);
-
         if (!parsedCursor) {
           query += ` OFFSET $${params.length + 1}`;
           params.push(offset);
@@ -162,7 +160,7 @@ export async function GET(request: Request) {
 
         const countRes = await client.query<{ total_count: string; total_amount: string | null }>(
           `SELECT count(*)::text AS total_count, coalesce(sum(amount), 0)::text AS total_amount FROM payments WHERE merchant_id = $1 AND ts IS NOT NULL`,
-          [merchant.id],
+          [merchantId],
         );
         const totalCount = countRes.rows.length
           ? Number(countRes.rows[0].total_count ?? countRes.rows.length)
@@ -176,11 +174,10 @@ export async function GET(request: Request) {
 
         return {
           rows: result.rows,
-          sync: await getSyncState(client, merchant.id),
+          sync: await getSyncState(client, merchantId),
           totalCount,
           totalAmount,
         };
-        return { rows: result.rows, sync: await getSyncState(client, merchant.id) };
       },
     );
 

--- a/apps/web/src/lib/analytics.test.ts
+++ b/apps/web/src/lib/analytics.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Client } from 'pg';
+import { getDashboardAnalytics } from './analytics';
+
+/**
+ * A fake pg client answering the four queries getDashboardAnalytics runs,
+ * keyed off the SQL so each test can stub just the periods it cares about.
+ */
+function clientFor(rows: {
+  current?: Record<string, unknown>[];
+  previous?: Record<string, unknown>[];
+  topProducts?: Record<string, unknown>[];
+  dailyTrend?: Record<string, unknown>[];
+}): Client {
+  const query = vi.fn(async (sql: string) => {
+    if (sql.includes('count(DISTINCT payer)')) return { rows: rows.current ?? [] };
+    if (sql.includes('ts < $3')) return { rows: rows.previous ?? [] };
+    if (sql.includes('GROUP BY route')) return { rows: rows.topProducts ?? [] };
+    if (sql.includes('date_trunc')) return { rows: rows.dailyTrend ?? [] };
+    throw new Error(`unexpected query: ${sql}`);
+  });
+  return { query } as unknown as Client;
+}
+
+describe('getDashboardAnalytics', () => {
+  it('averages exactly beyond Number.MAX_SAFE_INTEGER, where floats cannot', async () => {
+    // 2^53 + 1 in the whole part: parseFloat already rounds this to 2^53.
+    const revenue = '9007199254740993.1234567';
+    const analytics = await getDashboardAnalytics(
+      clientFor({
+        current: [{ total_revenue: revenue, total_payments: '3', unique_payers: '2' }],
+      }),
+      '1',
+    );
+
+    // The average is floored to the stroop, exactly: 90071992547409931234567
+    // stroops / 3 = 30023997515803310411522 stroops.
+    expect(analytics.averagePayment).toBe('3002399751580331.0411522');
+    // The amount itself passes through untouched.
+    expect(analytics.totalRevenue).toBe(revenue);
+    expect(analytics.totalPayments).toBe(3);
+
+    // The float route this replaces could not have produced that: 2^53 + 1
+    // is not representable, so the parse snaps to the nearest double and
+    // loses the .1234567 (and the +1) entirely.
+    expect(Number('9007199254740993.1234567')).toBe(9007199254740994);
+  });
+
+  it('computes revenue change from stroops and rounds to 0.1%', async () => {
+    const analytics = await getDashboardAnalytics(
+      clientFor({
+        current: [{ total_revenue: '10.0000000', total_payments: '4', unique_payers: '3' }],
+        previous: [{ total_revenue: '5.0000000', total_payments: '2' }],
+      }),
+      '1',
+    );
+    expect(analytics.revenueChange).toBe(100);
+  });
+
+  it('rounds revenue change half away from zero at the 0.1% digit', async () => {
+    const analytics = await getDashboardAnalytics(
+      clientFor({
+        current: [{ total_revenue: '100.1500000', total_payments: '1', unique_payers: '1' }],
+        previous: [{ total_revenue: '100.0000000', total_payments: '1' }],
+      }),
+      '1',
+    );
+    // 0.15% -> 0.2%, decided in bigint before any float is involved.
+    expect(analytics.revenueChange).toBe(0.2);
+  });
+
+  it('floors the average to the stroop like the route breakdown does', async () => {
+    const analytics = await getDashboardAnalytics(
+      clientFor({
+        current: [{ total_revenue: '1.0000000', total_payments: '3', unique_payers: '1' }],
+      }),
+      '1',
+    );
+    // 10,000,000 stroops / 3 = 3,333,333r stroops, not a rounded 0.3333334.
+    expect(analytics.averagePayment).toBe('0.3333333');
+  });
+
+  it('reports zero growth and no average when there is nothing to compare', async () => {
+    const analytics = await getDashboardAnalytics(
+      clientFor({
+        current: [{ total_revenue: '0', total_payments: '0', unique_payers: '0' }],
+      }),
+      '1',
+    );
+    expect(analytics.revenueChange).toBe(0);
+    expect(analytics.paymentsChange).toBe(0);
+    expect(analytics.averagePayment).toBe('0');
+  });
+
+  it('passes top product revenue and daily trend amounts through verbatim', async () => {
+    const analytics = await getDashboardAnalytics(
+      clientFor({
+        current: [{ total_revenue: '12.5000000', total_payments: '2', unique_payers: '1' }],
+        topProducts: [{ route: '/api/quote', revenue: '9007199254740993.1234567', count: '1' }],
+        dailyTrend: [
+          { day: new Date('2026-08-20T00:00:00.000Z'), revenue: '7.2500000', count: '1' },
+          { day: '2026-08-19', revenue: '5.2500000', count: '1' },
+        ],
+      }),
+      '1',
+    );
+    expect(analytics.topProducts[0].revenue).toBe('9007199254740993.1234567');
+    expect(analytics.dailyTrend.map((d) => d.date)).toEqual(['2026-08-20', '2026-08-19']);
+    expect(analytics.dailyTrend[0].revenue).toBe('7.2500000');
+  });
+});

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -12,7 +12,8 @@
  *   });
  */
 
-import type { PostgresClient } from './db';
+import type { Client } from 'pg';
+import { fromStroops, toStroops } from './money';
 
 export type AnalyticsPeriod = '24h' | '7d' | '30d' | '90d' | 'all';
 
@@ -52,10 +53,23 @@ const PERIOD_DAYS: Record<AnalyticsPeriod, number> = {
 };
 
 /**
+ * Divides two bigints, rounding half away from zero instead of truncating.
+ *
+ * Bigint division truncates toward zero; this adds half the denominator back
+ * (in the sign's direction) so the last kept digit is the nearest one, the
+ * same behaviour `Math.round` gives a float quotient — without any amount
+ * passing through a float to get there.
+ */
+function roundDiv(num: bigint, den: bigint): bigint {
+  const half = den / 2n;
+  return (num + (num < 0n ? -half : half)) / den;
+}
+
+/**
  * Get dashboard analytics for a merchant.
  */
 export async function getDashboardAnalytics(
-  client: PostgresClient,
+  client: Client,
   merchantId: string,
   opts: { period?: AnalyticsPeriod } = {},
 ): Promise<DashboardAnalytics> {
@@ -95,14 +109,21 @@ export async function getDashboardAnalytics(
   const cur = currentStats.rows[0];
   const prev = previousStats.rows[0];
 
+  // Revenue is folded in integer stroops exactly as on the ledger — never
+  // through a float, which would round a sum past 2^53 stroops. Only the final
+  // *ratios* (percentages) become Numbers, and they are derived by dividing
+  // bigints first, so no amount is ever represented as a float.
   const totalRevenue = cur?.total_revenue ?? '0';
+  const totalStroops = toStroops(totalRevenue) ?? 0n;
   const totalPayments = parseInt(cur?.total_payments ?? '0', 10);
   const uniquePayers = parseInt(cur?.unique_payers ?? '0', 10);
-  const prevRevenue = parseFloat(prev?.total_revenue ?? '0');
+  const prevStroops = toStroops(prev?.total_revenue ?? '0') ?? 0n;
   const prevPayments = parseInt(prev?.total_payments ?? '0', 10);
 
-  const revenueChange = prevRevenue > 0
-    ? ((parseFloat(totalRevenue) - prevRevenue) / prevRevenue) * 100
+  // Percentage at 0.1% resolution, rounded in bigint before anything becomes
+  // a float: ((cur - prev) / prev) * 100, with the rounding digit kept exact.
+  const revenueChange = prevStroops > 0n
+    ? Number(roundDiv((totalStroops - prevStroops) * 1000n, prevStroops)) / 10
     : 0;
   const paymentsChange = prevPayments > 0
     ? ((totalPayments - prevPayments) / prevPayments) * 100
@@ -125,7 +146,8 @@ export async function getDashboardAnalytics(
 
   // Daily trend
   const dailyTrendResult = await client.query<{
-    day: string;
+    // pg returns a Date for `::date` columns; the mapper below accepts both.
+    day: Date | string;
     revenue: string;
     count: string;
   }>(
@@ -142,10 +164,12 @@ export async function getDashboardAnalytics(
   return {
     totalRevenue,
     totalPayments,
+    // Integer division in stroops, floored to the stroop like the route
+    // breakdown averages — never divided through a float.
     averagePayment: totalPayments > 0
-      ? (parseFloat(totalRevenue) / totalPayments).toFixed(7)
+      ? fromStroops(totalStroops / BigInt(totalPayments))
       : '0',
-    revenueChange: Math.round(revenueChange * 10) / 10,
+    revenueChange,
     paymentsChange: Math.round(paymentsChange * 10) / 10,
     topProducts: topProductsResult.rows.map((r) => ({
       route: r.route,


### PR DESCRIPTION
## Summary

Fixes **#136** — the last place in the frontend where Stellar amounts passed through JavaScript floats. Large XLM/USDC balances (past `Number.MAX_SAFE_INTEGER` stroops) were rounded or rendered with scientific notation; now every amount on the dashboard stays in exact integer stroops until the moment it is displayed.

### What changed

**1. `lib/analytics.ts` — stroop-exact analytics math**
- Replaced `parseFloat()` on revenue amounts with the existing bigint helpers (`toStroops` / `fromStroops` from `lib/money.ts`), the same stroop-based pipeline already used by the dashboard, route breakdown, chart, refund panel, and CSV export.
- `averagePayment` is now integer stroop division, floored to the stroop — consistent with the route-breakdown averages — instead of `(parseFloat(totalRevenue) / totalPayments).toFixed(7)`, which rounded past 2^53 stroops.
- `revenueChange` is computed by dividing bigints first and rounding at the 0.1% digit with a new `roundDiv` helper (half-away-from-zero, exactly matching the previous `Math.round` behaviour) — the percentage is a ratio, never a float representation of money.
- Fixed the broken `PostgresClient` import (the module exports `pg`'s `Client`, not that name) and the `day` row type (`::date` comes back as a `Date` from pg), which were pre-existing typecheck errors.

**2. `app/api/payments/route.ts` — repaired merge damage that broke the dashboard totals API**
This route feeds the dashboard's "Total Settled" header (`total_amount`), the payment table, and the CSV export. It had been damaged by a bad merge on `main`:
- A duplicated `ORDER BY … LIMIT` clause producing invalid SQL → every `/api/payments` request 500'd, taking the whole dashboard down.
- `totalCount` / `totalAmount` declared inside the `withMerchantClient` callback but referenced outside it (they were `undefined` in the response, so the header fell back to summing only the visible page).
- An unreachable `return` after the real one.

All amounts cross this route as `::text`/string, so nothing is parsed into a float server-side either.

### Acceptance criteria

- ✅ **Balances display exactly as they do on the ledger** — amounts are carried as 7-decimal strings end to end and summed in integer stroops; `formatAmount` only adds grouping/trimming for display.
- ✅ **No scientific notation shown to users** — formatting is pure string manipulation; `Number` is never applied to an amount.
- ✅ **Math operations on the frontend are safe from floating-point errors** — the only remaining float in the amount pipeline is the `fraction()` pixel ratio in the chart, which is derived from bigint division and is geometry, not money.

### Testing

- `pnpm typecheck` — clean (was failing with 6 errors on `main`).
- `pnpm test` — **419 passing / 0 failing** (was 404 passing / 9 failing on `main`; the 9 failures were all from the broken payments route).
- New `lib/analytics.test.ts` proves exactness beyond 2^53 stroops, e.g. `9007199254740993.1234567` summed over 3 payments yields the exact average `3002399751580331.0411522`, while `Number('9007199254740993.1234567')` snaps to `9007199254740994`.

closes #136