### PR TITLE
feat(sdk): rate-limit retry wrapper and read caching (#155 #160)

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -171,9 +171,17 @@ discriminate the failure modes you actually branch on:
 | Class                  | Thrown when                                                                                                 | Metadata         |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------- |
 | `AccensaAuthError`     | The indexer rejected the credential (HTTP 401/403).                                                         | `status`, `path` |
+| `AccensaRateLimitError`| A rate-limited RPC or indexer node answered 429 and the retry budget was spent.                             | `path`, `retryAfterMs` |
 | `AccensaNetworkError`  | The indexer could not be reached — `fetch` failed, timed out, or is unavailable.                            | `url`, `cause`   |
 | `AccensaContractError` | The indexer (or a receipt) violated the wire contract: a malformed row, a non-JSON body, a bad Merkle hash. | `index`          |
 | `AccensaError`         | The base class; also thrown directly for other non-2xx statuses (e.g. 500).                                 | `status`         |
+
+Rate limits are retried automatically: the client waits out `Retry-After`
+(up to 3 times) before throwing `AccensaRateLimitError`, so a transient 429
+from a public Soroban RPC node never crashes the app mid-poll. Reads are
+also served from a short in-memory cache (10s TTL, configurable via
+`cacheTtlMs`, `0` to disable), so repeated profile/product reads across page
+navigations bypass the network. Call `client.clearCache()` after a write.
 
 ```ts
 import { AccensaClient, AccensaAuthError, AccensaNetworkError } from '@accensa/sdk';

--- a/packages/sdk/retry.test.ts
+++ b/packages/sdk/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fetchWithRetry, HttpError } from './retry';
+import { fetchWithRetry, HttpError, retryAfterMs } from './retry';
 
 const ok = () => new Response(null, { status: 200 });
 const status = (code: number) => new Response(null, { status: code });
@@ -177,6 +177,102 @@ describe('fetchWithRetry', () => {
 
     expect(response.ok).toBe(true);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a 429 by default', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => status(429));
+
+    await expect(
+      fetchWithRetry('https://example.test', undefined, { ...FAST, fetchImpl }),
+    ).rejects.toThrow(HttpError);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('retries a 429 when retryOn429 is set, waiting out Retry-After', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>();
+      const rateLimited = new Response(null, {
+        status: 429,
+        headers: { 'Retry-After': '1' },
+      });
+      fetchImpl.mockResolvedValueOnce(rateLimited);
+      fetchImpl.mockResolvedValueOnce(ok());
+
+      const pending = fetchWithRetry('https://example.test', undefined, {
+        baseDelayMs: 10,
+        fetchImpl,
+        retryOn429: true,
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+      const response = await pending;
+
+      expect(response.ok).toBe(true);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to exponential backoff when a 429 has no Retry-After', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>();
+      fetchImpl.mockResolvedValueOnce(status(429));
+      fetchImpl.mockResolvedValueOnce(ok());
+      const onRetry = vi.fn();
+
+      const pending = fetchWithRetry('https://example.test', undefined, {
+        baseDelayMs: 100,
+        fetchImpl,
+        retryOn429: true,
+        onRetry,
+      });
+      await vi.advanceTimersByTimeAsync(100);
+      const response = await pending;
+
+      expect(response.ok).toBe(true);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+      expect(onRetry.mock.calls[0][2]).toBe(100);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('throws HttpError(429) after exhausting retries with retryOn429', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>(async () => status(429));
+
+      const pending = fetchWithRetry('https://example.test', undefined, {
+        baseDelayMs: 10,
+        maxRetries: 2,
+        fetchImpl,
+        retryOn429: true,
+      });
+      const result = pending.catch((e: unknown) => e);
+      // 2 retries: 10ms then 20ms backoff (no Retry-After header).
+      for (let i = 0; i < 2; i++) await vi.advanceTimersByTimeAsync(10 * 2 ** i);
+      const error = await result;
+
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).status).toBe(429);
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('parses a Retry-After HTTP-date into milliseconds', () => {
+    const later = new Date(Date.now() + 5_000).toUTCString();
+    const ms = retryAfterMs(new Response(null, { headers: { 'Retry-After': later } }));
+    expect(ms).toBeGreaterThanOrEqual(4_000);
+    expect(ms).toBeLessThanOrEqual(5_000);
+  });
+
+  it('returns undefined Retry-After when the header is absent', () => {
+    expect(retryAfterMs(ok())).toBeUndefined();
   });
 });
 

--- a/packages/sdk/retry.ts
+++ b/packages/sdk/retry.ts
@@ -34,6 +34,27 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Reads the server's `Retry-After` hint from a response, if present.
+ *
+ * Returns milliseconds to wait. Handles both the HTTP-date form and the
+ * integer-seconds form the rate-limit middlewares in common use actually send
+ * (a bare number of seconds, per RFC 9110). Returns undefined when the header
+ * is absent or unparseable, so callers fall back to their own backoff.
+ */
+export function retryAfterMs(response: Response): number | undefined {
+  const header = response.headers.get('retry-after');
+  if (!header) return undefined;
+
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+
+  const date = Date.parse(header);
+  if (Number.isFinite(date)) return Math.max(0, date - Date.now());
+
+  return undefined;
+}
+
 export interface RetryOptions {
   /** Retry attempts after the first try. Defaults to 3. */
   maxRetries?: number;
@@ -43,6 +64,13 @@ export interface RetryOptions {
   fetchImpl?: typeof fetch;
   /** Which HTTP status codes are worth retrying. Defaults to 500-599. */
   isRetryableStatus?: (status: number) => boolean;
+  /**
+   * Also retry HTTP 429 (Too Many Requests), honouring the response's
+   * `Retry-After` header when present and falling back to the exponential
+   * backoff otherwise. Defaults to false, keeping 429 a fast, non-retried
+   * failure unless a caller opts in (#155).
+   */
+  retryOn429?: boolean;
   /** Called before each retry's delay, e.g. for logging. Never called for the final failure. */
   onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
 }
@@ -56,6 +84,11 @@ export interface RetryOptions {
  * an `AbortError` means the caller already decided to stop waiting — retrying
  * either would just fail the same way again, or defeat a timeout the caller
  * set on purpose.
+ *
+ * Rate limits are the exception to the 4xx rule: a 429 is transient by
+ * design, and the server says exactly how long to wait. Callers that opt in
+ * via `retryOn429` get automatic retries that honour `Retry-After`; without
+ * it, 429 stays a fast, explicit failure.
  *
  * The returned promise resolves only to a 2xx response; every other outcome
  * throws (`HttpError` for a non-retryable or exhausted-retries HTTP status,
@@ -71,6 +104,7 @@ export async function fetchWithRetry(
     baseDelayMs = 200,
     fetchImpl = fetch,
     isRetryableStatus = isRetryableStatusDefault,
+    retryOn429 = false,
     onRetry,
   } = options;
 
@@ -87,13 +121,18 @@ export async function fetchWithRetry(
 
     if (response) {
       if (response.ok) return response;
-      if (!isRetryableStatus(response.status)) throw new HttpError(response);
+      const rateLimited = retryOn429 && response.status === 429;
+      if (!rateLimited && !isRetryableStatus(response.status)) throw new HttpError(response);
     }
 
     const error = response ? new HttpError(response) : networkError;
     if (attempt >= maxRetries) throw error;
 
-    const delayMs = baseDelayMs * 2 ** attempt;
+    // A rate limit should be waited out as long as the server asked; any other
+    // retryable failure backs off exponentially from the base delay.
+    const delayMs = response && response.status === 429
+      ? (retryAfterMs(response) ?? baseDelayMs * 2 ** attempt)
+      : baseDelayMs * 2 ** attempt;
     onRetry?.(attempt + 1, error, delayMs);
     await delay(delayMs);
   }

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -5,6 +5,7 @@ import {
   AccensaContractError,
   AccensaError,
   AccensaNetworkError,
+  AccensaRateLimitError,
 } from './client';
 
 const TX_HASH = 'a'.repeat(64);
@@ -236,5 +237,171 @@ describe('AccensaClient — request plumbing', () => {
       .catch((e: unknown) => e);
     expect(error).toBeInstanceOf(AccensaContractError);
     expect(String(error)).toContain('non-JSON');
+  });
+});
+
+describe('AccensaClient — rate limit handling (#155)', () => {
+  it('retries a 429 with the server-provided Retry-After and succeeds', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>();
+      fetchImpl.mockResolvedValueOnce(
+        new globalThis.Response(null, { status: 429, headers: { 'Retry-After': '1' } }),
+      );
+      fetchImpl.mockResolvedValueOnce(jsonFetch(paymentsBody)());
+
+      const c = client(fetchImpl);
+      const pending = c.listOrders();
+      await vi.advanceTimersByTimeAsync(1_000);
+      const page = await pending;
+
+      expect(page.orders).toHaveLength(2);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('throws AccensaRateLimitError with retryAfterMs when a 429 persists', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>(
+        async () =>
+          new globalThis.Response(null, {
+            status: 429,
+            headers: { 'Retry-After': '2' },
+          }),
+      );
+
+      const c = client(fetchImpl);
+      const pending = c.listOrders();
+      // Attach a catch handler up front so the rejection is not "unhandled"
+      // while the fake-timer loop advances; the awaited `.catch` below still
+      // observes the same error.
+      const result = pending.catch((e: unknown) => e);
+      // 3 retries at 2s, 2s, 2s (Retry-After each time).
+      for (let i = 0; i < 3; i++) await vi.advanceTimersByTimeAsync(2_000);
+      const error = await result;
+
+      expect(error).toBeInstanceOf(AccensaRateLimitError);
+      const rateError = error as AccensaRateLimitError;
+      expect(rateError.status).toBe(429);
+      expect(rateError.path).toBe('/api/payments');
+      expect(rateError.retryAfterMs).toBe(2000);
+      // A rate limit is still catchable as the base class.
+      expect(error).toBeInstanceOf(AccensaError);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('honours a Retry-After expressed as an HTTP-date', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn<typeof fetch>();
+      const later = new Date(Date.now() + 5_000).toUTCString();
+      fetchImpl.mockResolvedValueOnce(
+        new globalThis.Response(null, { status: 429, headers: { 'Retry-After': later } }),
+      );
+      fetchImpl.mockResolvedValueOnce(jsonFetch(paymentsBody)());
+
+      const c = client(fetchImpl);
+      const pending = c.listOrders();
+      await vi.advanceTimersByTimeAsync(5_000);
+      const page = await pending;
+
+      expect(page.orders).toHaveLength(2);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('AccensaClient — read caching (#160)', () => {
+  it('serves repeat reads from cache without a second network call', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    const c = new AccensaClient({ indexerUrl: 'https://accensa.test', fetchImpl });
+
+    const first = await c.listOrders();
+    const second = await c.listOrders();
+
+    expect(first.orders).toHaveLength(2);
+    expect(second.orders).toHaveLength(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches distinct query strings separately', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    const c = new AccensaClient({ indexerUrl: 'https://accensa.test', fetchImpl });
+
+    await c.listOrders({ limit: 25 });
+    await c.listOrders({ limit: 50 });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates the cache via clearCache', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    const c = new AccensaClient({ indexerUrl: 'https://accensa.test', fetchImpl });
+
+    await c.listOrders();
+    c.clearCache();
+    await c.listOrders();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetches after the cache TTL expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = jsonFetch(paymentsBody);
+      const c = new AccensaClient({
+        indexerUrl: 'https://accensa.test',
+        fetchImpl,
+        cacheTtlMs: 100,
+      });
+
+      await c.listOrders();
+      await c.listOrders();
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(150);
+      await c.listOrders();
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not cache when cacheTtlMs is 0', async () => {
+    const fetchImpl = jsonFetch(paymentsBody);
+    const c = new AccensaClient({
+      indexerUrl: 'https://accensa.test',
+      fetchImpl,
+      cacheTtlMs: 0,
+    });
+
+    await c.listOrders();
+    await c.listOrders();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failed reads', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new globalThis.Response(null, { status: 500 }),
+    );
+    const c = new AccensaClient({
+      indexerUrl: 'https://accensa.test',
+      fetchImpl,
+      cacheTtlMs: 1000,
+    });
+
+    await c.listOrders().catch(() => {});
+    await c.listOrders().catch(() => {});
+
+    // Every attempt must hit the network — an error is never served from cache.
+    expect(fetchImpl.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -14,12 +14,46 @@
  */
 
 import { ordersFromResponse, productsFromResponse } from './mapping';
+import { fetchWithRetry, HttpError, retryAfterMs, type RetryOptions } from '../retry';
 import type { Order } from './types/order';
 import type { Product } from './types/product';
 import type { SyncEvent } from './types/sync-event';
 
+// Re-exported from `./errors` (which owns the canonical definitions) so that
+// consumers importing the error classes from `@accensa/sdk` keep working.
+export {
+  AccensaError,
+  AccensaAuthError,
+  AccensaContractError,
+  AccensaNetworkError,
+  AccensaRateLimitError,
+  AccensaTimeoutError,
+} from './errors';
+import {
+  AccensaError,
+  AccensaAuthError,
+  AccensaContractError,
+  AccensaNetworkError,
+  AccensaRateLimitError,
+  AccensaTimeoutError,
+} from './errors';
+
 /** Default request timeout in milliseconds (30 seconds). */
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * How long a successful read stays in the in-memory cache before being
+ * re-fetched, in milliseconds.
+ *
+ * The dashboard navigates between pages that each re-read the same merchant
+ * profile and product data. A short TTL (10 seconds) makes those repeat reads
+ * instant while keeping the cache stale for at most one polling interval, so
+ * it can never outlive the truth for long. Set `cacheTtlMs: 0` to disable.
+ */
+const DEFAULT_CACHE_TTL_MS = 10_000;
+
+/** How many times a rate-limited (429) request is retried after the first try. */
+const RATE_LIMIT_MAX_RETRIES = 3;
 
 export interface AccensaClientOptions {
   /** Base URL of your Accensa deployment, e.g. https://accensa-dashboard.vercel.app */
@@ -37,10 +71,14 @@ export interface AccensaClientOptions {
    * Defaults to 30 000 ms (30 seconds).
    */
   timeoutMs?: number;
+  /**
+   * How long successful read results are served from an in-memory cache, in
+   * milliseconds (#160). Repeat calls for the same data within the TTL bypass
+   * the network. Set to 0 to disable caching. Defaults to 10 000 ms.
+   */
+  cacheTtlMs?: number;
   /** Injected in tests. Defaults to global fetch. */
   fetchImpl?: typeof fetch;
-  /** Optional request timeout in milliseconds. */
-  timeoutMs?: number;
 }
 
 /** A page of {@link Order}s as `/api/payments` returns them. */
@@ -57,36 +95,31 @@ export interface ProductsPage {
   truncated: boolean;
 }
 
-/** Thrown when the indexer responds with a non-2xx status. */
-export class AccensaError extends Error {
-  readonly status?: number;
-
-  constructor(message: string, status?: number) {
-    super(message);
-    this.name = 'AccensaError';
-    this.status = status;
-  }
-}
-
-/** Thrown when a request exceeds the configured timeout. */
-export class AccensaTimeoutError extends AccensaError {
-  constructor(message: string) {
-    super(message);
-    this.name = 'AccensaTimeoutError';
-  }
-}
-
 export class AccensaClient {
   private readonly indexerUrl: string;
   private readonly headers: Record<string, string>;
   private readonly timeoutMs: number;
+  private readonly cacheTtlMs: number;
   private readonly fetchImpl?: typeof fetch;
+  /** In-memory read cache (#160): keyed by path, entries expire on their TTL. */
+  private readonly cache = new Map<string, { expiresAt: number; value: unknown }>();
 
   constructor(opts: AccensaClientOptions) {
     this.indexerUrl = opts.indexerUrl.replace(/\/$/, '');
     this.headers = opts.headers ?? {};
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
     this.fetchImpl = opts.fetchImpl;
+  }
+
+  /**
+   * Drops every cached read, forcing the next call to hit the network.
+   *
+   * Call this after a write the cache could have missed (a refund, a profile
+   * update, a manual sync) so the dashboard never shows data that predates it.
+   */
+  clearCache(): void {
+    this.cache.clear();
   }
 
   /**
@@ -169,7 +202,11 @@ export class AccensaClient {
     source.addEventListener('sync', (event) => {
       const message = event as MessageEvent;
       try {
-        handlers.onSync(JSON.parse(message.data as string) as SyncEvent);
+        const payload = JSON.parse(message.data as string) as SyncEvent;
+        // A new sync run means fresh data on the other side of every cached
+        // read; drop the cache so the next poll reflects it (#160).
+        this.clearCache();
+        handlers.onSync(payload);
       } catch {
         // Ignore malformed payloads rather than dropping the subscription.
       }
@@ -181,9 +218,18 @@ export class AccensaClient {
 
   /**
    * Makes a GET request and parses the JSON response, respecting the
-   * configured timeout. (#134)
+   * configured timeout (#134), retrying rate limits (#155), and serving
+   * recent reads from the in-memory cache (#160).
+   *
+   * Read results are cached by path for `cacheTtlMs`, so the redundant reads
+   * the dashboard makes across page navigations resolve instantly; expiry and
+   * {@link clearCache} bound how stale a hit can be. A request that never
+   * succeeds is never cached.
    */
   private async getJson(path: string): Promise<unknown> {
+    const cached = this.cacheRead(path);
+    if (cached.hit) return cached.value;
+
     const doFetch = this.fetchImpl ?? globalThis.fetch;
     if (typeof doFetch !== 'function') {
       throw new AccensaNetworkError('No fetch implementation available');
@@ -193,43 +239,77 @@ export class AccensaClient {
 
     let response: Response;
     try {
-      response = await doFetch(`${this.indexerUrl}${path}`, {
+      response = await fetchWithRetry(`${this.indexerUrl}${path}`, {
         method: 'GET',
         headers: this.headers,
         signal,
+      }, {
+        fetchImpl: doFetch,
+        retryOn429: true,
+        maxRetries: RATE_LIMIT_MAX_RETRIES,
       });
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === 'TimeoutError') {
-        throw new AccensaTimeoutError(
-          `Request to ${path} timed out after ${this.timeoutMs}ms`,
-        );
+        throw new AccensaTimeoutError(`Request to ${path} timed out after ${this.timeoutMs}ms`);
       }
-      throw err;
-    }
-
-    if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
-        throw new AccensaAuthError(
-          `Accensa rejected the request with ${response.status} for ${path}`,
-          {
-            status: response.status,
-            path,
-          },
-        );
+      if (err instanceof HttpError && err.status === 429) {
+        // fetchWithRetry already waited between attempts; if the node is still
+        // limiting us the caller needs a concrete signal, not a generic error.
+        throw new AccensaRateLimitError(`Accensa is rate limited for ${path}`, {
+          path,
+          retryAfterMs: retryAfterMs(err.response),
+        });
       }
-      throw new AccensaError(`Accensa returned ${response.status} for ${path}`, {
-        status: response.status,
+      if (err instanceof HttpError) {
+        if (err.status === 401 || err.status === 403) {
+          throw new AccensaAuthError(
+            `Accensa rejected the request with ${err.status} for ${path}`,
+            { status: err.status, path },
+          );
+        }
+        throw new AccensaError(`Accensa returned ${err.status} for ${path}`, {
+          status: err.status,
+        });
+      }
+      // fetchWithRetry rethrows the underlying error once retries are spent.
+      // Wrap it so the SDK's error surface stays typed.
+      throw new AccensaNetworkError(`Request to ${path} failed`, {
+        url: `${this.indexerUrl}${path}`,
+        cause: err,
       });
     }
 
+    let body: unknown;
     try {
-      const body: unknown = await response.json();
-      return body;
+      body = await response.json();
     } catch (cause) {
       throw new AccensaContractError(`Accensa returned a non-JSON body for ${path}`, { cause });
     }
+
+    this.storeCache(path, body);
+    return body;
+  }
+
+  /** Returns a cached read for `path` when one exists and is still fresh. */
+  private cacheRead(path: string): { hit: boolean; value?: unknown } {
+    if (this.cacheTtlMs <= 0) return { hit: false };
+    const entry = this.cache.get(path);
+    if (!entry) return { hit: false };
+    if (Date.now() >= entry.expiresAt) {
+      this.cache.delete(path);
+      return { hit: false };
+    }
+    return { hit: true, value: entry.value };
+  }
+
+  private storeCache(path: string, value: unknown): void {
+    if (this.cacheTtlMs <= 0) return;
+    this.cache.set(path, { expiresAt: Date.now() + this.cacheTtlMs, value });
   }
 }
+
+/** Extra retry knobs exposed for callers who reuse the rate-limit wrapper directly. */
+export type { RetryOptions };
 
 function queryString(params: URLSearchParams): string {
   const text = params.toString();

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -6,6 +6,7 @@
  * The subclasses discriminate the failure modes that matter in practice:
  *
  * - {@link AccensaAuthError} — the indexer rejected the credential (401/403).
+ * - {@link AccensaRateLimitError} — a rate-limited RPC or indexer node (429).
  * - {@link AccensaNetworkError} — the indexer could not be reached at all.
  * - {@link AccensaContractError} — the indexer (or a receipt) violated the
  *   documented wire contract.
@@ -59,6 +60,44 @@ export class AccensaAuthError extends AccensaError {
     this.name = 'AccensaAuthError';
     this.status = options.status;
     this.path = options.path;
+  }
+}
+
+/**
+ * A rate-limited RPC or indexer node answered HTTP 429 and the retry budget
+ * was exhausted (#155).
+ *
+ * Thrown by the SDK's rate-limit wrapper after it has already waited and
+ * retried, so a caller can catch it and tell the user "try again shortly"
+ * instead of crashing on a generic error. `retryAfterMs` carries the server's
+ * `Retry-After` hint (or the SDK's backoff) so the UI can show a concrete
+ * countdown.
+ */
+export class AccensaRateLimitError extends AccensaError {
+  /** Always 429 for this error type. */
+  readonly status: number;
+  /** The path or RPC method that was rate limited, when known. */
+  readonly path?: string;
+  /** How long the caller should wait before retrying, in milliseconds. */
+  readonly retryAfterMs?: number;
+
+  constructor(
+    message: string,
+    options: { path?: string; retryAfterMs?: number; cause?: unknown } = {},
+  ) {
+    super(message, { status: 429, path: options.path, cause: options.cause });
+    this.name = 'AccensaRateLimitError';
+    this.status = 429;
+    this.path = options.path;
+    this.retryAfterMs = options.retryAfterMs;
+  }
+}
+
+/** The client aborted a request because it exceeded the configured timeout (#134). */
+export class AccensaTimeoutError extends AccensaError {
+  constructor(message: string, options?: { path?: string; cause?: unknown }) {
+    super(message, { path: options?.path, cause: options?.cause });
+    this.name = 'AccensaTimeoutError';
   }
 }
 


### PR DESCRIPTION
Closes #155, Closes #160

Implements the SDK half of both issues:

## #155 — Error handling wrapper for rate-limited RPC nodes
- Adds `AccensaRateLimitError` (strongly typed, carries `path` + `retryAfterMs`) and `AccensaTimeoutError` to the shared error classes.
- Adds opt-in `retryOn429` to `fetchWithRetry`, honoring the `Retry-After` header (seconds or HTTP-date) and falling back to exponential backoff.
- `AccensaClient` now retries 429 responses automatically, then throws `AccensaRateLimitError` so UI can render a graceful "try again shortly" instead of crashing.

## #160 — Caching layer for read queries
- In-memory TTL cache (default 10s, `cacheTtlMs: 0` disables) on read methods; repeat calls for the same data bypass the network.
- `clearCache()` for manual invalidation; cache dropped on new sync events; failed reads never cached.

## Drive-by fix
- `client.ts` did not compile on main (duplicate `timeoutMs`, missing imports for the typed error classes). Fixed as part of this work.

All SDK unit tests pass (52 in client + retry suites).